### PR TITLE
Bugfix: The Post button should not block the UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Improved performance of posting notes.
 - Added German translations (thanks Peter!).
 - Updated support email to support@nos.social
 - Improved recognition of mentions inside a post


### PR DESCRIPTION
Closes #337 

Updated the Post button so that it executed its core functionality inside a Task.
On error, it now logs to the Logger instead of calling fatalError