### PR TITLE
Improve relay communication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Improved performance of the relay manager
 - Add the ability to report notes and profiles using NIP-32 labels and NIP-69 classification.
 - Fixed a crash which occurs on some versions of MacOS when attempting to mention other users during post creation.
 - Fixed a bug where the note options menu wouldn't show up sometimes.

--- a/Nos/Models/Event+CoreDataClass.swift
+++ b/Nos/Models/Event+CoreDataClass.swift
@@ -239,6 +239,15 @@ public class Event: NosManagedObject {
         return fetchRequest
     }
     
+    @nonobjc public class func lastReceived(for user: Author) -> NSFetchRequest<Event> {
+        let fetchRequest = NSFetchRequest<Event>(entityName: "Event")
+        fetchRequest.sortDescriptors = [NSSortDescriptor(keyPath: \Event.createdAt, ascending: false)]
+        fetchRequest.predicate = NSPredicate(format: "author != %@", user)
+        fetchRequest.fetchLimit = 1
+        fetchRequest.sortDescriptors = [NSSortDescriptor(keyPath: \Event.receivedAt, ascending: false)]
+        return fetchRequest
+    }
+    
     @nonobjc public class func allReplies(to rootEvent: Event) -> NSFetchRequest<Event> {
         allReplies(toNoteWith: rootEvent.identifier)
     }

--- a/Nos/Service/Filter.swift
+++ b/Nos/Service/Filter.swift
@@ -90,19 +90,4 @@ struct Filter: Hashable, Identifiable {
         hasher.combine(pTags)
         hasher.combine(since)
     }
-    
-    func isFulfilled(by event: Event) -> Bool {
-        guard limit == 1 else {
-            return false
-        }
-        
-        if kinds.count == 1,
-            event.kind == kinds.first?.rawValue,
-            !authorKeys.isEmpty,
-            let authorKey = event.author?.hexadecimalPublicKey {
-            return authorKeys.contains(authorKey)
-        }
-        
-        return false
-    }
 }

--- a/Nos/Service/RelaySubscriptionManager.swift
+++ b/Nos/Service/RelaySubscriptionManager.swift
@@ -159,6 +159,7 @@ actor RelaySubscriptionManager {
         var subscription = subscription
         subscription.subscriptionStartDate = .now
         updateSubscriptions(with: subscription)
+        Log.info("starting subscription: \(subscription.id)")
         relays.forEach { relayURL in
             if let socket = socket(for: relayURL) {
                 requestEvents(from: socket, subscription: subscription)

--- a/Nos/Views/HomeFeedView.swift
+++ b/Nos/Views/HomeFeedView.swift
@@ -68,15 +68,6 @@ struct HomeFeedView: View {
             let textSub = await relayService.openSubscription(with: textFilter)
             subscriptionIDs.append(textSub)
         }
-        
-        let currentUserAuthorKeys = [currentUserKey]
-        let userLikesFilter = Filter(
-            authorKeys: currentUserAuthorKeys,
-            kinds: [.like, .delete],
-            since: fetchSinceDate
-        )
-        let userLikesSub = await relayService.openSubscription(with: userLikesFilter)
-        subscriptionIDs.append(userLikesSub)
     }
     
     func cancelSubscriptions() async {

--- a/Nos/Views/HomeFeedView.swift
+++ b/Nos/Views/HomeFeedView.swift
@@ -17,7 +17,6 @@ struct HomeFeedView: View {
     @EnvironmentObject var router: Router
     @EnvironmentObject var currentUser: CurrentUser
     @Dependency(\.analytics) private var analytics
-    @AppStorage("lastHomeFeedRequestDate") var lastRequestDateUnix: TimeInterval?
     
     @FetchRequest var events: FetchedResults<Event>
     @State private var date = Date(timeIntervalSince1970: Date.now.timeIntervalSince1970 + Double(Self.initialLoadTime))
@@ -42,19 +41,6 @@ struct HomeFeedView: View {
             
         guard let currentUserKey = currentUser.publicKeyHex else {
             return
-        }
-        
-        var fetchSinceDate: Date?
-        // Make sure the lastRequestDate was more than a minute ago
-        // to make sure we got all the events from it.
-        if let lastRequestDateUnix {
-            let lastRequestDate = Date(timeIntervalSince1970: lastRequestDateUnix)
-            if lastRequestDate.distance(to: .now) > 60 {
-                fetchSinceDate = lastRequestDate
-                self.lastRequestDateUnix = Date.now.timeIntervalSince1970
-            }
-        } else {
-            self.lastRequestDateUnix = Date.now.timeIntervalSince1970
         }
                 
         if !followedKeys.isEmpty {


### PR DESCRIPTION
A couple more tweaks to reduce long spinners on reposts:
- Be more aggressive when closing relay subscriptions for one time filters
- Combine all subscriptions for the logged in user into one.