### PR TITLE
Strip whitespace and newlines from searched npub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed a crash which occurs on some versions of MacOS when attempting to mention other users during post creation.
 - Fixed a bug where the note options menu wouldn't show up sometimes.
+- Strip whitespace and newline characters when parsing search box input on discover screen as npub.
 
 ## [0.1 (44)] - 2023-05-31Z
 

--- a/Nos/Views/DiscoverView.swift
+++ b/Nos/Views/DiscoverView.swift
@@ -280,7 +280,10 @@ struct DiscoverView: View {
     }
     
     func author(fromPublicKey publicKeyString: String) -> Author? {
-        guard let publicKey = PublicKey(npub: publicKeyString) ?? PublicKey(hex: publicKeyString) else {
+        let strippedString = publicKeyString.trimmingCharacters(
+            in: NSCharacterSet.whitespacesAndNewlines
+        )
+        guard let publicKey = PublicKey(npub: strippedString) ?? PublicKey(hex: strippedString) else {
             return nil
         }
         guard let author = try? Author.findOrCreate(by: publicKey.hex, context: viewContext) else {


### PR DESCRIPTION
When copying npubs from websites such as rsslay the user may accidently copy whitespace characters or newlines. In my case I accidently copied the tab character ("\t"). This character is not visible in the search box at all (it just doesn't render) leading to confusion when Nos doesn't correctly navigate to user profile.

I am sorry but I am not sure how to write tests for this.