### PR TITLE
feature/nos65-search-bar-find-user-ids

### DIFF
--- a/Nos.xcodeproj/project.pbxproj
+++ b/Nos.xcodeproj/project.pbxproj
@@ -155,6 +155,7 @@
 		CD76864D29B133E600085358 /* ExpandingTextFieldAndSubmitButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD76864B29B12F7E00085358 /* ExpandingTextFieldAndSubmitButton.swift */; };
 		CD76865029B6503500085358 /* NoteOptionsButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD76864F29B6503500085358 /* NoteOptionsButton.swift */; };
 		CD76865129B68B4400085358 /* NoteOptionsButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD76864F29B6503500085358 /* NoteOptionsButton.swift */; };
+		CD76865329B793F400085358 /* DiscoverSearchBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD76865229B793F400085358 /* DiscoverSearchBar.swift */; };
 		CDDA1F7B29A527650047ACD8 /* Starscream in Frameworks */ = {isa = PBXBuildFile; productRef = CDDA1F7A29A527650047ACD8 /* Starscream */; };
 		CDDA1F7D29A527650047ACD8 /* SwiftUINavigation in Frameworks */ = {isa = PBXBuildFile; productRef = CDDA1F7C29A527650047ACD8 /* SwiftUINavigation */; };
 /* End PBXBuildFile section */
@@ -258,6 +259,7 @@
 		CD2CF38F299E68BE00332116 /* NoteButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteButton.swift; sourceTree = "<group>"; };
 		CD76864B29B12F7E00085358 /* ExpandingTextFieldAndSubmitButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpandingTextFieldAndSubmitButton.swift; sourceTree = "<group>"; };
 		CD76864F29B6503500085358 /* NoteOptionsButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteOptionsButton.swift; sourceTree = "<group>"; };
+		CD76865229B793F400085358 /* DiscoverSearchBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscoverSearchBar.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -486,6 +488,7 @@
 				C94437E529B0DB83004D8C86 /* NotificationsView.swift */,
 				CD76864F29B6503500085358 /* NoteOptionsButton.swift */,
 				3F60F42829B27D3E000D62C4 /* ThreadView.swift */,
+				CD76865229B793F400085358 /* DiscoverSearchBar.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -690,6 +693,7 @@
 				C95D68A3299E6D9000429F86 /* SelectableText.swift in Sources */,
 				C9F84C27298DC98800C6714D /* KeyPair.swift in Sources */,
 				C9F0BB6F29A50437000547FC /* NostrConstants.swift in Sources */,
+				CD76865329B793F400085358 /* DiscoverSearchBar.swift in Sources */,
 				3FB5E651299D28A200386527 /* OnboardingView.swift in Sources */,
 				A3B943CF299AE00100A15A08 /* KeyChain.swift in Sources */,
 				C9671D73298DB94C00EE7E12 /* Data+Encoding.swift in Sources */,

--- a/Nos/Views/DiscoverSearchBar.swift
+++ b/Nos/Views/DiscoverSearchBar.swift
@@ -1,0 +1,32 @@
+//
+//  SearchBar.swift
+//  Nos
+//
+//  Created by Jason Cheatham on 3/7/23.
+//
+
+import Foundation
+import SwiftUI
+struct DiscoverSearchBar: View {
+    @State private var text = ""
+    let placeholder: String
+    let onSubmitSearch: (String) -> Void
+    
+    var body: some View {
+        HStack {
+            Image(systemName: "magnifyingglass")
+            TextField(placeholder, text: $text)
+                .foregroundColor(.primary)
+                .onSubmit {
+                    onSubmitSearch(text)
+                }
+                .frame(maxWidth: .infinity)
+        }
+        .padding(.vertical, 5)
+        .padding(.horizontal, 5)
+        .background(Color(.systemGray5))
+        .cornerRadius(10)
+        .frame(maxWidth: .infinity) 
+    }
+}
+// "Find a user by ID"

--- a/Nos/Views/DiscoverView.swift
+++ b/Nos/Views/DiscoverView.swift
@@ -43,18 +43,23 @@ struct DiscoverView: View {
             }
             .padding(.horizontal)
             .toolbar {
-                ToolbarItem(placement: .navigationBarTrailing) {
-                    Button {
-                        columns += 1
-                    } label: {
-                        Image(systemName: "plus")
-                    }
-                }
-                ToolbarItem(placement: .navigationBarTrailing) {
-                    Button {
-                        columns = max(columns - 1, 1)
-                    } label: {
-                        Image(systemName: "minus")
+                ToolbarItem(placement: ToolbarItemPlacement.principal) {
+                    HStack {
+                        Button {
+                            columns = max(columns - 1, 1)
+                        } label: {
+                            Image(systemName: "minus")
+                        }
+                        DiscoverSearchBar(placeholder: "Find a user by ID", onSubmitSearch: { text in
+                            let publicKey = PublicKey(npub: text)
+                            let author = try! Author.findOrCreate(by: publicKey!.hex, context: viewContext)
+                            router.path.append(author)
+                        })
+                        Button {
+                            columns += 1
+                        } label: {
+                            Image(systemName: "plus")
+                        }
                     }
                 }
             }


### PR DESCRIPTION
https://github.com/planetary-social/nos/issues/65

Add a search bar to the discover tab that users can use to look up other users. 
It won't do full text search, but it accepts npub format public keys and opens the profile page for the user when "Enter" is tapped on the keyboard.