### PR TITLE
Share Logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - Added a button to view raw event JSON in the options menu on notes.
+- Added a button to share the application logs in the Settings menu
+- Automatically attach debug logs to support emails
 
 ## [0.1 (30)] - 2023-04-10Z
 

--- a/Nos.xcodeproj/project.pbxproj
+++ b/Nos.xcodeproj/project.pbxproj
@@ -232,6 +232,10 @@
 		C9F0BB6D29A503D9000547FC /* Int+Bool.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9F0BB6829A5039D000547FC /* Int+Bool.swift */; };
 		C9F0BB6F29A50437000547FC /* NostrConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9F0BB6E29A50437000547FC /* NostrConstants.swift */; };
 		C9F0BB7029A50437000547FC /* NostrConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9F0BB6E29A50437000547FC /* NostrConstants.swift */; };
+		C9F64D8C29ED840700563F2B /* LogHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9F64D8B29ED840700563F2B /* LogHelper.swift */; };
+		C9F64D8D29ED840700563F2B /* LogHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9F64D8B29ED840700563F2B /* LogHelper.swift */; };
+		C9F64D8F29ED88CD00563F2B /* Localization+Nos.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9F64D8E29ED88CD00563F2B /* Localization+Nos.swift */; };
+		C9F64D9029ED88CD00563F2B /* Localization+Nos.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9F64D8E29ED88CD00563F2B /* Localization+Nos.swift */; };
 		C9F84C1A298DBB6300C6714D /* Data+Encoding.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9671D72298DB94C00EE7E12 /* Data+Encoding.swift */; };
 		C9F84C1C298DBBF400C6714D /* Data+Sha.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9F84C1B298DBBF400C6714D /* Data+Sha.swift */; };
 		C9F84C1D298DBC6100C6714D /* Data+Sha.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9F84C1B298DBBF400C6714D /* Data+Sha.swift */; };
@@ -435,6 +439,8 @@
 		C9F0BB6829A5039D000547FC /* Int+Bool.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Int+Bool.swift"; sourceTree = "<group>"; };
 		C9F0BB6A29A503D6000547FC /* PublicKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublicKey.swift; sourceTree = "<group>"; };
 		C9F0BB6E29A50437000547FC /* NostrConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NostrConstants.swift; sourceTree = "<group>"; };
+		C9F64D8B29ED840700563F2B /* LogHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogHelper.swift; sourceTree = "<group>"; };
+		C9F64D8E29ED88CD00563F2B /* Localization+Nos.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Localization+Nos.swift"; sourceTree = "<group>"; };
 		C9F84C1B298DBBF400C6714D /* Data+Sha.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data+Sha.swift"; sourceTree = "<group>"; };
 		C9F84C20298DC36800C6714D /* AppView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppView.swift; sourceTree = "<group>"; };
 		C9F84C22298DC7B900C6714D /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
@@ -518,6 +524,7 @@
 				C9646EA029B7A22C007239A4 /* Analytics.swift */,
 				C9A0DAF729C92F4500466635 /* UNSAPI.swift */,
 				C9C2B77E29E0731600548B4A /* AsyncTimer.swift */,
+				C9F64D8B29ED840700563F2B /* LogHelper.swift */,
 			);
 			path = Service;
 			sourceTree = "<group>";
@@ -642,6 +649,7 @@
 				C93EC2F329C34C860012EE2A /* NSPredicate+Bool.swift */,
 				C93EC2F629C351470012EE2A /* Optional+Unwrap.swift */,
 				C9C2B77B29E072E400548B4A /* WebSocket+Nos.swift */,
+				C9F64D8E29ED88CD00563F2B /* Localization+Nos.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -1010,6 +1018,7 @@
 			files = (
 				CD09A74429A50F1D0063464F /* SideMenu.swift in Sources */,
 				C9DEC06E2989668E0078B43A /* Relay+CoreDataClass.swift in Sources */,
+				C9F64D8C29ED840700563F2B /* LogHelper.swift in Sources */,
 				C9C2B78529E073E300548B4A /* RelaySubscription.swift in Sources */,
 				3FFB1D9C29A7DF9D002A755D /* StackedAvatarsView.swift in Sources */,
 				C9A0DAF529C9112400466635 /* UniversalNameWizard.swift in Sources */,
@@ -1047,6 +1056,7 @@
 				A351E1A229BA92240009B7F6 /* ProfileEditView.swift in Sources */,
 				C9DFA969299BEC33006929C1 /* CardStyle.swift in Sources */,
 				A362584229C10AD500D07C9A /* NSSet+Add.swift in Sources */,
+				C9F64D8F29ED88CD00563F2B /* Localization+Nos.swift in Sources */,
 				C95D68AD299E721700429F86 /* ProfileView.swift in Sources */,
 				C942566929B66A2800C4202C /* Date+Elapsed.swift in Sources */,
 				C9ADB13829928CC30075E7F8 /* String+Hex.swift in Sources */,
@@ -1138,6 +1148,7 @@
 				CD09A75129A521D20063464F /* CompactNoteView.swift in Sources */,
 				C9C2B78329E0735400548B4A /* RelaySubscriptionManager.swift in Sources */,
 				CD09A75229A521D20063464F /* RepliesView.swift in Sources */,
+				C9F64D9029ED88CD00563F2B /* Localization+Nos.swift in Sources */,
 				CD09A75329A521D20063464F /* AppView.swift in Sources */,
 				CD09A75429A521D20063464F /* PlaceholderModifier.swift in Sources */,
 				C94FE9F829DB25A800019CD3 /* Text+Gradient.swift in Sources */,
@@ -1148,6 +1159,7 @@
 				A303AF8429A969F5005DC8FC /* FollowButton.swift in Sources */,
 				CD09A75629A521D20063464F /* SettingsView.swift in Sources */,
 				3F30021729C3BFEB003D4F8B /* OnboardingLoginView.swift in Sources */,
+				C9F64D8D29ED840700563F2B /* LogHelper.swift in Sources */,
 				3FBCDE6D29B648FE00A6C2D4 /* ThreadView.swift in Sources */,
 				C9A0DAE529C69F0C00466635 /* HighlightedText.swift in Sources */,
 				CD09A75729A521D20063464F /* NewNoteView.swift in Sources */,

--- a/Nos/AppController.swift
+++ b/Nos/AppController.swift
@@ -8,6 +8,7 @@
 import Foundation
 import Dependencies
 import SwiftUI
+import Logger
 
 class AppController: ObservableObject {
     
@@ -26,7 +27,7 @@ class AppController: ObservableObject {
     init(currentUser: CurrentUser, router: Router) {
         self.router = router
         self.currentUser = currentUser
-        print("Initializing analytics. This is hack to get the dependency initialzed by printing it: \(analytics)")
+        Log.info("App Version: \(Bundle.current.versionAndBuild)")
     }
     
     func configureCurrentState() {

--- a/Nos/Assets/Localization/Localizable.swift
+++ b/Nos/Assets/Localization/Localizable.swift
@@ -1,5 +1,4 @@
 import Foundation
-import SwiftUI
 
 let testingLocalization = ProcessInfo.processInfo.environment["TESTING_LOCALIZATION"]
 
@@ -15,14 +14,15 @@ protocol Localizable: RawRepresentable<String> {
     /// optionally override this to provide your own namespace key
     /// defaults to the type name of the enum
     static var namespace: String { get }
-    
-    /// Creates a SwiftUI Text view for this text.
-    var view: Text { get }
 
     static func exportForStringsFile() -> String
 }
 
 extension Localizable {
+
+    var key: String {
+        "\(Self.namespace).\(String(describing: self))"
+    }
     
     // You can modify this to perform localization, or overrides based on server or other config
     var string: String {
@@ -43,48 +43,11 @@ extension Localizable {
             return string
         }
     }
-
-    // replaces keys in the string with values from the dictionary passed
-    // case greeting = "Hello {{ name }}."
-    // greeting.text(["name": ]) -> Hello
-    func text(_ arguments: [String: String]) -> String {
-        do {
-            var text = self.string
-            for (key, value) in arguments {
-                let regex = try NSRegularExpression(pattern: "\\{\\{\\s*\(key)\\s*\\}\\}", options: .caseInsensitive)
-                text = regex.stringByReplacingMatches(
-                    in: text,
-                    options: NSRegularExpression.MatchingOptions(rawValue: 0),
-                    range: NSRange(location: 0, length: text.count),
-                    withTemplate: value
-                )
-            }
-            return text
-        } catch {
-            return ""
-        }
-    }
-
-    var uppercased: String {
-        string.uppercased()
-    }
-
+    
     static var namespace: String {
         String(describing: self)
     }
     
-    var view: Text {
-        Text(string)
-    }
-    
-    func view(_ arguments: [String: String]) -> Text {
-        Text(text(arguments))
-    }
-
-    var key: String {
-        "\(Self.namespace).\(String(describing: self))"
-    }
-
     // escape newlines in templates, used when exporting templates for Localizable.strings
     var escapedTemplate: String {
         template.replacingOccurrences(of: "\n", with: "\\n")

--- a/Nos/Assets/Localization/Localized.swift
+++ b/Nos/Assets/Localization/Localized.swift
@@ -168,6 +168,8 @@ enum Localized: String, Localizable, CaseIterable {
     case invalidKey = "Invalid Key"
     case couldNotReadPrivateKeyMessage = "Could not read your private key. Please verify that it is in nsec or hex format."
     case createAccount = "Create an account"
+    case shareLogs = "Share logs"
+    case failedToExportLogs = "Failed to export logs."
     
     case post = "Post" // (verb form)
     case newNote = "New Note"

--- a/Nos/Assets/Localization/Localized.swift
+++ b/Nos/Assets/Localization/Localized.swift
@@ -170,6 +170,7 @@ enum Localized: String, Localizable, CaseIterable {
     case createAccount = "Create an account"
     case shareLogs = "Share logs"
     case failedToExportLogs = "Failed to export logs."
+    case appVersion = "App Version:"
     
     case post = "Post" // (verb form)
     case newNote = "New Note"

--- a/Nos/Assets/Localization/en.lproj/Generated.strings
+++ b/Nos/Assets/Localization/en.lproj/Generated.strings
@@ -30,6 +30,8 @@
 "Localized.invalidKey" = "Invalid Key";
 "Localized.couldNotReadPrivateKeyMessage" = "Could not read your private key. Please verify that it is in nsec or hex format.";
 "Localized.createAccount" = "Create an account";
+"Localized.shareLogs" = "Share logs";
+"Localized.failedToExportLogs" = "Failed to export logs.";
 "Localized.post" = "Post";
 "Localized.newNote" = "New Note";
 "Localized.newNotePlaceholder" = "Type your post here...";

--- a/Nos/Assets/Localization/en.lproj/Generated.strings
+++ b/Nos/Assets/Localization/en.lproj/Generated.strings
@@ -32,6 +32,7 @@
 "Localized.createAccount" = "Create an account";
 "Localized.shareLogs" = "Share logs";
 "Localized.failedToExportLogs" = "Failed to export logs.";
+"Localized.appVersion" = "App Version:";
 "Localized.post" = "Post";
 "Localized.newNote" = "New Note";
 "Localized.newNotePlaceholder" = "Type your post here...";

--- a/Nos/Extensions/Bundle+Current.swift
+++ b/Nos/Extensions/Bundle+Current.swift
@@ -13,4 +13,20 @@ private class CurrentBundle {}
 extension Bundle {
 
     static let current = Bundle(for: CurrentBundle.self)
+    
+    var version: String {
+        let version = self.infoDictionary?["CFBundleShortVersionString"] as? String ?? ""
+        return version
+    }
+
+    var build: String {
+        let build = self.infoDictionary?["CFBundleVersion"] as? String ?? ""
+        return build
+    }
+
+    /// Returns a string from the bundle version and short version
+    /// formatted as 1.2.3 (123).
+    var versionAndBuild: String {
+        "\(self.version) (\(self.build))"
+    }
 }

--- a/Nos/Extensions/Localization+Nos.swift
+++ b/Nos/Extensions/Localization+Nos.swift
@@ -1,0 +1,50 @@
+//
+//  Localization+Nos.swift
+//  Nos
+//
+//  Created by Matthew Lorentz on 4/17/23.
+//
+
+import Foundation
+import SwiftUI
+import SwiftUINavigation
+
+extension Localizable {
+
+    // replaces keys in the string with values from the dictionary passed
+    // case greeting = "Hello {{ name }}."
+    // greeting.text(["name": ]) -> Hello
+    func text(_ arguments: [String: String]) -> String {
+        do {
+            var text = self.string
+            for (key, value) in arguments {
+                let regex = try NSRegularExpression(pattern: "\\{\\{\\s*\(key)\\s*\\}\\}", options: .caseInsensitive)
+                text = regex.stringByReplacingMatches(
+                    in: text,
+                    options: NSRegularExpression.MatchingOptions(rawValue: 0),
+                    range: NSRange(location: 0, length: text.count),
+                    withTemplate: value
+                )
+            }
+            return text
+        } catch {
+            return ""
+        }
+    }
+
+    var uppercased: String {
+        string.uppercased()
+    }
+
+    var view: Text {
+        Text(string)
+    }
+    
+    func view(_ arguments: [String: String]) -> Text {
+        Text(text(arguments))
+    }
+    
+    var textState: TextState {
+        TextState(string)
+    }
+}

--- a/Nos/NosApp.swift
+++ b/Nos/NosApp.swift
@@ -25,7 +25,6 @@ struct NosApp: App {
                 .environmentObject(currentUser)
                 .task {
                     currentUser.relayService = relayService
-                    await relayService.publishFailedEvents()
                 }
         }
     }

--- a/Nos/Service/LogHelper.swift
+++ b/Nos/Service/LogHelper.swift
@@ -1,0 +1,44 @@
+//
+//  LogHelper.swift
+//  Nos
+//
+//  Created by Matthew Lorentz on 4/17/23.
+//
+
+import Foundation
+import Logger
+
+enum LogHelper {
+    static func zipLogs() async throws -> URL {
+        let appFileUrls = Log.fileUrls
+        let temporaryDirectory = URL(fileURLWithPath: NSTemporaryDirectory())
+        let url = temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        return try await Task {
+            try FileManager.default.createDirectory(at: url, withIntermediateDirectories: false)
+            let zipFileURL = temporaryDirectory.appendingPathComponent("\(UUID().uuidString).zip")
+            let copy = { (appFileURL: URL) throws in
+                let destFileURL = url.appendingPathComponent(appFileURL.lastPathComponent)
+                try FileManager.default.copyItem(at: appFileURL, to: destFileURL)
+            }
+            
+            try appFileUrls.forEach { try copy($0) }
+            
+            let coord = NSFileCoordinator()
+            var readError: NSError?
+            return try await withCheckedThrowingContinuation { continuation in
+                coord.coordinate(
+                    readingItemAt: url, 
+                    options: .forUploading, 
+                    error: &readError
+                ) { (zippedURL: URL) -> Void in
+                    do {
+                        try FileManager.default.copyItem(at: zippedURL, to: zipFileURL)
+                        continuation.resume(with: .success(zipFileURL))
+                    } catch {
+                        continuation.resume(with: .failure(error))
+                    }
+                }
+            }
+        }.value
+    }
+}

--- a/Nos/Views/ReportABugMailView.swift
+++ b/Nos/Views/ReportABugMailView.swift
@@ -6,6 +6,8 @@
 //
 import MessageUI
 import SwiftUI
+import Logger
+
 struct ReportABugMailView: UIViewControllerRepresentable {
     
     @Environment(\.presentationMode) var presentation
@@ -53,6 +55,17 @@ struct ReportABugMailView: UIViewControllerRepresentable {
             "Hello, \n\n I have found a bug in Nos and would like to provide feedback",
             isHTML: false
         )
+        Task {
+            do {
+                mailViewController.addAttachmentData(
+                    try Data(contentsOf: try await LogHelper.zipLogs()),
+                    mimeType: "application/zip", 
+                    fileName: "diagnostics.zip"
+                )
+            } catch {
+                Log.error("failed to zip logs for MFMailComposeViewController")
+            }
+        }
         return mailViewController
     }
     

--- a/Nos/Views/SettingsView.swift
+++ b/Nos/Views/SettingsView.swift
@@ -74,6 +74,9 @@ struct SettingsView: View {
             
             Section {
                 HStack {
+                    Text("\(Localized.appVersion.string) \(Bundle.current.versionAndBuild)")
+                        .foregroundColor(.primaryTxt)
+                    Spacer()
                     SecondaryActionButton(title: Localized.shareLogs) {
                         Task {
                             do {


### PR DESCRIPTION
Added an option to export logs in the Settings menu, and automatically attach logs in support emails. This will help me gather some more diagnostic information to debug performance issues and other bugs. Closes #94 and #169.