### PR TITLE
Move event parsing to a background thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added support for threads in reply views
 - Retry failed Event sends every 2 minutes (max 5 retries)
 - Add basic notifications tab
+- Fixed UI freezes when using many relays by moving event processing to a background thread.
 
 ## [0.1 (5)] 2023-03-02 
 

--- a/Nos/Models/Persistence.swift
+++ b/Nos/Models/Persistence.swift
@@ -34,6 +34,14 @@ struct PersistenceController {
         let viewContext = result.container.viewContext
         return result
     }()
+    
+    var viewContext: NSManagedObjectContext {
+        return container.viewContext
+    }
+    
+    func newBackgroundContext() -> NSManagedObjectContext {
+        return container.newBackgroundContext()
+    }
 
     var container: NSPersistentContainer
 

--- a/Nos/Models/Persistence.swift
+++ b/Nos/Models/Persistence.swift
@@ -36,13 +36,9 @@ struct PersistenceController {
     }()
     
     var viewContext: NSManagedObjectContext {
-        return container.viewContext
+        container.viewContext
     }
     
-    func newBackgroundContext() -> NSManagedObjectContext {
-        return container.newBackgroundContext()
-    }
-
     var container: NSPersistentContainer
 
     init(inMemory: Bool = false) {
@@ -116,5 +112,9 @@ struct PersistenceController {
             currentAuthor.follows = NSSet(array: follows)
             // swiftlint:enable legacy_objc_type
         }
+    }
+    
+    func newBackgroundContext() -> NSManagedObjectContext {
+        container.newBackgroundContext()
     }
 }


### PR DESCRIPTION
This moves the main parsing of Events that come in through the RelayService on to a background thread. It works surprisingly well, here's me publishing and viewing content with 75 relays open, with hundreds of events constantly streaming in!

https://user-images.githubusercontent.com/1165004/223445887-cae1ed7c-b8e6-4a0f-942b-db464485bf6b.MP4

