### PR TITLE
Core data migrations

### DIFF
--- a/Nos.xcodeproj/project.pbxproj
+++ b/Nos.xcodeproj/project.pbxproj
@@ -263,6 +263,7 @@
 		A3B943CE299AE00100A15A08 /* KeyChain.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyChain.swift; sourceTree = "<group>"; };
 		A3B943D4299D514800A15A08 /* Follow+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Follow+CoreDataClass.swift"; sourceTree = "<group>"; };
 		C92DF80129BFAF9300400561 /* ProductionSecrets.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = ProductionSecrets.xcconfig; sourceTree = "<group>"; };
+		C92DF80229C22E4F00400561 /* Nos 2.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Nos 2.xcdatamodel"; sourceTree = "<group>"; };
 		C931517C29B915AF00934506 /* StaggeredGrid.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StaggeredGrid.swift; sourceTree = "<group>"; };
 		C93CA0C229AE3A1E00921183 /* JSONEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONEvent.swift; sourceTree = "<group>"; };
 		C942566829B66A2800C4202C /* Date+Elapsed.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Date+Elapsed.swift"; sourceTree = "<group>"; };
@@ -1518,9 +1519,10 @@
 		C9DEBFD5298941000078B43A /* Nos.xcdatamodeld */ = {
 			isa = XCVersionGroup;
 			children = (
+				C92DF80229C22E4F00400561 /* Nos 2.xcdatamodel */,
 				C9DEBFD6298941000078B43A /* Nos.xcdatamodel */,
 			);
-			currentVersion = C9DEBFD6298941000078B43A /* Nos.xcdatamodel */;
+			currentVersion = C92DF80229C22E4F00400561 /* Nos 2.xcdatamodel */;
 			path = Nos.xcdatamodeld;
 			sourceTree = "<group>";
 			versionGroupType = wrapper.xcdatamodel;

--- a/Nos/Models/Event+CoreDataClass.swift
+++ b/Nos/Models/Event+CoreDataClass.swift
@@ -485,6 +485,7 @@ public class Event: NosManagedObject {
         }
     }
     
+    // swiftlint:disable function_body_length
     func hydrateContactList(from jsonEvent: JSONEvent, author newAuthor: Author, context: NSManagedObjectContext) {
         guard createdAt! > newAuthor.lastUpdatedContactList ?? Date.distantPast else {
             return
@@ -514,25 +515,25 @@ public class Event: NosManagedObject {
         }
         
         if author?.hexadecimalPublicKey == CurrentUser.shared.author?.hexadecimalPublicKey {
-             do {
-                 try context.save()
-             } catch {
-                 Log.error(error.localizedDescription)
-             }
-             CurrentUser.shared.updateInNetworkAuthors(from: context)
-             CurrentUser.shared.refreshFriendMetadata()
-         }
-
-         if CurrentUser.shared.author?.follows?.contains(where: {
-             ($0 as? Follow)?.destination?.hexadecimalPublicKey == author?.hexadecimalPublicKey
-         }) == true {
-             do {
-                 try context.save()
-             } catch {
-                 Log.error(error.localizedDescription)
-             }
-             CurrentUser.shared.updateInNetworkAuthors(from: context)
-         }
+            do {
+                try context.save()
+            } catch {
+                Log.error(error.localizedDescription)
+            }
+            CurrentUser.shared.updateInNetworkAuthors(from: context)
+            CurrentUser.shared.refreshFriendMetadata()
+        }
+        
+        if CurrentUser.shared.author?.follows?.contains(where: {
+            ($0 as? Follow)?.destination?.hexadecimalPublicKey == author?.hexadecimalPublicKey
+        }) == true {
+            do {
+                try context.save()
+            } catch {
+                Log.error(error.localizedDescription)
+            }
+            CurrentUser.shared.updateInNetworkAuthors(from: context)
+        }
         
         // Get the user's active relays out of the content property
         if let data = jsonEvent.content.data(using: .utf8, allowLossyConversion: false),
@@ -552,6 +553,7 @@ public class Event: NosManagedObject {
             }
         }
     }
+    // swiftlint:enable function_body_length
     
     func hydrateDefault(from jsonEvent: JSONEvent, context: NSManagedObjectContext) {
         let newEventReferences = NSMutableOrderedSet()

--- a/Nos/Models/Nos.xcdatamodeld/Nos 2.xcdatamodel/.xccurrentversion
+++ b/Nos/Models/Nos.xcdatamodeld/Nos 2.xcdatamodel/.xccurrentversion
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>_XCCurrentVersionName</key>
-	<string>Nos 2.xcdatamodel</string>
+	<string>Nos.xcdatamodel</string>
 </dict>
 </plist>

--- a/Nos/Models/Nos.xcdatamodeld/Nos 2.xcdatamodel/Nos.xcdatamodel/contents
+++ b/Nos/Models/Nos.xcdatamodeld/Nos 2.xcdatamodel/Nos.xcdatamodel/contents
@@ -31,6 +31,7 @@
         <attribute name="signature" optional="YES" attributeType="String"/>
         <relationship name="author" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Author" inverseName="events" inverseEntity="Author"/>
         <relationship name="authorReferences" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="AuthorReference" inverseName="event" inverseEntity="AuthorReference"/>
+        <relationship name="deletedOn" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Relay"/>
         <relationship name="eventReferences" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="EventReference" inverseName="referencingEvent" inverseEntity="EventReference"/>
         <relationship name="publishedTo" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Relay"/>
         <relationship name="referencingEvents" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="EventReference" inverseName="referencedEvent" inverseEntity="EventReference"/>

--- a/Nos/Models/Nos.xcdatamodeld/Nos 2.xcdatamodel/contents
+++ b/Nos/Models/Nos.xcdatamodeld/Nos 2.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="21513" systemVersion="22D68" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="21513" systemVersion="22C65" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="Author" representedClassName=".Author" syncable="YES" codeGenerationType="category">
         <attribute name="about" optional="YES" attributeType="String"/>
         <attribute name="displayName" optional="YES" attributeType="String"/>
@@ -31,6 +31,7 @@
         <attribute name="signature" optional="YES" attributeType="String"/>
         <relationship name="author" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Author" inverseName="events" inverseEntity="Author"/>
         <relationship name="authorReferences" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="AuthorReference" inverseName="event" inverseEntity="AuthorReference"/>
+        <relationship name="deletedOn" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Relay"/>
         <relationship name="eventReferences" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="EventReference" inverseName="referencingEvent" inverseEntity="EventReference"/>
         <relationship name="publishedTo" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Relay"/>
         <relationship name="referencingEvents" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="EventReference" inverseName="referencedEvent" inverseEntity="EventReference"/>

--- a/Nos/Models/Persistence.swift
+++ b/Nos/Models/Persistence.swift
@@ -70,13 +70,11 @@ struct PersistenceController {
             }
             
             if let error = error as NSError? {
-                if error.domain == NSCocoaErrorDomain, error.code == 134_110, let storeURL = storeDescription.url {
-                    Self.clearCoreData(store: storeURL, in: container)
-                    needsReload = true
-                    // The data model changed. Clear core data.
-                } else {
-                    fatalError("Could not initialize database \(error), \(error.userInfo)")
+                if error.domain == NSCocoaErrorDomain, error.code == 134_110 {
+                    Log.error("Could not migrate data model. Did you change the xcdatamodel and forget to make a " +
+                        "new version?")
                 }
+                fatalError("Could not initialize database \(error), \(error.userInfo)")
             }
         })
         


### PR DESCRIPTION
This removes the code that deleted the database whenever the Core Data schema changed. Now we have a versioned xcdatamodel and Core Data should generate lightweight migrations when we change it.