### PR TITLE
Another try at fixing the duplicate note issue

### DIFF
--- a/Nos/Views/NewNoteView.swift
+++ b/Nos/Views/NewNoteView.swift
@@ -90,6 +90,7 @@ struct NewNoteView: View {
                 event.author = try Author.findOrCreate(by: keyPair.publicKeyHex, context: viewContext)
 
                 try event.sign(withKey: keyPair)
+                try viewContext.save()
                 relayService.publishToAll(event: event)
                 isPresented = false
                 analytics.published(note: event)

--- a/Nos/Views/RepliesView.swift
+++ b/Nos/Views/RepliesView.swift
@@ -77,6 +77,9 @@ struct RepliesView: View {
                 .background(Color.cardBgBottom)
             }
             .fixedSize(horizontal: false, vertical: true)
+            .onAppear {
+                print("npub: \(keyPair?.npub ?? "null")")
+            }
         }
         .background(Color.appBg)
     }
@@ -119,6 +122,7 @@ struct RepliesView: View {
             let event = try Event.findOrCreate(jsonEvent: jsonEvent, context: viewContext)
                 
             try event.sign(withKey: keyPair)
+            try viewContext.save()
             relayService.publishToAll(event: event)
         } catch {
             alert = AlertState(title: {


### PR DESCRIPTION
This is another try at fixing the duplicate note issue. I thought it was fixed in #131, but I just saw it again. My hypothesis that is a race condition where if we post the event to a relay and it sends it back to us because we have an open filter for it, then it gets parsed and saved again if the context we originally saved the event in hasn't been saved yet.