### PR TITLE
feature/nos64-button-copy-user-in-profile-view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added support for threads in reply views
 - Retry failed Event sends every 2 minutes (max 5 retries)
 - Add basic notifications tab
+- Filter the Home Feed down to root posts
+- The profile view requests the latest events and metadata for the given user from the relays
+- Add the ellipsis button to NoteCard and allow the user to copy the NIP-19 note ID of a note.
+- Enabled button to copy user ID on Profile View
 
 ## [0.1 (5)] 2023-03-02 
 
@@ -28,10 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed app crash when no user is passed to HomeFeedView initializer
 - Added ability to post a reply in thread view.
 - Fixed READ MORE Button
-- Filter the Home Feed down to root posts
 - In the Discover tab, display a feed of interesting people
-- The profile view requests the latest events and metadata for the given user from the relays
-- Add the ellipsis button to NoteCard and allow the user to copy the NIP-19 note ID of a note.
 
 ## [0.1 (4)] - 2023-02-24
 

--- a/Nos/Assets/Localization/Localized.swift
+++ b/Nos/Assets/Localization/Localized.swift
@@ -94,6 +94,7 @@ enum Localized: String, Localizable, CaseIterable {
     case notifications = "Notifications"
     case noNotifications = "No notifications (yet)!"
     case copyNoteIdentifier = "Copy Note Identifier"
+    case copyUserIdentifier = "Copy User ID"
     case share = "Share"
     case reportPost = "Report this post"
 }

--- a/Nos/Router.swift
+++ b/Nos/Router.swift
@@ -12,4 +12,6 @@ class Router: ObservableObject {
     @Published var path = NavigationPath()
     /// Sets the title when navigating to a view
     @Published var navigationTitle = ""
+    
+    @Published var userNpubPublicKey = ""
 }

--- a/Nos/Views/AppView.swift
+++ b/Nos/Views/AppView.swift
@@ -21,6 +21,9 @@ struct AppView: View {
     
     @Environment(\.managedObjectContext) private var viewContext
     
+    @State
+    private var showingOptions = false
+    
     /// An enumeration of the destinations for AppView.
     enum Destination: String, Hashable {
         case home
@@ -123,11 +126,17 @@ struct AppView: View {
                                     if router.path.count > 0 {
                                         Button(
                                             action: {
+                                                showingOptions = true
                                             },
                                             label: {
                                                 Image(systemName: "ellipsis")
                                             }
                                         )
+                                        .confirmationDialog(Localized.share.string, isPresented: $showingOptions) {
+                                            Button(Localized.copyUserIdentifier.string) {
+                                                UIPasteboard.general.string = router.userNpubPublicKey
+                                            }
+                                        }
                                     } else {
                                         Button(
                                             action: {
@@ -140,7 +149,6 @@ struct AppView: View {
                                     }
                                 }
                         )
-
                         .sheet(isPresented: $isCreatingNewPost, content: {
                             NewPostView(isPresented: $isCreatingNewPost)
                         })

--- a/Nos/Views/ProfileView.swift
+++ b/Nos/Views/ProfileView.swift
@@ -78,6 +78,7 @@ struct ProfileView: View {
         .navigationBarBackButtonHidden(true)
         .onAppear {
             router.navigationTitle = Localized.profile.rawValue
+            router.userNpubPublicKey = author.publicKey?.npub ?? ""
         }
         .task {
             refreshProfileFeed()


### PR DESCRIPTION
Enabled button to copy user ID on Profile View
https://github.com/planetary-social/nos/issues/64

https://user-images.githubusercontent.com/125296686/223461989-1e9441b6-f7af-4f21-b6c9-baa09bda27b1.mov

