### PR TITLE
feature/nos-63-ellipsis-copy-note-identifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed READ MORE Button
 - Filter the Home Feed down to root posts
 - In the Discover tab, display a feed of interesting people
+- Add the ellipsis button to NoteCard and allow the user to copy the NIP-19 note ID of a note.
 
 ## [0.1 (4)] - 2023-02-24
 

--- a/Nos.xcodeproj/project.pbxproj
+++ b/Nos.xcodeproj/project.pbxproj
@@ -150,6 +150,7 @@
 		CD76864C29B12F7E00085358 /* ExpandingTextFieldAndSubmitButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD76864B29B12F7E00085358 /* ExpandingTextFieldAndSubmitButton.swift */; };
 		CD76864D29B133E600085358 /* ExpandingTextFieldAndSubmitButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD76864B29B12F7E00085358 /* ExpandingTextFieldAndSubmitButton.swift */; };
 		CD76865029B6503500085358 /* NoteOptionsButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD76864F29B6503500085358 /* NoteOptionsButton.swift */; };
+		CD76865129B68B4400085358 /* NoteOptionsButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD76864F29B6503500085358 /* NoteOptionsButton.swift */; };
 		CDDA1F7B29A527650047ACD8 /* Starscream in Frameworks */ = {isa = PBXBuildFile; productRef = CDDA1F7A29A527650047ACD8 /* Starscream */; };
 		CDDA1F7D29A527650047ACD8 /* SwiftUINavigation in Frameworks */ = {isa = PBXBuildFile; productRef = CDDA1F7C29A527650047ACD8 /* SwiftUINavigation */; };
 /* End PBXBuildFile section */
@@ -726,6 +727,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				CD76865129B68B4400085358 /* NoteOptionsButton.swift in Sources */,
 				CD76864D29B133E600085358 /* ExpandingTextFieldAndSubmitButton.swift in Sources */,
 				CD09A76329A522190063464F /* OnboardingView.swift in Sources */,
 				CD09A76129A5220E0063464F /* NosApp.swift in Sources */,

--- a/Nos.xcodeproj/project.pbxproj
+++ b/Nos.xcodeproj/project.pbxproj
@@ -147,6 +147,7 @@
 		CD2CF390299E68BE00332116 /* NoteButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD2CF38F299E68BE00332116 /* NoteButton.swift */; };
 		CD76864C29B12F7E00085358 /* ExpandingTextFieldAndSubmitButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD76864B29B12F7E00085358 /* ExpandingTextFieldAndSubmitButton.swift */; };
 		CD76864D29B133E600085358 /* ExpandingTextFieldAndSubmitButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD76864B29B12F7E00085358 /* ExpandingTextFieldAndSubmitButton.swift */; };
+		CD76865029B6503500085358 /* NoteOptionsButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD76864F29B6503500085358 /* NoteOptionsButton.swift */; };
 		CDDA1F7B29A527650047ACD8 /* Starscream in Frameworks */ = {isa = PBXBuildFile; productRef = CDDA1F7A29A527650047ACD8 /* Starscream */; };
 		CDDA1F7D29A527650047ACD8 /* SwiftUINavigation in Frameworks */ = {isa = PBXBuildFile; productRef = CDDA1F7C29A527650047ACD8 /* SwiftUINavigation */; };
 /* End PBXBuildFile section */
@@ -246,6 +247,7 @@
 		CD2CF38D299E67F900332116 /* CardButtonStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardButtonStyle.swift; sourceTree = "<group>"; };
 		CD2CF38F299E68BE00332116 /* NoteButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteButton.swift; sourceTree = "<group>"; };
 		CD76864B29B12F7E00085358 /* ExpandingTextFieldAndSubmitButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpandingTextFieldAndSubmitButton.swift; sourceTree = "<group>"; };
+		CD76864F29B6503500085358 /* NoteOptionsButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteOptionsButton.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -470,6 +472,7 @@
 				C9DFA970299BF8CD006929C1 /* ThreadView.swift */,
 				C9CDBBA029A8F14C00C555C7 /* DiscoverView.swift */,
 				CD76864B29B12F7E00085358 /* ExpandingTextFieldAndSubmitButton.swift */,
+				CD76864F29B6503500085358 /* NoteOptionsButton.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -694,6 +697,7 @@
 				C93CA0C329AE3A1E00921183 /* JSONEvent.swift in Sources */,
 				3FFB1D89299FF37C002A755D /* AvatarView.swift in Sources */,
 				C9DEC04529894BED0078B43A /* Event+CoreDataClass.swift in Sources */,
+				CD76865029B6503500085358 /* NoteOptionsButton.swift in Sources */,
 				C9DFA966299BEB96006929C1 /* NoteCard.swift in Sources */,
 				C9DEBFD4298941000078B43A /* Persistence.swift in Sources */,
 				CD76864C29B12F7E00085358 /* ExpandingTextFieldAndSubmitButton.swift in Sources */,

--- a/Nos/Assets/Localization/Localized.swift
+++ b/Nos/Assets/Localization/Localized.swift
@@ -89,6 +89,10 @@ enum Localized: String, Localizable, CaseIterable {
     case debug = "Debug"
     case loadSampleData = "Load Sample Data"
     case sampleDataInstructions = "This will delete all events and load those in sample_data.json"
+    
+    case copyNoteIdentifier = "Copy Note Identifier"
+    case share = "Share"
+    case reportPost = "Report this post"
 }
 
 // MARK: - Onboarding

--- a/Nos/Models/NostrConstants.swift
+++ b/Nos/Models/NostrConstants.swift
@@ -12,4 +12,5 @@ enum Nostr {
     // https://github.com/nostr-protocol/nips/blob/master/19.md
     static let privateKeyPrefix = "nsec"
     static let publicKeyPrefix = "npub"
+    static let notePrefix = "note"
 }

--- a/Nos/Views/NoteCard.swift
+++ b/Nos/Views/NoteCard.swift
@@ -86,7 +86,7 @@ struct NoteCard: View {
                                 .frame(maxWidth: .infinity, alignment: .leading)
                         }
                     }
-                    // TODO: Put MessageOptionsButton back here eventually
+                    NoteOptionsButton(note: note)
                 }
                 .onAppear {
                     if author.needsMetadata, let subscriptionID = author.requestMetadata(using: relayService) {

--- a/Nos/Views/NoteOptionsButton.swift
+++ b/Nos/Views/NoteOptionsButton.swift
@@ -1,0 +1,91 @@
+//
+//  NoteOptionsButton.swift
+//  Nos
+//
+//  Created by Jason Cheatham on 3/6/23.
+//
+
+import Foundation
+import SwiftUI
+import secp256k1
+
+struct NoteOptionsButton: View {
+
+    var note: Event
+
+    @State
+    private var showingOptions = false
+
+    @State
+    private var showingShare = false
+
+    @State
+    private var showingSource = false
+
+    var body: some View {
+        VStack {
+            Button {
+                showingOptions = true
+            } label: {
+                Image(systemName: "ellipsis")
+            }
+            .confirmationDialog(Localized.share.string, isPresented: $showingOptions) {
+                Button(Localized.copyNoteIdentifier.string) {
+                    // Analytics.shared.trackDidSelectAction(actionName: "copy_message_identifier")
+                    copyMessageIdentifier()
+                }
+                // Button(Localized.shareThisMessage.text) {
+                // Analytics.shared.trackDidSelectAction(actionName: "share_message")
+                // showingShare = true
+                // }
+                // Button(Localized.viewSource.text) {
+                // Analytics.shared.trackDidSelectAction(actionName: "view_message_source")
+                // showingSource = true
+                // }
+                Button(Localized.reportPost.string, role: .destructive) {
+                // Analytics.shared.trackDidSelectAction(actionName: "report_post")
+                    reportPost()
+                }
+            }
+            .sheet(isPresented: $showingSource) {
+            }
+            .sheet(isPresented: $showingShare) {
+            }
+        }
+    }
+
+    func copyMessageIdentifier() {
+        let bech32NoteID = Bech32.encode(Nostr.notePrefix, baseEightData: Data(try! note.identifier!.bytes))
+        UIPasteboard.general.string = bech32NoteID
+    }
+
+    func reportPost() {
+        // AppController.shared.report(message, in: nil, from: message.author)
+    }
+}
+
+struct NoteOptionsView_Previews: PreviewProvider {
+    static var persistenceController = PersistenceController.preview
+    static var previewContext = persistenceController.container.viewContext
+    
+    static var shortNote: Event {
+        let note = Event(context: previewContext)
+        note.content = "Hello, world!"
+        return note
+    }
+    
+    static let note: Event = {
+        var note = shortNote
+        return note
+    }()
+
+    static var previews: some View {
+        Group {
+            NoteOptionsButton(note: note)
+            NoteOptionsButton(note: note)
+                .preferredColorScheme(.dark)
+        }
+        .padding()
+        .background(Color.cardBackground)
+    }
+}

--- a/Nos/Views/NoteOptionsButton.swift
+++ b/Nos/Views/NoteOptionsButton.swift
@@ -27,6 +27,9 @@ struct NoteOptionsButton: View {
             Button {
                 showingOptions = true
             } label: {
+                Image.iconOptions
+                    // This hack fixes a weird issue where the confirmationDialog wouldn't be shown sometimes. ¯\_(ツ)_/¯
+                    .background(showingOptions == true ? .clear : .clear)
                 Image(systemName: "ellipsis")
             }
             .confirmationDialog(Localized.share.string, isPresented: $showingOptions) {


### PR DESCRIPTION
Add the ellipsis button back to NoteCard and allow the user to copy the [NIP-19] note ID of a note.
https://github.com/planetary-social/nos/issues/63