### PR TITLE
Fix home feed preview

### DIFF
--- a/Nos/Models/Persistence.swift
+++ b/Nos/Models/Persistence.swift
@@ -15,8 +15,6 @@ struct PersistenceController {
         let controller = PersistenceController(inMemory: true)
         let viewContext = controller.container.viewContext
         PersistenceController.loadSampleData(context: viewContext)
-        let relay = Relay(context: viewContext)
-        relay.address = "wss://dev-relay.nos.social"
         
         do {
             try viewContext.save()
@@ -88,7 +86,7 @@ struct PersistenceController {
         Event.deleteAll(context: context)
         context.reset()
         
-        guard let events = try? EventProcessor.parse(jsonData: sampleData, in: PersistenceController.shared) else {
+        guard let events = try? EventProcessor.parse(jsonData: sampleData, in: context) else {
             print("Error: Could not parse events")
             return
         }

--- a/Nos/Service/CurrentUser.swift
+++ b/Nos/Service/CurrentUser.swift
@@ -98,7 +98,7 @@ enum CurrentUser {
         if let privateKey = privateKey, let pair = KeyPair(privateKeyHex: privateKey) {
             do {
                 try jsonEvent.sign(withKey: pair)
-                let event = try EventProcessor.parse(jsonEvent: jsonEvent, in: PersistenceController.shared)
+                let event = try EventProcessor.parse(jsonEvent: jsonEvent, in: context)
                 relayService?.sendEventToAll(event: event)
             } catch {
                 print("failed to update Follows \(error.localizedDescription)")

--- a/Nos/Service/RelayService.swift
+++ b/Nos/Service/RelayService.swift
@@ -180,7 +180,7 @@ final class RelayService: WebSocketDelegate, ObservableObject {
                 }
                 
                 do {
-                    _ = try EventProcessor.parse(jsonObject: eventJSON, in: persistenceController)
+                    _ = try EventProcessor.parse(jsonObject: eventJSON, in: persistenceController.container.viewContext)
                 } catch {
                     print("error parsing event from relay: \(response)")
                 }

--- a/Nos/Views/DiscoverView.swift
+++ b/Nos/Views/DiscoverView.swift
@@ -20,7 +20,7 @@ struct DiscoverView: View {
     
     @State var columns: Int = 2
     
-    @Namespace var animation
+    @Namespace private var animation
     
     var body: some View {
         NavigationStack(path: $router.path) {
@@ -131,9 +131,12 @@ struct DiscoverView_Previews: PreviewProvider {
     static var emptyPreviewContext = emptyPersistenceController.container.viewContext
     static var emptyRelayService = RelayService(persistenceController: emptyPersistenceController)
     
+    static var router = Router()
+    
     static var shortNote: Event {
         let note = Event(context: previewContext)
         note.content = "Hello, world!"
+        try! previewContext.save()
         return note
     }
     
@@ -147,5 +150,6 @@ struct DiscoverView_Previews: PreviewProvider {
         DiscoverView()
             .environment(\.managedObjectContext, previewContext)
             .environmentObject(relayService)
+            .environmentObject(router)
     }
 }

--- a/Nos/Views/HomeFeedView.swift
+++ b/Nos/Views/HomeFeedView.swift
@@ -121,8 +121,11 @@ struct ContentView_Previews: PreviewProvider {
     static var emptyPreviewContext = emptyPersistenceController.container.viewContext
     static var emptyRelayService = RelayService(persistenceController: emptyPersistenceController)
     
+    static var router = Router()
+    
     static var shortNote: Event {
         let note = Event(context: previewContext)
+        note.kind = 1
         note.content = "Hello, world!"
         note.author = user
         return note
@@ -130,6 +133,7 @@ struct ContentView_Previews: PreviewProvider {
     
     static var longNote: Event {
         let note = Event(context: previewContext)
+        note.kind = 1
         note.content = .loremIpsum(5)
         note.author = user
         return note
@@ -137,7 +141,7 @@ struct ContentView_Previews: PreviewProvider {
     
     static var user: Author {
         let author = Author(context: previewContext)
-        author.hexadecimalPublicKey = KeyFixture.pubKeyHex
+        author.hexadecimalPublicKey = "d0a1ffb8761b974cec4a3be8cbcb2e96a7090dcf465ffeac839aa4ca20c9a59e"
         return author
     }
     
@@ -147,11 +151,13 @@ struct ContentView_Previews: PreviewProvider {
         }
         .environment(\.managedObjectContext, previewContext)
         .environmentObject(relayService)
+        .environmentObject(router)
         
         NavigationView {
             HomeFeedView(user: user)
         }
         .environment(\.managedObjectContext, emptyPreviewContext)
         .environmentObject(emptyRelayService)
+        .environmentObject(router)
     }
 }

--- a/NosTests/EventTests.swift
+++ b/NosTests/EventTests.swift
@@ -156,9 +156,10 @@ final class EventTests: XCTestCase {
         }
 
         let jsonEvent = try JSONDecoder().decode(JSONEvent.self, from: jsonData)
+        let context = PersistenceController(inMemory: true).container.viewContext
 
         // Act
-        let parsedEvent = try EventProcessor.parse(jsonEvent: jsonEvent, in: PersistenceController(inMemory: true))
+        let parsedEvent = try EventProcessor.parse(jsonEvent: jsonEvent, in: context)
          
         // Assert
         XCTAssertEqual(parsedEvent.signature, sampleContactListSignature)


### PR DESCRIPTION
This fixes the preview on the HomeFeedView, which was always showing the "no events" message. This was happening because some code was `PersistenceController.shared` where the SwiftUI views were reading from `PersistenceController.preview`.