### PR TITLE
Move metadata requests into NoteCard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 - Fixed follow / unfollow sync
 - Reduced number of REQ sent to relays
+- Request profile metadata for users displayed on the Discover tab
 
 ## [0.1 (5)] 2023-03-02 
 

--- a/Nos/Models/Author+CoreDataClass.swift
+++ b/Nos/Models/Author+CoreDataClass.swift
@@ -29,6 +29,7 @@ public class Author: NosManagedObject {
     }
     
     var needsMetadata: Bool {
+        // TODO: consider checking lastUpdated time as an optimization.
         about == nil && name == nil && displayName == nil && profilePhotoURL == nil
     }
     

--- a/Nos/Models/Author+CoreDataClass.swift
+++ b/Nos/Models/Author+CoreDataClass.swift
@@ -28,6 +28,10 @@ public class Author: NosManagedObject {
         return PublicKey(hex: hex)
     }
     
+    var needsMetadata: Bool {
+        about == nil && name == nil && displayName == nil && profilePhotoURL == nil
+    }
+    
     class func find(by pubKey: HexadecimalString, context: NSManagedObjectContext) throws -> Author? {
         let fetchRequest = NSFetchRequest<Author>(entityName: String(describing: Author.self))
         fetchRequest.predicate = NSPredicate(format: "hexadecimalPublicKey = %@", pubKey)
@@ -71,5 +75,17 @@ public class Author: NosManagedObject {
             print("Failed to fetch authors. Error: \(error.description)")
             return []
         }
+    }
+    
+    func requestMetadata(using relayService: RelayService) -> String? {
+        guard let hexadecimalPublicKey else {
+            return nil
+        }
+        
+        // TODO: make sure this subscription gets closed if there is no new metadata, or no metadata at all for this
+        // user.
+        let metaFilter = Filter(authorKeys: [hexadecimalPublicKey], kinds: [.metaData], limit: 1)
+        let metaSub = relayService.requestEventsFromAll(filter: metaFilter)
+        return metaSub
     }
 }

--- a/Nos/Views/HomeFeedView.swift
+++ b/Nos/Views/HomeFeedView.swift
@@ -47,7 +47,7 @@ struct HomeFeedView: View {
                 let textSub = relayService.requestEventsFromAll(filter: textFilter)
                 subscriptionIds.append(textSub)
                 
-                let metaFilter = Filter(authorKeys: authors, kinds: [.metaData, .contactList], limit: 100)
+                let metaFilter = Filter(authorKeys: authors, kinds: [.contactList], limit: 100)
                 let metaSub = relayService.requestEventsFromAll(filter: metaFilter)
                 subscriptionIds.append(metaSub)
             }

--- a/Nos/Views/NoteCard.swift
+++ b/Nos/Views/NoteCard.swift
@@ -57,6 +57,9 @@ struct NoteCard: View {
     }
     
     @EnvironmentObject private var router: Router
+    @EnvironmentObject private var relayService: RelayService
+    
+    @State private var subscriptionIDs = [String]()
     
     init(author: Author, note: Event, style: CardStyle = .compact) {
         self.author = author
@@ -84,6 +87,15 @@ struct NoteCard: View {
                         }
                     }
                     // TODO: Put MessageOptionsButton back here eventually
+                }
+                .onAppear {
+                    if author.needsMetadata, let subscriptionID = author.requestMetadata(using: relayService) {
+                        subscriptionIDs.append(subscriptionID)
+                    }
+                }
+                .onDisappear {
+                    relayService.sendCloseToAll(subscriptions: subscriptionIDs)
+                    subscriptionIDs.removeAll()
                 }
                 .padding(10)
                 Divider().overlay(Color.cardDivider).shadow(color: .cardDividerShadow, radius: 0, x: 0, y: 1)


### PR DESCRIPTION
Closes #101. This makes sure that we see metadata for authors displayed on the Discover tab.