### PR TITLE
bug/fix-tabs-show-feed-behind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Fix translucent tab bar in the simulator.
 
 ## [0.1 (7)] - 2023-03-10Z
 - Use only relays added in RelayView for sending and receiving events

--- a/Nos/Views/HomeFeedView.swift
+++ b/Nos/Views/HomeFeedView.swift
@@ -63,6 +63,7 @@ struct HomeFeedView: View {
             }
             .background(Color.appBg)
             .padding(.top, 1)
+            .padding(.bottom, 1)
             .navigationDestination(for: Event.self) { note in
                 RepliesView(note: note)
             }

--- a/Nos/Views/NotificationsView.swift
+++ b/Nos/Views/NotificationsView.swift
@@ -48,6 +48,7 @@ struct NotificationsView: View {
             })
             .background(Color.appBg)
             .padding(.top, 1)
+            .padding(.bottom, 1)
             .navigationBarTitle(Localized.notifications.string, displayMode: .inline)
             .toolbarBackground(.visible, for: .navigationBar)
             .toolbarBackground(Color.cardBgBottom, for: .navigationBar)

--- a/Nos/Views/ProfileView.swift
+++ b/Nos/Views/ProfileView.swift
@@ -67,6 +67,7 @@ struct ProfileView: View {
                 }
             }
             .padding(.top, 1)
+            .padding(.bottom, 1)
             .background(Color.appBg)
             .overlay(Group {
                 if !events.contains(where: { !$0.author!.muted }) {


### PR DESCRIPTION
Added padding to the bottom to prevent the feed from showing behind the tabs in the simulator.

The latest TestFlight build doesn't have the tab bar translucent, so this fix may not be needed.
![HomeFeedTab](https://user-images.githubusercontent.com/125296686/224746222-269a4a3d-4d9c-48f5-b1d1-82c371b89202.png)
![NotificationsTab](https://user-images.githubusercontent.com/125296686/224746226-f8a8ef46-7948-4ce5-b41f-49d522fdb690.png)
![ProfileTab](https://user-images.githubusercontent.com/125296686/224746228-8f3a305a-5f3e-452b-a0b5-d97e1b6850ec.png)
