### PR TITLE
task/nos13-side-menu-scrolling-nav-padding-fix

### DIFF
--- a/Nos/Views/HomeFeedView.swift
+++ b/Nos/Views/HomeFeedView.swift
@@ -60,6 +60,7 @@ struct HomeFeedView: View {
                     }
                 }
             }
+            .padding(.top, 1)
             .navigationDestination(for: Event.self) { note in
                 ThreadView(note: note)
             }
@@ -71,6 +72,7 @@ struct HomeFeedView: View {
                     SettingsView()
                 }
             }
+            
         }
 
         .overlay(Group {

--- a/Nos/Views/HomeFeedView.swift
+++ b/Nos/Views/HomeFeedView.swift
@@ -72,7 +72,6 @@ struct HomeFeedView: View {
                     SettingsView()
                 }
             }
-            
         }
 
         .overlay(Group {


### PR DESCRIPTION
Fixes notes from showing up behind navigation view at the top