### PR TITLE
Remove trailing slashes from relay urls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Fixed an issue where you could have duplicate relays: one with a trailing slash and one without.
 - Added the number of connected relays at the top right corner of the Home Feed.
 - Fixed a bug where expired messages could be published to relays that doesn't support them
 

--- a/Nos.xcodeproj/project.pbxproj
+++ b/Nos.xcodeproj/project.pbxproj
@@ -70,8 +70,8 @@
 		A3B943D8299D758F00A15A08 /* KeyChain.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3B943CE299AE00100A15A08 /* KeyChain.swift */; };
 		C905EA382A33623F006F1E99 /* SetUpUNSBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = C905EA372A33623F006F1E99 /* SetUpUNSBanner.swift */; };
 		C90862BE29E9804B00C35A71 /* NosPerformanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C90862BD29E9804B00C35A71 /* NosPerformanceTests.swift */; };
-		C92DF80529C25DE900400561 /* URL+MimeTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = C92DF80429C25DE900400561 /* URL+MimeTypes.swift */; };
-		C92DF80629C25DE900400561 /* URL+MimeTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = C92DF80429C25DE900400561 /* URL+MimeTypes.swift */; };
+		C92DF80529C25DE900400561 /* URL+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C92DF80429C25DE900400561 /* URL+Extensions.swift */; };
+		C92DF80629C25DE900400561 /* URL+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C92DF80429C25DE900400561 /* URL+Extensions.swift */; };
 		C92DF80829C25FA900400561 /* SquareImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = C92DF80729C25FA900400561 /* SquareImage.swift */; };
 		C92DF80929C25FA900400561 /* SquareImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = C92DF80729C25FA900400561 /* SquareImage.swift */; };
 		C931517D29B915AF00934506 /* StaggeredGrid.swift in Sources */ = {isa = PBXBuildFile; fileRef = C931517C29B915AF00934506 /* StaggeredGrid.swift */; };
@@ -451,7 +451,7 @@
 		C90862BB29E9804B00C35A71 /* NosPerformanceTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = NosPerformanceTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		C90862BD29E9804B00C35A71 /* NosPerformanceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NosPerformanceTests.swift; sourceTree = "<group>"; };
 		C92DF80129BFAF9300400561 /* ProductionSecrets.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = ProductionSecrets.xcconfig; sourceTree = "<group>"; };
-		C92DF80429C25DE900400561 /* URL+MimeTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URL+MimeTypes.swift"; sourceTree = "<group>"; };
+		C92DF80429C25DE900400561 /* URL+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URL+Extensions.swift"; sourceTree = "<group>"; };
 		C92DF80729C25FA900400561 /* SquareImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SquareImage.swift; sourceTree = "<group>"; };
 		C931517C29B915AF00934506 /* StaggeredGrid.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StaggeredGrid.swift; sourceTree = "<group>"; };
 		C936B45B2A4C7D6B00DF1EB9 /* UniversalNameWizard.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UniversalNameWizard.swift; sourceTree = "<group>"; };
@@ -844,7 +844,7 @@
 				C9F0BB6829A5039D000547FC /* Int+Bool.swift */,
 				C987F85729BA981800B44E7A /* Font.swift */,
 				C987F86029BABAF800B44E7A /* String+Markdown.swift */,
-				C92DF80429C25DE900400561 /* URL+MimeTypes.swift */,
+				C92DF80429C25DE900400561 /* URL+Extensions.swift */,
 				C93EC2F329C34C860012EE2A /* NSPredicate+Bool.swift */,
 				C93EC2F629C351470012EE2A /* Optional+Unwrap.swift */,
 				C9C2B77B29E072E400548B4A /* WebSocket+Nos.swift */,
@@ -1394,7 +1394,7 @@
 				5B8C96B229DB313300B73AEC /* AuthorRow.swift in Sources */,
 				C9A0DADA29C685E500466635 /* SideMenuButton.swift in Sources */,
 				A3B943D5299D514800A15A08 /* Follow+CoreDataClass.swift in Sources */,
-				C92DF80529C25DE900400561 /* URL+MimeTypes.swift in Sources */,
+				C92DF80529C25DE900400561 /* URL+Extensions.swift in Sources */,
 				3F60F42929B27D3E000D62C4 /* ThreadView.swift in Sources */,
 				C9B678DB29EEBF3B00303F33 /* DependencyInjection.swift in Sources */,
 				C95D68A9299E709900429F86 /* LinearGradient+Planetary.swift in Sources */,
@@ -1609,7 +1609,7 @@
 				C9A25B3E29F174D200B39534 /* ReadabilityPadding.swift in Sources */,
 				C9DEBFE9298941020078B43A /* EventTests.swift in Sources */,
 				C9ADB14229951CB10075E7F8 /* NSManagedObject+Nos.swift in Sources */,
-				C92DF80629C25DE900400561 /* URL+MimeTypes.swift in Sources */,
+				C92DF80629C25DE900400561 /* URL+Extensions.swift in Sources */,
 				C9F75AD32A02D41E005BBE45 /* ComposerActionBar.swift in Sources */,
 				C93CA0C029AD59D700921183 /* GoldenPostView.swift in Sources */,
 				C9646EAF29B8D653007239A4 /* ViewDidLoadModifier.swift in Sources */,

--- a/Nos/Extensions/URL+Extensions.swift
+++ b/Nos/Extensions/URL+Extensions.swift
@@ -1,5 +1,5 @@
 //
-//  URL+MimeTypes.swift
+//  URL+Extensions.swift
 //  Nos
 //
 //  Created by Matthew Lorentz on 3/15/23.
@@ -12,5 +12,13 @@ extension URL {
     var isImage: Bool {
         let imageExtensions = ["png", "jpg", "jpeg", "gif"]
         return imageExtensions.contains(pathExtension)
+    }
+    
+    func strippingTrailingSlash() -> String {
+        var string = absoluteString
+        if string.last == "/" {
+            string.removeLast()
+        }
+        return string
     }
 }

--- a/Nos/Models/Relay+CoreDataClass.swift
+++ b/Nos/Models/Relay+CoreDataClass.swift
@@ -19,27 +19,27 @@ public class Relay: NosManagedObject {
 
     static var recommended: [String] {
         [
-        "wss://relay.nostr.band/",
-        "wss://relay.damus.io/",
-        "wss://e.nos.lol/",
+        "wss://relay.nostr.band",
+        "wss://relay.damus.io",
+        "wss://e.nos.lol",
         "wss://purplepag.es",
         ]
     }
     
     static var allKnown: [String] {
         [
-        "wss://eden.nostr.land/",
-        "wss://nostr.fmt.wiz.biz/",
-        "wss://relay.damus.io/",
-        "wss://nostr-pub.wellorder.net/",
-        "wss://relay.nostr.info/",
-        "wss://offchain.pub/",
-        "wss://nos.lol/",
-        "wss://brb.io/",
-        "wss://relay.snort.social/",
-        "wss://relay.current.fyi/",
-        "wss://nostr.relayer.se/",
-        "wss://e.nos.lol/",
+        "wss://eden.nostr.land",
+        "wss://nostr.fmt.wiz.biz",
+        "wss://relay.damus.io",
+        "wss://nostr-pub.wellorder.net",
+        "wss://relay.nostr.info",
+        "wss://offchain.pub",
+        "wss://nos.lol",
+        "wss://brb.io",
+        "wss://relay.snort.social",
+        "wss://relay.current.fyi",
+        "wss://nostr.relayer.se",
+        "wss://e.nos.lol",
         "wss://purplepag.es",
         ]
     }
@@ -142,7 +142,7 @@ public class Relay: NosManagedObject {
         }
         
         self.init(context: context)
-        self.address = addressURL.absoluteString
+        self.address = addressURL.strippingTrailingSlash()
         self.createdAt = Date.now
         if let author {
             authors.insert(author)

--- a/NosTests/EventTests.swift
+++ b/NosTests/EventTests.swift
@@ -57,7 +57,7 @@ final class EventTests: XCTestCase {
     let sampleEventSignature = "31c710803d3b77cb2c61697c8e2a980a53ec66e980990ca34cc24f9018bf85bfd2b0669c1404f364de776a9d9ed31a5d6d32f5662ac77f2dc6b89c7762132d63"
     let sampleEventPubKey = "d0a1ffb8761b974cec4a3be8cbcb2e96a7090dcf465ffeac839aa4ca20c9a59e"
     let sampleEventContent = "Spent today on our company retreat talking a lot about Nostr. The team seems very keen to build something in this space. It’s exciting to be opening our minds to so many possibilities after being deep in the Scuttlebutt world for so long."
-    let sampleRelay = "wss://nostr.lorentz.is/"
+    let sampleRelay = "wss://nostr.lorentz.is"
     let sampleName = "Test Name"
     
     let sampleContactListSignature = "a01fa191a0236ffe5ee1fbd9401cd7b1da7daad5e19a25962eb7ea4c9335522478bdff255f1de40ca6c98cdf8cf26aa1f5f1b6c263c5004b0b6dcdc12573cfd7"


### PR DESCRIPTION
Fixes an issue where you could have duplicate relays in the db: one with a trailing slash and one without.