### PR TITLE
bug/nos78-fix-read-more-button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ We define "Noteworthy changes" as 1) user-facing features or bugfixes 2) signifi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
 ## [0.1 (5)] 2023-03-02 
 
 - Added a Discover tab that shows all events from all relays.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed empty home feed message so it doesn't overlay other views
 - Change settings and onboarding to accept nsec-format private key
 - Fixed app crash when no user is passed to HomeFeedView initializer
+- Fixed READ MORE Button
 
 ## [0.1 (4)] - 2023-02-24
 

--- a/Nos/Views/CompactNoteView.swift
+++ b/Nos/Views/CompactNoteView.swift
@@ -16,6 +16,9 @@ struct CompactNoteView: View {
 
     @State
     private var shouldShowReadMore = false
+    
+    @State
+    private var showFullMessage = false
 
     @State
     private var intrinsicSize = CGSize.zero
@@ -31,46 +34,57 @@ struct CompactNoteView: View {
     
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            Text(note.content ?? "")
-                .lineLimit(5)
-                .font(.body)
-                .foregroundColor(.primaryTxt)
-                .accentColor(.accent)
-                .padding(15)
-                .background {
-                    GeometryReader { geometryProxy in
-                        Color.clear.preference(key: TruncatedSizePreferenceKey.self, value: geometryProxy.size)
-                    }
-                }
-                .onPreferenceChange(TruncatedSizePreferenceKey.self) { newSize in
-                    if newSize.height > truncatedSize.height {
-                        truncatedSize = newSize
-                        updateShouldShowReadMore()
-                    }
-                }
-                .background {
-                    Text(note.content ?? "")
-                        .font(.body)
-                        .padding(15)
-                        .fixedSize(horizontal: false, vertical: true)
-                        .hidden()
-                        .background {
-                            GeometryReader { geometryProxy in
-                                Color.clear.preference(key: IntrinsicSizePreferenceKey.self, value: geometryProxy.size)
-                            }
+            if showFullMessage {
+                Text(note.content ?? "")
+                    .font(.body)
+                    .foregroundColor(.primaryTxt)
+                    .accentColor(.accent)
+                    .padding(15)
+            } else {
+                Text(note.content ?? "")
+                    .lineLimit(5)
+                    .font(.body)
+                    .foregroundColor(.primaryTxt)
+                    .accentColor(.accent)
+                    .padding(15)
+                    .background {
+                        GeometryReader { geometryProxy in
+                            Color.clear.preference(key: TruncatedSizePreferenceKey.self, value: geometryProxy.size)
                         }
-                        .onPreferenceChange(IntrinsicSizePreferenceKey.self) { newSize in
-                            if newSize.height > intrinsicSize.height {
-                                intrinsicSize = newSize
-                                updateShouldShowReadMore()
-                            }
+                    }
+                    .onPreferenceChange(TruncatedSizePreferenceKey.self) { newSize in
+                        if newSize.height > truncatedSize.height {
+                            truncatedSize = newSize
+                            updateShouldShowReadMore()
                         }
-                }
-            if shouldShowReadMore {
+                    }
+                    .background {
+                        Text(note.content ?? "")
+                            .font(.body)
+                            .padding(15)
+                            .fixedSize(horizontal: false, vertical: true)
+                            .hidden()
+                            .background {
+                                GeometryReader { geometryProxy in
+                                    Color.clear.preference(
+                                        key: IntrinsicSizePreferenceKey.self,
+                                        value: geometryProxy.size
+                                    )
+                                }
+                            }
+                            .onPreferenceChange(IntrinsicSizePreferenceKey.self) { newSize in
+                                if newSize.height > intrinsicSize.height {
+                                    intrinsicSize = newSize
+                                    updateShouldShowReadMore()
+                                }
+                            }
+                    }
+            }
+            if shouldShowReadMore && !showFullMessage {
                 
                 ZStack(alignment: .center) {
                     Button {
-                        router.path.append(note)
+                        showFullMessage = true
                     } label: {
                         Text("Read more".uppercased())
                             .font(.caption)

--- a/Nos/Views/CompactNoteView.swift
+++ b/Nos/Views/CompactNoteView.swift
@@ -84,7 +84,9 @@ struct CompactNoteView: View {
                 
                 ZStack(alignment: .center) {
                     Button {
-                        showFullMessage = true
+                        withAnimation {
+                            showFullMessage = true
+                        }
                     } label: {
                         Text("Read more".uppercased())
                             .font(.caption)


### PR DESCRIPTION
https://github.com/planetary-social/nos/issues/78

When a note is too long it gets truncated and a "READ MORE" button is displayed. After clicking the button, the whole note should be displayed.