### PR TITLE
NOS51 - Retry Relay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reduced number of REQ sent to relays
 - Request profile metadata for users displayed on the Discover tab
 - Cleanup RelayService
+- Retry failed Event sends every 2 minutes (max 5 retries)
 
 ## [0.1 (5)] 2023-03-02 
 

--- a/Nos/Models/Event+CoreDataClass.swift
+++ b/Nos/Models/Event+CoreDataClass.swift
@@ -91,7 +91,8 @@ public class Event: NosManagedObject {
     @nonobjc public class func allUserPostsRequest(_ eventKind: EventKind = .text) -> NSFetchRequest<Event> {
         let fetchRequest = NSFetchRequest<Event>(entityName: "Event")
         fetchRequest.sortDescriptors = [NSSortDescriptor(keyPath: \Event.createdAt, ascending: false)]
-        fetchRequest.predicate = NSPredicate(format: "kind = %i AND userCreated = true", eventKind.rawValue)
+        let kind = eventKind.rawValue
+        fetchRequest.predicate = NSPredicate(format: "kind = %i AND sendAttempts > 0 AND sendAttempts < 5", kind)
         return fetchRequest
     }
     
@@ -265,7 +266,7 @@ public class Event: NosManagedObject {
 		identifier = jsonEvent.id
 		kind = jsonEvent.kind
 		signature = jsonEvent.signature
-        userCreated = false
+        sendAttempts = 0
         
         // Tags
         allTags = jsonEvent.tags as NSObject

--- a/Nos/Models/Event+CoreDataClass.swift
+++ b/Nos/Models/Event+CoreDataClass.swift
@@ -88,11 +88,10 @@ public class Event: NosManagedObject {
         return fetchRequest
     }
     
-    @nonobjc public class func allUserPostsRequest(_ eventKind: EventKind = .text) -> NSFetchRequest<Event> {
+    @nonobjc public class func allUserPostsRequest() -> NSFetchRequest<Event> {
         let fetchRequest = NSFetchRequest<Event>(entityName: "Event")
         fetchRequest.sortDescriptors = [NSSortDescriptor(keyPath: \Event.createdAt, ascending: false)]
-        let kind = eventKind.rawValue
-        fetchRequest.predicate = NSPredicate(format: "kind = %i AND sendAttempts > 0 AND sendAttempts < 5", kind)
+        fetchRequest.predicate = NSPredicate(format: "sendAttempts > 0 AND sendAttempts < 5")
         return fetchRequest
     }
     

--- a/Nos/Models/Event+CoreDataClass.swift
+++ b/Nos/Models/Event+CoreDataClass.swift
@@ -169,8 +169,16 @@ public class Event: NosManagedObject {
         return fetchRequest
     }
     
+    class func find(by identifier: String, context: NSManagedObjectContext) -> Event? {
+        if let existingEvent = try? context.fetch(Event.event(by: identifier)).first {
+            return existingEvent
+        }
+
+        return nil
+    }
+    
     class func findOrCreate(jsonEvent: JSONEvent, context: NSManagedObjectContext) -> Event? {
-        if let existingEvent = try? context.fetch(Event.event(by: jsonEvent.id)).first {
+        if let existingEvent = find(by: jsonEvent.id, context: context) {
             return existingEvent
         } else {
             return try? Event(context: context, jsonEvent: jsonEvent)

--- a/Nos/Models/Event+CoreDataClass.swift
+++ b/Nos/Models/Event+CoreDataClass.swift
@@ -88,6 +88,13 @@ public class Event: NosManagedObject {
         return fetchRequest
     }
     
+    @nonobjc public class func allUserPostsRequest(_ eventKind: EventKind = .text) -> NSFetchRequest<Event> {
+        let fetchRequest = NSFetchRequest<Event>(entityName: "Event")
+        fetchRequest.sortDescriptors = [NSSortDescriptor(keyPath: \Event.createdAt, ascending: false)]
+        fetchRequest.predicate = NSPredicate(format: "kind = %i AND userCreated = true", eventKind.rawValue)
+        return fetchRequest
+    }
+    
     @nonobjc public class func allReplies(to rootEvent: Event) -> NSFetchRequest<Event> {
         let fetchRequest = NSFetchRequest<Event>(entityName: "Event")
         fetchRequest.sortDescriptors = [NSSortDescriptor(keyPath: \Event.createdAt, ascending: false)]
@@ -258,6 +265,7 @@ public class Event: NosManagedObject {
 		identifier = jsonEvent.id
 		kind = jsonEvent.kind
 		signature = jsonEvent.signature
+        userCreated = false
         
         // Tags
         allTags = jsonEvent.tags as NSObject
@@ -339,6 +347,18 @@ public class Event: NosManagedObject {
     
     class func all(context: NSManagedObjectContext) -> [Event] {
         let allRequest = Event.allPostsRequest()
+        
+        do {
+            let results = try context.fetch(allRequest)
+            return results
+        } catch let error as NSError {
+            print("Failed to fetch events. Error: \(error.description)")
+            return []
+        }
+    }
+    
+    class func allByUser(context: NSManagedObjectContext) -> [Event] {
+        let allRequest = Event.allUserPostsRequest()
         
         do {
             let results = try context.fetch(allRequest)

--- a/Nos/Models/Nos.xcdatamodeld/Nos.xcdatamodel/contents
+++ b/Nos/Models/Nos.xcdatamodeld/Nos.xcdatamodel/contents
@@ -22,8 +22,8 @@
         <attribute name="createdAt" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="identifier" attributeType="String"/>
         <attribute name="kind" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="sendAttempts" optional="YES" attributeType="Integer 16" usesScalarValueType="YES"/>
         <attribute name="signature" attributeType="String"/>
-        <attribute name="userCreated" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
         <relationship name="author" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Author" inverseName="events" inverseEntity="Author"/>
         <relationship name="authorReferences" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="AuthorReference" inverseName="event" inverseEntity="AuthorReference"/>
         <relationship name="eventReferences" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="EventReference" inverseName="event" inverseEntity="EventReference"/>

--- a/Nos/Models/Nos.xcdatamodeld/Nos.xcdatamodel/contents
+++ b/Nos/Models/Nos.xcdatamodeld/Nos.xcdatamodel/contents
@@ -26,6 +26,7 @@
         <relationship name="author" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Author" inverseName="events" inverseEntity="Author"/>
         <relationship name="authorReferences" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="AuthorReference" inverseName="event" inverseEntity="AuthorReference"/>
         <relationship name="eventReferences" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="EventReference" inverseName="event" inverseEntity="EventReference"/>
+        <relationship name="publishedTo" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Relay"/>
     </entity>
     <entity name="EventReference" representedClassName="EventReference" syncable="YES" codeGenerationType="category">
         <attribute name="eventId" optional="YES" attributeType="String"/>

--- a/Nos/Models/Nos.xcdatamodeld/Nos.xcdatamodel/contents
+++ b/Nos/Models/Nos.xcdatamodeld/Nos.xcdatamodel/contents
@@ -23,6 +23,7 @@
         <attribute name="identifier" attributeType="String"/>
         <attribute name="kind" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="signature" attributeType="String"/>
+        <attribute name="userCreated" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
         <relationship name="author" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Author" inverseName="events" inverseEntity="Author"/>
         <relationship name="authorReferences" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="AuthorReference" inverseName="event" inverseEntity="AuthorReference"/>
         <relationship name="eventReferences" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="EventReference" inverseName="event" inverseEntity="EventReference"/>
@@ -43,5 +44,6 @@
     </entity>
     <entity name="Relay" representedClassName=".Relay" syncable="YES" codeGenerationType="category">
         <attribute name="address" attributeType="String"/>
+        <attribute name="createdAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
     </entity>
 </model>

--- a/Nos/Models/Relay+CoreDataClass.swift
+++ b/Nos/Models/Relay+CoreDataClass.swift
@@ -24,7 +24,7 @@ public class Relay: NosManagedObject {
         return fetchRequest
     }
     
-    class func findOrCreate(by address: HexadecimalString, context: NSManagedObjectContext) -> Relay {
+    class func findOrCreate(by address: String, context: NSManagedObjectContext) -> Relay {
         if let existingRelay = try? context.fetch(Relay.relay(by: address)).first {
             return existingRelay
         } else {

--- a/Nos/Models/Relay+CoreDataClass.swift
+++ b/Nos/Models/Relay+CoreDataClass.swift
@@ -30,11 +30,24 @@ public class Relay: NosManagedObject {
         } else {
             let relay = Relay(context: context)
             relay.address = address
+            relay.createdAt = Date.now
             return relay
         }
     }
     
     var jsonRepresentation: String? {
         address
+    }
+    
+    class func all(context: NSManagedObjectContext) -> [Relay] {
+        let allRequest = Relay.allRelaysRequest()
+        
+        do {
+            let results = try context.fetch(allRequest)
+            return results
+        } catch let error as NSError {
+            print("Failed to fetch relays. Error: \(error.description)")
+            return []
+        }
     }
 }

--- a/Nos/NosApp.swift
+++ b/Nos/NosApp.swift
@@ -20,6 +20,9 @@ struct NosApp: App {
                 .environment(\.managedObjectContext, persistenceController.container.viewContext)
                 .environmentObject(relayService)
                 .environmentObject(router)
+                .task {
+                    relayService.publishFailedEvents()
+                }
         }
     }
 }

--- a/Nos/Service/RelayService.swift
+++ b/Nos/Service/RelayService.swift
@@ -19,8 +19,8 @@ final class RelayService: ObservableObject {
         self.persistenceController = persistenceController
         openSocketsForRelays()
         
-        let pubSelector = #selector(publishFailedEvents)
-        timer = Timer.scheduledTimer(timeInterval: 120, target: self, selector: pubSelector, userInfo: nil, repeats: true)
+        let pubSel = #selector(publishFailedEvents)
+        timer = Timer.scheduledTimer(timeInterval: 120, target: self, selector: pubSel, userInfo: nil, repeats: true)
     }
     
     var allRelayAddresses: [String] {

--- a/Nos/Service/RelayService.swift
+++ b/Nos/Service/RelayService.swift
@@ -231,8 +231,8 @@ extension RelayService {
 extension RelayService {
     func publish(from client: WebSocketClient, event: Event) {
         do {
-            // Keep track of this so if it fails we can retry
-            event.userCreated = true
+            // Keep track of this so if it fails we can retry N times
+            event.sendAttempts += 1
             let request: [Any] = ["EVENT", event.jsonRepresentation!]
             let requestData = try JSONSerialization.data(withJSONObject: request)
             let requestString = String(data: requestData, encoding: .utf8)!

--- a/Nos/Service/RelayService.swift
+++ b/Nos/Service/RelayService.swift
@@ -259,6 +259,8 @@ extension RelayService {
     }
     
     @objc func publishFailedEvents() {
+        openSocketsForRelays()
+
         let objectContext = persistenceController.container.viewContext
         let userSentEvents = Event.allByUser(context: objectContext)
         let relays = Relay.all(context: objectContext)

--- a/Nos/Service/RelayService.swift
+++ b/Nos/Service/RelayService.swift
@@ -177,7 +177,7 @@ extension RelayService {
             
             if let event = Event.find(by: eventId, context: objectContext) {
                 if success {
-                    print("\(eventId) has sent successfully")
+                    print("\(eventId) has sent successfully to \(socketUrl)")
                     let relay = Relay.findOrCreate(by: socketUrl, context: objectContext)
                     if let pubRelays = event.publishedTo?.mutableCopy() as? NSMutableSet {
                         pubRelays.add(relay)
@@ -264,7 +264,7 @@ extension RelayService {
                 guard let missedAddress = missedRelay.address else { continue }
                 if let index = sockets.firstIndex(where: { $0.request.url!.absoluteString == missedAddress }) {
                     // Publish again to this socket
-                    print("Republishing \(event.identifier!)")
+                    print("Republishing \(event.identifier!) on \(missedAddress)")
                     publish(from: sockets[index], event: event)
                 }
             }

--- a/Nos/Views/RelayView.swift
+++ b/Nos/Views/RelayView.swift
@@ -78,6 +78,7 @@ struct RelayView: View {
             
             let relay = Relay(context: viewContext)
             relay.address = newRelayAddress.lowercased().trimmingCharacters(in: .whitespacesAndNewlines)
+            relay.createdAt = Date.now
             newRelayAddress = ""
 
             do {


### PR DESCRIPTION
- Adds `sendAttempts` property and `publishedTo` relationship to `Event`
- Adds `createdAt` property to `Relay`
- Adds code to track every `Relay` that returns an OK after an `Event` sent
- Adds a method, `publishFailedEvents`, to reattempt to send an `Event` to any relays that haven't responded OK after (max) 2 minutes