### PR TITLE
Fix blank home feed after key import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 - Display a user's NIP-05 identifier on the profile page after making a web request to verify that it is correct 
+- Fix blank home feed during first launch
 
 ## [0.1 (9)] - 2023-03-14Z
 - Fixed a crash on launch when relay model was outdated.

--- a/Nos/Models/Author+CoreDataClass.swift
+++ b/Nos/Models/Author+CoreDataClass.swift
@@ -95,17 +95,7 @@ public class Author: NosManagedObject {
         )
         return fetchRequest
     }
-    
-    @nonobjc func homeFeedPredicate() -> NSPredicate {
-        NSPredicate(
-            // swiftlint:disable line_length
-            format: "kind = 1 AND SUBQUERY(eventReferences, $reference, $reference.marker = 'root' OR $reference.marker = 'reply' OR $reference.marker = nil).@count = 0 AND (ANY author.followers.source = %@ OR author = %@)",
-            // swiftlint:enable line_length
-            self,
-            self
-        )
-    }
-    
+
     @nonobjc public class func emptyRequest() -> NSFetchRequest<Author> {
         let fetchRequest = NSFetchRequest<Author>(entityName: "Author")
         fetchRequest.sortDescriptors = [NSSortDescriptor(keyPath: \Author.hexadecimalPublicKey, ascending: true)]

--- a/Nos/Models/Author+CoreDataClass.swift
+++ b/Nos/Models/Author+CoreDataClass.swift
@@ -86,6 +86,26 @@ public class Author: NosManagedObject {
         return fetchRequest
     }
     
+    @nonobjc func followsRequest() -> NSFetchRequest<Author> {
+        let fetchRequest = NSFetchRequest<Author>(entityName: "Author")
+        fetchRequest.sortDescriptors = [NSSortDescriptor(keyPath: \Author.hexadecimalPublicKey, ascending: false)]
+        fetchRequest.predicate = NSPredicate(
+            format: "ANY followers = %@",
+            self
+        )
+        return fetchRequest
+    }
+    
+    @nonobjc func homeFeedPredicate() -> NSPredicate {
+        NSPredicate(
+            // swiftlint:disable line_length
+            format: "kind = 1 AND SUBQUERY(eventReferences, $reference, $reference.marker = 'root' OR $reference.marker = 'reply' OR $reference.marker = nil).@count = 0 AND (ANY author.followers.source = %@ OR author = %@)",
+            // swiftlint:enable line_length
+            self,
+            self
+        )
+    }
+    
     @nonobjc public class func emptyRequest() -> NSFetchRequest<Author> {
         let fetchRequest = NSFetchRequest<Author>(entityName: "Author")
         fetchRequest.sortDescriptors = [NSSortDescriptor(keyPath: \Author.hexadecimalPublicKey, ascending: true)]

--- a/Nos/Models/Event+CoreDataClass.swift
+++ b/Nos/Models/Event+CoreDataClass.swift
@@ -209,7 +209,6 @@ public class Event: NosManagedObject {
         return fetchRequest
     }
     
-    
     @nonobjc public class func homeFeedPredicate(for user: Author) -> NSPredicate {
         NSPredicate(
             // swiftlint:disable line_length
@@ -501,7 +500,6 @@ public class Event: NosManagedObject {
                 }
             }
             
-
         case .metaData:
             guard createdAt! > newAuthor.lastUpdatedMetadata ?? Date.distantPast else {
                 // This is old data

--- a/Nos/Models/Persistence.swift
+++ b/Nos/Models/Persistence.swift
@@ -135,7 +135,11 @@ struct PersistenceController {
     }
     
     func newBackgroundContext() -> NSManagedObjectContext {
-        container.newBackgroundContext()
+        let context = container.newBackgroundContext()
+        context.automaticallyMergesChangesFromParent = true
+        let mergeType = NSMergePolicyType.mergeByPropertyObjectTrumpMergePolicyType
+        context.mergePolicy = NSMergePolicy(merge: mergeType)
+        return context
     }
     
     static func loadVersionFromDisk() -> Int {

--- a/Nos/NosApp.swift
+++ b/Nos/NosApp.swift
@@ -21,6 +21,7 @@ struct NosApp: App {
                 .environmentObject(relayService)
                 .environmentObject(router)
                 .environmentObject(AppController(router: router))
+                .environmentObject(CurrentUser.shared)
                 .task {
                     CurrentUser.shared.relayService = relayService
                     relayService.publishFailedEvents()

--- a/Nos/Service/CurrentUser.swift
+++ b/Nos/Service/CurrentUser.swift
@@ -194,8 +194,6 @@ class CurrentUser: ObservableObject {
                 Log.debug("failed to update Follows \(error.localizedDescription)")
             }
         }
-        
-        updateInNetworkAuthors()
     }
     
     /// Follow by public hex key
@@ -259,12 +257,8 @@ class CurrentUser: ObservableObject {
             }
         }
 
+        try! context.save()
         publishContactList(tags: stillFollowingKeys.tags)
-
-        // Delete cached texts from this person
-        if let author = try? Author.find(by: unfollowedKey, context: context) {
-            author.deleteAllPosts(context: context)
-        }
     }
     
     func updateInNetworkAuthors() {

--- a/Nos/Service/RelayService.swift
+++ b/Nos/Service/RelayService.swift
@@ -218,7 +218,7 @@ extension RelayService {
                     }
                 }
             } catch {
-                print("Error: parsing event from relay (\(socket.request.url?.absoluteString ?? "")): \(responseArray)")
+                print("Error: parsing event from relay (\(socket.request.url?.absoluteString ?? "")): \(responseArray)\nerror: \(error.localizedDescription)")
             }
         }
     }

--- a/Nos/Service/RelayService.swift
+++ b/Nos/Service/RelayService.swift
@@ -218,7 +218,8 @@ extension RelayService {
                     }
                 }
             } catch {
-                print("Error: parsing event from relay (\(socket.request.url?.absoluteString ?? "")): \(responseArray)\nerror: \(error.localizedDescription)")
+                print("Error: parsing event from relay (\(socket.request.url?.absoluteString ?? "")): " +
+                      "\(responseArray)\nerror: \(error.localizedDescription)")
             }
         }
     }

--- a/Nos/Service/RelayService.swift
+++ b/Nos/Service/RelayService.swift
@@ -219,7 +219,7 @@ extension RelayService {
                 }
             } catch {
                 print("Error: parsing event from relay (\(socket.request.url?.absoluteString ?? "")): " +
-                      "\(responseArray)\nerror: \(error.localizedDescription)")
+                    "\(responseArray)\nerror: \(error.localizedDescription)")
             }
         }
     }

--- a/Nos/Service/RelayService.swift
+++ b/Nos/Service/RelayService.swift
@@ -206,7 +206,7 @@ extension RelayService {
             return
         }
         
-        Task.detached(priority: .userInitiated) {
+        Task.detached(priority: .utility) {
             do {
                 try await self.backgroundContext.perform {
                     let event = try EventProcessor.parse(jsonObject: eventJSON, in: self.backgroundContext)

--- a/Nos/Views/AppView.swift
+++ b/Nos/Views/AppView.swift
@@ -62,14 +62,6 @@ struct AppView: View {
         }
     }
     
-    var predicateBinding: Binding<String> {
-        Binding {
-            let key = CurrentUser.shared.author!.hexadecimalPublicKey!
-            return "kind = 1 AND SUBQUERY(eventReferences, $reference, $reference.marker = 'root' OR $reference.marker = 'reply' OR $reference.marker = nil).@count = 0 AND ANY author.followers.source.hexadecimalPublicKey = \(key)"
-        } set: { _ in
-        }
-    }
-    
     var body: some View {
         
         ZStack {

--- a/Nos/Views/AppView.swift
+++ b/Nos/Views/AppView.swift
@@ -18,6 +18,7 @@ struct AppView: View {
     @EnvironmentObject var router: Router
     @Environment(\.managedObjectContext) private var viewContext
     @Dependency(\.analytics) private var analytics
+    @EnvironmentObject var currentUser: CurrentUser
     
     @State private var showingOptions = false
     @State private var lastSelectedTab = Destination.home
@@ -61,6 +62,14 @@ struct AppView: View {
         }
     }
     
+    var predicateBinding: Binding<String> {
+        Binding {
+            let key = CurrentUser.shared.author!.hexadecimalPublicKey!
+            return "kind = 1 AND SUBQUERY(eventReferences, $reference, $reference.marker = 'root' OR $reference.marker = 'reply' OR $reference.marker = nil).@count = 0 AND ANY author.followers.source.hexadecimalPublicKey = \(key)"
+        } set: { _ in
+        }
+    }
+    
     var body: some View {
         
         ZStack {
@@ -68,7 +77,7 @@ struct AppView: View {
                 OnboardingView(completion: appController.completeOnboarding)
             } else {
                 TabView(selection: $router.selectedTab) {
-                    if let author = CurrentUser.shared.author {
+                    if let author = currentUser.author {
                         HomeFeedView(user: author)
                             .tabItem {
                                 VStack {

--- a/Nos/Views/AppView.swift
+++ b/Nos/Views/AppView.swift
@@ -88,7 +88,9 @@ struct AppView: View {
                             .onAppear {
                                 // TODO: Move this somewhere better like CurrentUser when it becomes the source of truth
                                 // for who is logged in
-                                analytics.identify(with: CurrentUser.shared.keyPair!)
+                                if let keyPair = CurrentUser.shared.keyPair {
+                                    analytics.identify(with: keyPair)
+                                }
                             }
                     }
                     

--- a/Nos/Views/NoteCard.swift
+++ b/Nos/Views/NoteCard.swift
@@ -164,7 +164,7 @@ struct NoteCard: View {
                 GoldenPostView(author: author, note: note)
             }
         }
-        .task {
+        .task(priority: .userInitiated) {
             if author.needsMetadata {
                 _ = author.requestMetadata(using: relayService)
             }

--- a/Nos/Views/ProfileHeader.swift
+++ b/Nos/Views/ProfileHeader.swift
@@ -107,14 +107,16 @@ struct ProfileHeader: View {
             FollowsView(followed: followed)
         }
         .onAppear {
-            Task {
-                if let nip05Identifier = author.nip05, let publicKey = author.publicKey?.hex {
+            Task.detached(priority: .userInitiated) {
+                if let nip05Identifier = await author.nip05, let publicKey = await author.publicKey?.hex {
                     let identifierVerified = await relayService.verifyInternetIdentifier(
                     identifier: nip05Identifier,
                     userPublicKey: publicKey
                     )
                     if identifierVerified {
-                        verifiedNip05Identifier = nip05Identifier
+                        await MainActor.run {
+                            verifiedNip05Identifier = nip05Identifier
+                        }
                     }
                 }
             }

--- a/Nos/Views/ProfileView.swift
+++ b/Nos/Views/ProfileView.swift
@@ -123,10 +123,12 @@ struct ProfileView: View {
                     }
                 }
         )
+        .task {
+            refreshProfileFeed()
+        }
         .onAppear {
             router.viewedAuthor = author
             analytics.showedProfile()
-            refreshProfileFeed()
         }
         .refreshable {
             refreshProfileFeed()


### PR DESCRIPTION
This makes various changes mostly in pursuit of making the first experience after importing your key in onboarding feel better. In particular the home feed now updates with new posts after we download your metadata. I also lowered the priority for some tasks like event parsing to try to make the app less choppy.

Unfortunately it seems like sometimes the request to download our own metadata gets blocked behind all the discover feed events streaming in and it takes a long time to figure out who we are following. This needs some optimizing but I decided to punt on that for now.