### PR TITLE
Bugfixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Fixed a crash on launch when relay model was outdated.
+- Fix your own posts showing as outside your network on a fresh install. 
 
 ## [0.1 (8)] - 2023-03-13Z
 - Fix translucent tab bar in the simulator.

--- a/Nos/Models/Event+CoreDataClass.swift
+++ b/Nos/Models/Event+CoreDataClass.swift
@@ -508,6 +508,8 @@ public class Event: NosManagedObject {
                     }
                 }
             }
+            
+            CurrentUser.shared.updateInNetworkAuthors()
 
         case .metaData:
             guard createdAt! > newAuthor.lastUpdatedMetadata ?? Date.distantPast else {

--- a/Nos/Models/Persistence.swift
+++ b/Nos/Models/Persistence.swift
@@ -10,6 +10,10 @@ import Logger
 
 struct PersistenceController {
     static let shared = PersistenceController()
+    
+    /// Increment this to delete core data on update
+    static let version = 1
+    static let versionKey = "NosPersistenceControllerVersion"
 
     // swiftlint:disable force_try
     static var preview: PersistenceController = {
@@ -55,15 +59,21 @@ struct PersistenceController {
         var needsReload = false
         container.loadPersistentStores(completionHandler: { [container] (storeDescription, error) in
             
+            if Self.loadVersionFromDisk() < Self.version {
+                guard let storeURL = storeDescription.url else {
+                    Log.error("need to delete core data due to version change but could not get store URL")
+                    return
+                }
+                Self.clearCoreData(store: storeURL, in: container)
+                needsReload = true
+                Self.saveVersionToDisk(Self.version)
+            }
+            
             if let error = error as NSError? {
                 if error.domain == NSCocoaErrorDomain, error.code == 134_110, let storeURL = storeDescription.url {
+                    Self.clearCoreData(store: storeURL, in: container)
+                    needsReload = true
                     // The data model changed. Clear core data.
-                    do {
-                        try container.persistentStoreCoordinator.destroyPersistentStore(at: storeURL, type: .sqlite)
-                        needsReload = true
-                    } catch {
-                        fatalError("Could not erase database \(error.localizedDescription)")
-                    }
                 } else {
                     fatalError("Could not initialize database \(error), \(error.userInfo)")
                 }
@@ -76,6 +86,15 @@ struct PersistenceController {
         
         if needsReload {
             self = PersistenceController(inMemory: inMemory)
+        }
+    }
+    
+    static func clearCoreData(store storeURL: URL, in container: NSPersistentContainer) {
+        Log.info("Dropping Core Data...")
+        do {
+            try container.persistentStoreCoordinator.destroyPersistentStore(at: storeURL, type: .sqlite)
+        } catch {
+            fatalError("Could not erase database \(error.localizedDescription)")
         }
     }
     
@@ -117,5 +136,13 @@ struct PersistenceController {
     
     func newBackgroundContext() -> NSManagedObjectContext {
         container.newBackgroundContext()
+    }
+    
+    static func loadVersionFromDisk() -> Int {
+        UserDefaults.standard.integer(forKey: Self.versionKey)
+    }
+    
+    static func saveVersionToDisk(_ newVersion: Int) {
+        UserDefaults.standard.set(newVersion, forKey: Self.versionKey)
     }
 }

--- a/Nos/Service/CurrentUser.swift
+++ b/Nos/Service/CurrentUser.swift
@@ -267,9 +267,10 @@ class CurrentUser: ObservableObject {
     
     func updateInNetworkAuthors() {
         do {
-            let inNetworkAuthors = try context.fetch(Author.inNetworkRequest())
-            DispatchQueue.main.async {
-                self.inNetworkAuthors = inNetworkAuthors
+            if let inNetworkAuthors = try context?.fetch(Author.inNetworkRequest()) {
+                DispatchQueue.main.async {
+                    self.inNetworkAuthors = inNetworkAuthors
+                }
             }
         } catch {
             Log.error("Error updating in network authors: \(error.localizedDescription)")

--- a/Nos/Service/RelayService.swift
+++ b/Nos/Service/RelayService.swift
@@ -279,7 +279,9 @@ extension RelayService {
             }
             switch responseType {
             case "EVENT":
+                #if DEBUG
                 Log.info(response)
+                #endif
                 parseEvent(responseArray, socket)
             case "NOTICE":
                 print(response)

--- a/Nos/Views/HomeFeedView.swift
+++ b/Nos/Views/HomeFeedView.swift
@@ -56,7 +56,7 @@ struct HomeFeedView: View {
                 LazyVStack {
                     ForEach(events.unmuted) { event in
                         VStack {
-                            NoteButton(note: event)
+                            NoteButton(note: event, hideOutOfNetwork: false)
                                 .padding(.horizontal)
                         }
                     }

--- a/Nos/Views/NoteButton.swift
+++ b/Nos/Views/NoteButton.swift
@@ -16,6 +16,7 @@ struct NoteButton: View {
     var note: Event
     var style = CardStyle.compact
     var showFullMessage = false
+    var hideOutOfNetwork = true
     var allowsPush = true
     var showReplyCount = true
 
@@ -34,6 +35,7 @@ struct NoteButton: View {
                     note: note,
                     style: style,
                     showFullMessage: showFullMessage,
+                    hideOutOfNetwork: hideOutOfNetwork,
                     showReplyCount: showReplyCount
                 )
             }

--- a/Nos/Views/NoteCard.swift
+++ b/Nos/Views/NoteCard.swift
@@ -33,7 +33,7 @@ struct NoteCard: View {
     @State private var userTappedShowOutOfNetwork = false
     
     var showContents: Bool {
-        showFullMessage ||
+        !hideOutOfNetwork ||
         userTappedShowOutOfNetwork ||
         currentUser.inNetworkAuthors.contains(note.author!) ||
         Event.discoverTabUserIdToInfo.keys.contains(note.author?.hexadecimalPublicKey ?? "")
@@ -72,18 +72,21 @@ struct NoteCard: View {
     
     private var showFullMessage: Bool
     private let showReplyCount: Bool
+    private var hideOutOfNetwork: Bool
     
     init(
         author: Author,
         note: Event,
         style: CardStyle = .compact,
         showFullMessage: Bool = false,
+        hideOutOfNetwork: Bool = true,
         showReplyCount: Bool = true
     ) {
         self.author = author
         self.note = note
         self.style = style
         self.showFullMessage = showFullMessage
+        self.hideOutOfNetwork = hideOutOfNetwork
         self.showReplyCount = showReplyCount
         if showReplyCount {
             self.repliesRequest = FetchRequest(fetchRequest: Event.allReplies(to: note), animation: .default)

--- a/Nos/Views/ProfileView.swift
+++ b/Nos/Views/ProfileView.swift
@@ -61,7 +61,7 @@ struct ProfileView: View {
                 LazyVStack {
                     ForEach(events.unmuted) { event in
                         VStack {
-                            NoteButton(note: event)
+                            NoteButton(note: event, hideOutOfNetwork: false)
                                 .padding(.horizontal)
                         }
                     }

--- a/Nos/Views/RelayView.swift
+++ b/Nos/Views/RelayView.swift
@@ -132,7 +132,8 @@ struct RelayView: View {
             guard !newRelayAddress.isEmpty else { return }
             
             let address = newRelayAddress.lowercased().trimmingCharacters(in: .whitespacesAndNewlines)
-            let relay = Relay(context: viewContext, address: address, author: CurrentUser.shared.author)
+            let relay = Relay.findOrCreate(by: address, context: viewContext)
+            CurrentUser.shared.author?.add(relay: relay)
             newRelayAddress = ""
 
             do {

--- a/Nos/Views/RepliesView.swift
+++ b/Nos/Views/RepliesView.swift
@@ -86,8 +86,15 @@ struct RepliesView: View {
         VStack {
             ScrollView(.vertical) {
                 LazyVStack {
-                    NoteButton(note: note, showFullMessage: true, allowsPush: false, showReplyCount: false)
-                        .padding(.horizontal)
+                    NoteButton(
+                        note: note,
+                        showFullMessage: true,
+                        hideOutOfNetwork: false,
+                        allowsPush: false,
+                        showReplyCount: false
+                    )
+                    .padding(.horizontal)
+                    
                     ForEach(directReplies.reversed()) { event in
                         ThreadView(root: event, allReplies: replies.reversed())
                     }


### PR DESCRIPTION
- Add code to reset core data on next update because some people are seeing crashes when their relays don't have a lastUpdated date.
- fix your own posts being outside your network on a fresh install by updating the inNetworkAuthors whenever we parse a contact list
- Don't show the out of network warning on HomeFeed, ProfileView, root note in RepliesView