### PR TITLE
Reduce events downloaded on launch

### DIFF
--- a/Nos/Service/CurrentUser.swift
+++ b/Nos/Service/CurrentUser.swift
@@ -133,8 +133,9 @@ class CurrentUser: NSObject, ObservableObject, NSFetchedResultsControllerDelegat
             authorWatcher?.delegate = self
             try? authorWatcher?.performFetch()
             
+            socialGraph = SocialGraph(userKey: keyPair.publicKeyHex, context: backgroundContext)
+            
             Task {
-                socialGraph = await SocialGraph(userKey: keyPair.publicKeyHex, context: backgroundContext)
                 if relayService != nil {
                     await subscribe()
                     refreshFriendMetadata()

--- a/Nos/Service/CurrentUser.swift
+++ b/Nos/Service/CurrentUser.swift
@@ -190,20 +190,24 @@ class CurrentUser: NSObject, ObservableObject, NSFetchedResultsControllerDelegat
         }
         
         // Always listen to my changes
-        if let key = publicKeyHex {
+        if let key = publicKeyHex, let author {
             // Close out stale requests
             if !subscriptions.isEmpty {
                 await relayService.removeSubscriptions(for: subscriptions)
                 subscriptions.removeAll()
             }
-
-            let metaFilter = Filter(authorKeys: [key], kinds: [.metaData], limit: 1)
+            
+            let metaFilter = Filter(authorKeys: [key], kinds: [.metaData], since: author.lastUpdatedMetadata)
             async let metaSub = relayService.openSubscription(with: metaFilter, to: overrideRelays)
             
-            let contactFilter = Filter(authorKeys: [key], kinds: [.contactList], limit: 1)
+            let contactFilter = Filter(
+                authorKeys: [key], 
+                kinds: [.contactList], 
+                since: author.lastUpdatedContactList
+            )
             async let contactSub = relayService.openSubscription(with: contactFilter, to: overrideRelays)
             
-            let muteListFilter = Filter(authorKeys: [key], kinds: [.mute], limit: 1)
+            let muteListFilter = Filter(authorKeys: [key], kinds: [.mute])
             async let muteSub = relayService.openSubscription(with: muteListFilter, to: overrideRelays)
             
             subscriptions.append(await metaSub)
@@ -236,27 +240,27 @@ class CurrentUser: NSObject, ObservableObject, NSFetchedResultsControllerDelegat
                 ).follows as? Set<Follow>
                 return follows?
                     .shuffled()
-                    .map { ($0.destination?.hexadecimalPublicKey, $0.destination?.lastUpdatedMetadata) }
-            } ?? [(String?, Date?)]()
+                    .compactMap { $0.destination }
+                    .map { ($0.hexadecimalPublicKey, $0.lastUpdatedMetadata, $0.lastUpdatedContactList) }
+            } ?? [(String?, Date?, Date?)]()
             
             for followData in followData {
                 guard let followedKey = followData.0 else {
                     continue
                 }
-                let lastUpdated = followData.1
+                let lastUpdatedMetadata = followData.1
+                let lastUpdatedContactList = followData.2
                 let metaFilter = Filter(
                     authorKeys: [followedKey],
                     kinds: [.metaData],
-                    limit: 1,
-                    since: lastUpdated
+                    since: lastUpdatedMetadata
                 )
                 _ = await self?.relayService.openSubscription(with: metaFilter)
                 
                 let contactFilter = Filter(
                     authorKeys: [followedKey],
                     kinds: [.contactList],
-                    limit: 1,
-                    since: lastUpdated
+                    since: lastUpdatedContactList
                 )
                 _ = await self?.relayService.openSubscription(with: contactFilter)
                 

--- a/Nos/Service/Filter.swift
+++ b/Nos/Service/Filter.swift
@@ -14,7 +14,7 @@ struct Filter: Hashable, Identifiable {
     let eventIDs: [HexadecimalString]
     let kinds: [EventKind]
     let eTags: [HexadecimalString]
-    let limit: Int
+    let limit: Int?
     let since: Date?
     
     var id: String {
@@ -26,7 +26,7 @@ struct Filter: Hashable, Identifiable {
         eventIDs: [HexadecimalString] = [],
         kinds: [EventKind] = [],
         eTags: [HexadecimalString] = [],
-        limit: Int = 100,
+        limit: Int? = nil,
         since: Date? = nil
     ) {
         self.authorKeys = authorKeys.sorted(by: { $0 > $1 })
@@ -38,7 +38,11 @@ struct Filter: Hashable, Identifiable {
     }
     
     var dictionary: [String: Any] {
-        var filterDict: [String: Any] = ["limit": limit]
+        var filterDict = [String: Any]()
+        
+        if let limit {
+            filterDict["limit"] = limit
+        }
 
         if !authorKeys.isEmpty {
             filterDict["authors"] = authorKeys

--- a/Nos/Service/RelayService.swift
+++ b/Nos/Service/RelayService.swift
@@ -168,7 +168,6 @@ extension RelayService {
         let metaFilter = Filter(
             authorKeys: [authorKey],
             kinds: [.metaData],
-            limit: 1,
             since: since
         )
         return await openSubscription(with: metaFilter)

--- a/Nos/Views/HomeFeedView.swift
+++ b/Nos/Views/HomeFeedView.swift
@@ -37,9 +37,11 @@ struct HomeFeedView: View {
         await cancelSubscriptions()
         
         let followedKeys = currentUser.socialGraph.followedKeys 
+        let since = events.first?.createdAt
             
         if !followedKeys.isEmpty {
-            let textFilter = Filter(authorKeys: followedKeys, kinds: [.text, .delete], limit: 100)
+            // TODO: we could miss events with this since filter
+            let textFilter = Filter(authorKeys: followedKeys, kinds: [.text, .delete], limit: 100, since: since)
             let textSub = await relayService.openSubscription(with: textFilter)
             subscriptionIDs.append(textSub)
         }
@@ -47,7 +49,8 @@ struct HomeFeedView: View {
         let userLikesFilter = Filter(
             authorKeys: currentUserAuthorKeys,
             kinds: [.like, .delete],
-            limit: 100
+            limit: 100,
+            since: since
         )
         let userLikesSub = await relayService.openSubscription(with: userLikesFilter)
         subscriptionIDs.append(userLikesSub)

--- a/Nos/Views/ProfileView.swift
+++ b/Nos/Views/ProfileView.swift
@@ -45,7 +45,6 @@ struct ProfileView: View {
             let metaFilter = Filter(
                 authorKeys: authors,
                 kinds: [.metaData],
-                limit: 1,
                 since: author.lastUpdatedMetadata
             )
             async let metaSub = relayService.openSubscription(with: metaFilter)
@@ -53,7 +52,6 @@ struct ProfileView: View {
             let contactFilter = Filter(
                 authorKeys: authors,
                 kinds: [.contactList],
-                limit: 1,
                 since: author.lastUpdatedContactList
             )
             async let contactSub = relayService.openSubscription(with: contactFilter)


### PR DESCRIPTION
I found out when you send a request to a relay with "limit: 1" and a "since" date they will always send you at least 1 event, which is a little counter-intuitive. I removed the "limit: 1"s so that we just fetch events "since". This will result in more data being downloaded if you haven't opened the app for a long time, but it drastically reduces the number of duplicate events we download if you open the app frequently.