### PR TITLE
NOS90 - Mute author functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 - Use only relays added in RelayView for sending and receiving events
-
 - Add PostHog analytics
+- Add mute functionality
 
 ## [0.1 (6)] - 2023-03-08Z
 

--- a/Nos/Assets/Localization/Localized.swift
+++ b/Nos/Assets/Localization/Localized.swift
@@ -95,8 +95,11 @@ enum Localized: String, Localizable, CaseIterable {
     case noNotifications = "No notifications (yet)!"
     case copyNoteIdentifier = "Copy Note Identifier"
     case copyUserIdentifier = "Copy User ID"
+    case muteUser = "Mute"
+    case mutedUser = "Muted"
     case share = "Share"
     case reportPost = "Report this post"
+    case unmuteUser = "Un-Mute"
 }
 
 // MARK: - Onboarding

--- a/Nos/Models/Author+CoreDataClass.swift
+++ b/Nos/Models/Author+CoreDataClass.swift
@@ -96,6 +96,8 @@ public class Author: NosManagedObject {
         } catch let error as NSError {
             print("Failed to delete texts from \(hexadecimalPublicKey ?? ""). Error: \(error.description)")
         }
+        
+        try? context.save()
     }
     
     func mute(context: NSManagedObjectContext) {

--- a/Nos/Models/Author+CoreDataClass.swift
+++ b/Nos/Models/Author+CoreDataClass.swift
@@ -50,6 +50,7 @@ public class Author: NosManagedObject {
         } else {
             let author = Author(context: context)
             author.hexadecimalPublicKey = pubKey
+            author.muted = false
             return author
         }
     }
@@ -87,6 +88,22 @@ public class Author: NosManagedObject {
         }
     }
     
+    func deleteAllPosts(context: NSManagedObjectContext) {
+        let deleteRequest = Event.deleteAllPosts(by: self)
+        
+        do {
+            try context.execute(deleteRequest)
+        } catch let error as NSError {
+            print("Failed to delete texts from \(hexadecimalPublicKey ?? ""). Error: \(error.description)")
+        }
+    }
+    
+    func mute(context: NSManagedObjectContext) {
+        print("Muting \(hexadecimalPublicKey ?? "")")
+        muted = true
+        deleteAllPosts(context: context)
+    }
+    
     func remove(relay: Relay) {
         if let currentRelays = relays?.mutableCopy() as? NSMutableSet {
             currentRelays.remove(relay)
@@ -106,5 +123,10 @@ public class Author: NosManagedObject {
         let metaFilter = Filter(authorKeys: [hexadecimalPublicKey], kinds: [.metaData], limit: 1)
         let metaSub = relayService.requestEventsFromAll(filter: metaFilter)
         return metaSub
+    }
+    
+    func unmute() {
+        print("Un-muting \(hexadecimalPublicKey ?? "")")
+        muted = false
     }
 }

--- a/Nos/Models/Event+CoreDataClass.swift
+++ b/Nos/Models/Event+CoreDataClass.swift
@@ -10,6 +10,7 @@
 import Foundation
 import CoreData
 import RegexBuilder
+import SwiftUI
 
 enum EventError: Error {
 	case jsonEncoding
@@ -45,6 +46,17 @@ public enum EventKind: Int64, CaseIterable {
 	case like = 7
     case channelMessage = 42
     case parameterizedReplaceableEvent = 30_000
+}
+
+extension FetchedResults where Element == Event {
+    var unmuted: [Event] {
+        filter {
+            if let author = $0.author {
+                return !author.muted
+            }
+            return false
+        }
+    }
 }
 
 // swiftlint:disable type_body_length

--- a/Nos/Models/Nos.xcdatamodeld/Nos.xcdatamodel/contents
+++ b/Nos/Models/Nos.xcdatamodeld/Nos.xcdatamodel/contents
@@ -5,6 +5,7 @@
         <attribute name="displayName" optional="YES" attributeType="String"/>
         <attribute name="hexadecimalPublicKey" attributeType="String"/>
         <attribute name="lastUpdated" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="muted" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="name" optional="YES" attributeType="String"/>
         <attribute name="profilePhotoURL" optional="YES" attributeType="URI"/>
         <relationship name="events" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Event" inverseName="author" inverseEntity="Event"/>

--- a/Nos/Router.swift
+++ b/Nos/Router.swift
@@ -13,8 +13,8 @@ class Router: ObservableObject {
     @Published var path = NavigationPath()
     /// Sets the title when navigating to a view
     @Published var navigationTitle = ""
-    
-    @Published var userNpubPublicKey = ""
+    /// Set when a profile is viewed
+    @Published var viewedAuthor: Author?
 }
 
 extension Router {

--- a/Nos/Service/CurrentUser.swift
+++ b/Nos/Service/CurrentUser.swift
@@ -75,8 +75,8 @@ enum CurrentUser {
         }
     }
     
-    static func isFollowing(author: Author) -> Bool {
-        guard let following = follows, let key = author.hexadecimalPublicKey else {
+    static func isFollowing(author profile: Author) -> Bool {
+        guard let following = author.follows as? Set<Follow>, let key = profile.hexadecimalPublicKey else {
             return false
         }
         

--- a/Nos/Service/CurrentUser.swift
+++ b/Nos/Service/CurrentUser.swift
@@ -44,7 +44,14 @@ enum CurrentUser {
     }
     
     static var follows: Set<Follow>? {
-        author.follows as? Set<Follow>
+        let followSet = author.follows as? Set<Follow>
+        let umutedSet = followSet!.filter({
+            if let author = $0.destination {
+                return author.muted == false
+            }
+            return false
+        })
+        return umutedSet
     }
     
     static func subscribe() {

--- a/Nos/Service/CurrentUser.swift
+++ b/Nos/Service/CurrentUser.swift
@@ -169,13 +169,7 @@ enum CurrentUser {
 
         // Delete cached texts from this person
         if let author = try? Author.find(by: unfollowedKey, context: context) {
-            let deleteRequest = Event.deleteAllPosts(by: author)
-            
-            do {
-                try context.execute(deleteRequest)
-            } catch let error as NSError {
-                print("Failed to delete texts from \(unfollowedKey). Error: \(error.description)")
-            }
+            author.deleteAllPosts(context: context)
         }
     }
     

--- a/Nos/Service/RelayService.swift
+++ b/Nos/Service/RelayService.swift
@@ -118,7 +118,7 @@ extension RelayService {
         }
     }
     
-    func parseEvent(_ responseArray: [Any]) {
+    func parseEvent(_ responseArray: [Any], _ socket: WebSocket) {
         guard responseArray.count >= 3 else {
             print("Error: invalid EVENT response: \(responseArray)")
             return
@@ -135,7 +135,7 @@ extension RelayService {
                     _ = try EventProcessor.parse(jsonObject: eventJSON, in: self.backgroundContext)
                 }
             } catch {
-                print("Error: parsing event from relay: \(responseArray)")
+                print("Error: parsing event from relay (\(socket.request.url?.absoluteString ?? "")): \(responseArray)")
             }
         }
     }
@@ -196,7 +196,7 @@ extension RelayService {
             }
             switch responseType {
             case "EVENT":
-                parseEvent(responseArray)
+                parseEvent(responseArray, socket)
             case "NOTICE":
                 print(response)
             case "EOSE":

--- a/Nos/Views/AppView.swift
+++ b/Nos/Views/AppView.swift
@@ -134,7 +134,18 @@ struct AppView: View {
                                         )
                                         .confirmationDialog(Localized.share.string, isPresented: $showingOptions) {
                                             Button(Localized.copyUserIdentifier.string) {
-                                                UIPasteboard.general.string = router.userNpubPublicKey
+                                                UIPasteboard.general.string = router.viewedAuthor?.publicKey?.npub ?? ""
+                                            }
+                                            if let author = router.viewedAuthor {
+                                                if author.muted {
+                                                    Button(Localized.unmuteUser.string) {
+                                                        router.viewedAuthor?.unmute()
+                                                    }
+                                                } else {
+                                                    Button(Localized.muteUser.string) {
+                                                        router.viewedAuthor?.mute(context: viewContext)
+                                                    }
+                                                }
                                             }
                                         }
                                     } else {

--- a/Nos/Views/DiscoverView.swift
+++ b/Nos/Views/DiscoverView.swift
@@ -37,7 +37,7 @@ struct DiscoverView: View {
     
     var body: some View {
         NavigationStack(path: $router.path) {
-            StaggeredGrid(list: events, columns: columns) { note in
+            StaggeredGrid(list: events.unmuted, columns: columns) { note in
                 NoteButton(note: note, style: .golden)
                     .matchedGeometryEffect(id: note.identifier, in: animation)
             }

--- a/Nos/Views/FollowCard.swift
+++ b/Nos/Views/FollowCard.swift
@@ -34,6 +34,11 @@ struct FollowCard: View {
                             .foregroundColor(Color.secondaryTxt)
                             .multilineTextAlignment(.leading)
                             .frame(maxWidth: .infinity, alignment: .leading)
+                        if author.muted {
+                            Text(Localized.mutedUser.string)
+                                .font(.subheadline)
+                                .foregroundColor(Color.secondaryTxt)
+                        }
                         Spacer()
                         FollowButton(currentUserAuthor: CurrentUser.author, author: author)
                     }

--- a/Nos/Views/HomeFeedView.swift
+++ b/Nos/Views/HomeFeedView.swift
@@ -61,8 +61,11 @@ struct HomeFeedView: View {
                 LazyVStack {
                     ForEach(events) { event in
                         VStack {
-                            NoteButton(note: event)
-                                .padding(.horizontal)
+                            // TODO: A mute will delete posts but not refresh this feed. So it's hidden instead.
+                            if let author = event.author, !author.muted {
+                                NoteButton(note: event)
+                                    .padding(.horizontal)
+                            }
                         }
                     }
                 }

--- a/Nos/Views/HomeFeedView.swift
+++ b/Nos/Views/HomeFeedView.swift
@@ -59,7 +59,7 @@ struct HomeFeedView: View {
         NavigationStack(path: $router.path) {
             ScrollView(.vertical) {
                 LazyVStack {
-                    ForEach(events) { event in
+                    ForEach(events.filter { !$0.author!.muted }) { event in
                         VStack {
                             NoteButton(note: event)
                                 .padding(.horizontal)
@@ -80,7 +80,7 @@ struct HomeFeedView: View {
                 }
             }
             .overlay(Group {
-                if events.isEmpty {
+                if !events.contains(where: { !$0.author!.muted }) {
                     Localized.noEvents.view
                         .padding()
                 }

--- a/Nos/Views/HomeFeedView.swift
+++ b/Nos/Views/HomeFeedView.swift
@@ -61,11 +61,8 @@ struct HomeFeedView: View {
                 LazyVStack {
                     ForEach(events) { event in
                         VStack {
-                            // TODO: A mute will delete posts but not refresh this feed. So it's hidden instead.
-                            if let author = event.author, !author.muted {
-                                NoteButton(note: event)
-                                    .padding(.horizontal)
-                            }
+                            NoteButton(note: event)
+                                .padding(.horizontal)
                         }
                     }
                 }

--- a/Nos/Views/HomeFeedView.swift
+++ b/Nos/Views/HomeFeedView.swift
@@ -59,7 +59,7 @@ struct HomeFeedView: View {
         NavigationStack(path: $router.path) {
             ScrollView(.vertical) {
                 LazyVStack {
-                    ForEach(events.filter { !$0.author!.muted }) { event in
+                    ForEach(events.unmuted) { event in
                         VStack {
                             NoteButton(note: event)
                                 .padding(.horizontal)

--- a/Nos/Views/HomeFeedView.swift
+++ b/Nos/Views/HomeFeedView.swift
@@ -40,7 +40,7 @@ struct HomeFeedView: View {
             subscriptionIds.removeAll()
         }
 
-        if let follows = CurrentUser.author.follows as? Set<Follow> {
+        if let follows = CurrentUser.follows {
             let authors = follows.compactMap({ $0.destination?.hexadecimalPublicKey! })
             
             if !authors.isEmpty {

--- a/Nos/Views/NoteButton.swift
+++ b/Nos/Views/NoteButton.swift
@@ -20,7 +20,7 @@ struct NoteButton: View {
     @EnvironmentObject private var relayService: RelayService
 
     var body: some View {
-        if let author = note.author{
+        if let author = note.author {
             Button {
                 // If we are on the home feed or this is not the root note, allow clicks on replies
                 if router.path.count == 0 || note.eventReferences?.count ?? 0 > 0

--- a/Nos/Views/NoteButton.swift
+++ b/Nos/Views/NoteButton.swift
@@ -20,7 +20,7 @@ struct NoteButton: View {
     @EnvironmentObject private var relayService: RelayService
 
     var body: some View {
-        if let author = note.author {
+        if let author = note.author, !author.muted {
             Button {
                 // If we are on the home feed or this is not the root note, allow clicks on replies
                 if router.path.count == 0 || note.eventReferences?.count ?? 0 > 0

--- a/Nos/Views/NoteButton.swift
+++ b/Nos/Views/NoteButton.swift
@@ -20,7 +20,7 @@ struct NoteButton: View {
     @EnvironmentObject private var relayService: RelayService
 
     var body: some View {
-        if let author = note.author, !author.muted {
+        if let author = note.author{
             Button {
                 // If we are on the home feed or this is not the root note, allow clicks on replies
                 if router.path.count == 0 || note.eventReferences?.count ?? 0 > 0

--- a/Nos/Views/NotificationsView.swift
+++ b/Nos/Views/NotificationsView.swift
@@ -34,7 +34,7 @@ struct NotificationsView: View {
         NavigationStack(path: $router.path) {
             ScrollView(.vertical) {
                 LazyVStack {
-                    ForEach(events) { event in
+                    ForEach(events.unmuted) { event in
                         if let user {
                             NotificationCard(note: event, user: user)
                         }

--- a/Nos/Views/ProfileHeader.swift
+++ b/Nos/Views/ProfileHeader.swift
@@ -66,7 +66,14 @@ struct ProfileHeader: View {
                                 .font(.title3.weight(.semibold))
                                 .foregroundColor(Color.primaryTxt)
                             Spacer()
-                            FollowButton(currentUserAuthor: CurrentUser.author, author: author)
+                            VStack {
+                                FollowButton(currentUserAuthor: CurrentUser.author, author: author)
+                                if author.muted {
+                                    Text(Localized.mutedUser.string)
+                                        .font(.subheadline)
+                                        .foregroundColor(Color.secondaryTxt)
+                                }
+                            }
                         }
                         Spacer()
 

--- a/Nos/Views/ProfileView.swift
+++ b/Nos/Views/ProfileView.swift
@@ -78,7 +78,7 @@ struct ProfileView: View {
         .navigationBarBackButtonHidden(true)
         .onAppear {
             router.navigationTitle = Localized.profile.rawValue
-            router.userNpubPublicKey = author.publicKey?.npub ?? ""
+            router.viewedAuthor = author
         }
         .task {
             refreshProfileFeed()

--- a/Nos/Views/ProfileView.swift
+++ b/Nos/Views/ProfileView.swift
@@ -11,7 +11,7 @@ import CoreData
 struct ProfileView: View {
     @EnvironmentObject var router: Router
     
-    var author: Author
+    @ObservedObject var author: Author
     
     @Environment(\.managedObjectContext) private var viewContext
     
@@ -58,7 +58,7 @@ struct ProfileView: View {
                     .shadow(color: .profileShadow, radius: 10, x: 0, y: 4)
                 
                 LazyVStack {
-                    ForEach(events) { event in
+                    ForEach(events.filter { !$0.author!.muted }) { event in
                         VStack {
                             NoteButton(note: event)
                                 .padding(.horizontal)
@@ -69,7 +69,7 @@ struct ProfileView: View {
             .padding(.top, 1)
             .background(Color.appBg)
             .overlay(Group {
-                if events.isEmpty {
+                if !events.contains(where: { !$0.author!.muted }) {
                     Localized.noEventsOnProfile.view
                         .padding()
                 }

--- a/Nos/Views/ProfileView.swift
+++ b/Nos/Views/ProfileView.swift
@@ -58,7 +58,7 @@ struct ProfileView: View {
                     .shadow(color: .profileShadow, radius: 10, x: 0, y: 4)
                 
                 LazyVStack {
-                    ForEach(events.filter { !$0.author!.muted }) { event in
+                    ForEach(events.unmuted) { event in
                         VStack {
                             NoteButton(note: event)
                                 .padding(.horizontal)


### PR DESCRIPTION
- Adds a muted flag to Author
- Adds a Mute / Unmute option in the tab bar ellipses menu
- On mute, the Author is flagged as muted and all Events are deleted
- Updates CurrentUser.follows to ignore muted Authors, which stops HomeFeed requests of that user's Events
- Extends FetchedResults<Event> with an unmuted var, which is used where Events are fetched
- Updates Router to hold an Author instead of just a pubKey