### PR TITLE
feature/support-like-when-event-has-no-references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- Support likes
+- Support likes as described in NIP-25
 - Show "posted" and "replied" headers on NoteCards
 - Navigate to replied to note when tapping on reply from outside thread view
 - Search by name on Discover view

--- a/Nos/Views/NoteCard.swift
+++ b/Nos/Views/NoteCard.swift
@@ -220,22 +220,23 @@ struct NoteCard: View {
         guard let keyPair else {
             return
         }
-        guard let eventReferences = note.eventReferences?.array as? [EventReference] else {
-            return
-        }
-        // compactMap returns an array of the non-nil results.
-        var tags: [[String]] = eventReferences.compactMap { event in
-            guard let eventId = event.eventId else { return nil }
-            return ["e", eventId]
+        
+        var tags: [[String]] = []
+        if let eventReferences = note.eventReferences?.array as? [EventReference] {
+            // compactMap returns an array of the non-nil results.
+            tags += eventReferences.compactMap { event in
+                guard let eventId = event.eventId else { return nil }
+                return ["e", eventId]
+            }
         }
 
-        guard let authorReferences = note.authorReferences?.array as? [EventReference] else {
-            return
+        if let authorReferences = note.authorReferences?.array as? [EventReference] {
+            tags += authorReferences.compactMap { author in
+                guard let eventId = author.eventId else { return nil }
+                return ["p", eventId]
+            }
         }
-        tags += authorReferences.compactMap { author in
-            guard let eventId = author.eventId else { return nil }
-            return ["p", eventId]
-        }
+
         if let id = note.identifier {
             tags.append(["e", id])
         }


### PR DESCRIPTION
NIP-25
I wasn't able to like Matt's posts, and added code that doesn't assume that the event will have author or event references.