### PR TITLE
Add analytics events to UNS wizard

### DIFF
--- a/Nos/Service/Analytics.swift
+++ b/Nos/Service/Analytics.swift
@@ -149,4 +149,38 @@ class Analytics {
     func rateLimited(by socket: WebSocket) {
         track("Rate Limited", properties: ["relay": socket.request.url?.absoluteString ?? "null"])
     }
+    
+    // MARK: UNS
+    
+    func showedUNSWizard() {
+        track("UNS Showed Wizard")
+    }
+    
+    func canceledUNSWizard() {
+        track("UNS Canceled Wizard")
+    }
+    
+    func completedUNSWizard() {
+        track("UNS Completed Wizard")
+    }
+    
+    func enteredUNSPhone() {
+        track("UNS Entered Phone")
+    }
+    
+    func enteredUNSCode() {
+        track("UNS Entered Code")
+    }
+    
+    func choseUNSName() {
+        track("UNS Chose Name")
+    }
+    
+    func choseInvalidUNSName() {
+        track("UNS Invalid Name")
+    }
+    
+    func encounteredUNSError() {
+        track("UNS Error")
+    }
 }


### PR DESCRIPTION
This adds some analytics for the UNS wizard. I also updated the URLs to point to their sandbox environment as requested, although those URLs won't show up in the diff because they are in the production secrets file.