### PR TITLE
feature/nos189-like-reply-parent-fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- Support likes as described in NIP-25
+- Support likes as described in NIP-25, make sure reply likes are correct
 - Show "posted" and "replied" headers on NoteCards
 - Navigate to replied to note when tapping on reply from outside thread view
 - Search by name on Discover view

--- a/Nos/Views/NoteCard.swift
+++ b/Nos/Views/NoteCard.swift
@@ -178,14 +178,15 @@ struct NoteCard: View {
                         }
                         Spacer()
                         Image.buttonReply
-                        if noteLikedByUser.isEmpty {
+                        if !noteLikedByUser.isEmpty &&
+                        currentNoteIdMatchesLastETag(noteLikedByUser.compactMap({ $0 })) {
+                            Image.buttonLikeActive
+                        } else {
                             Button {
                                 likeNote()
                             } label: {
                                 Image.buttonLikeDefault
                             }
-                        } else {
-                            Image.buttonLikeActive
                         }
                     }
                     .padding(15)
@@ -213,6 +214,23 @@ struct NoteCard: View {
     
     private var keyPair: KeyPair? {
         KeyPair.loadFromKeychain()
+    }
+    
+    func currentNoteIdMatchesLastETag(_ eventList: [Event]) -> Bool {
+        var lastETagId = ""
+        for event in eventList {
+            if let tags = event.allTags as? [[String]] {
+                let eTagIds = tags.compactMap { tag in
+                    if tag.count > 1 && tag[safe: 0] == "e" {
+                        return tag[safe: 1]
+                    } else {
+                        return nil
+                    }
+                }
+                lastETagId = eTagIds.last ?? ""
+            }
+        }
+        return lastETagId == note.identifier
     }
     
     func likeNote() {


### PR DESCRIPTION
Fix problem where liking a reply made it look like you also liked the parent.

I found a last minute issue, so coded this as quick as I could, there is probably a better solution.