### PR TITLE
feature/get-rid-of-private-key-storage-warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed UI freezes when using many relays by moving event processing to a background thread.
 - On relay remove, send CLOSE to all subs then disconnect and delete socket
 - Render user mentions in NoteCard
+- Replace the warning message to tell the user never to share their private key with anyone.
 
 ## [0.1 (5)] 2023-03-02 
 

--- a/Nos/Assets/Localization/Localized.swift
+++ b/Nos/Assets/Localization/Localized.swift
@@ -61,7 +61,7 @@ enum Localized: String, Localizable, CaseIterable {
     case settingsLinkTitle = "⚙️ Settings"
     
     case keys = "Keys"
-    case keyEncryptionWarning = "Warning: your private key will be stored unencrypted on disk."
+    case keyEncryptionWarning = "Warning: Never share your private key with anyone."
     case privateKeyPlaceholder = "nsec..."
     case save = "Save"
     case settings = "Settings"


### PR DESCRIPTION
https://github.com/planetary-social/nos/issues/27

Replace the message to tell the user never to share their private key with anyone.