### PR TITLE
Fixed styling of uploaded file links

### DIFF
--- a/Nos.xcodeproj/project.pbxproj
+++ b/Nos.xcodeproj/project.pbxproj
@@ -108,6 +108,8 @@
 		C942566A29B66A2800C4202C /* Date+Elapsed.swift in Sources */ = {isa = PBXBuildFile; fileRef = C942566829B66A2800C4202C /* Date+Elapsed.swift */; };
 		C942566B29B66B2F00C4202C /* NotificationsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C94437E529B0DB83004D8C86 /* NotificationsView.swift */; };
 		C94437E629B0DB83004D8C86 /* NotificationsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C94437E529B0DB83004D8C86 /* NotificationsView.swift */; };
+		C94A5E152A716A6D00B6EC5D /* EditableNoteText.swift in Sources */ = {isa = PBXBuildFile; fileRef = C94A5E142A716A6D00B6EC5D /* EditableNoteText.swift */; };
+		C94A5E162A716A6D00B6EC5D /* EditableNoteText.swift in Sources */ = {isa = PBXBuildFile; fileRef = C94A5E142A716A6D00B6EC5D /* EditableNoteText.swift */; };
 		C94D14812A12B3F70014C906 /* SearchBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = C94D14802A12B3F70014C906 /* SearchBar.swift */; };
 		C94D14822A12B3F70014C906 /* SearchBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = C94D14802A12B3F70014C906 /* SearchBar.swift */; };
 		C94D855C2991479900749478 /* NewNoteView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C94D855B2991479900749478 /* NewNoteView.swift */; };
@@ -495,6 +497,7 @@
 		C93EC2FC29C3785C0012EE2A /* View+RoundedCorner.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "View+RoundedCorner.swift"; sourceTree = "<group>"; };
 		C942566829B66A2800C4202C /* Date+Elapsed.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Date+Elapsed.swift"; sourceTree = "<group>"; };
 		C94437E529B0DB83004D8C86 /* NotificationsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationsView.swift; sourceTree = "<group>"; };
+		C94A5E142A716A6D00B6EC5D /* EditableNoteText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditableNoteText.swift; sourceTree = "<group>"; };
 		C94BC09A2A0AC74A0098F6F1 /* PreviewData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewData.swift; sourceTree = "<group>"; };
 		C94D14802A12B3F70014C906 /* SearchBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchBar.swift; sourceTree = "<group>"; };
 		C94D855B2991479900749478 /* NewNoteView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewNoteView.swift; sourceTree = "<group>"; };
@@ -933,11 +936,13 @@
 				A3B943D4299D514800A15A08 /* Follow+CoreDataClass.swift */,
 				C973AB552A323167002AED16 /* Follow+CoreDataProperties.swift */,
 				C93CA0C229AE3A1E00921183 /* JSONEvent.swift */,
+				5B503F612A291A1A0098805A /* JSONRelayMetadata.swift */,
 				C9F84C26298DC98800C6714D /* KeyPair.swift */,
 				C9C547572A4F1D8C006B0741 /* NosNotification+CoreDataClass.swift */,
 				C9C547582A4F1D8C006B0741 /* NosNotification+CoreDataProperties.swift */,
 				C9F0BB6E29A50437000547FC /* NostrConstants.swift */,
 				5B6EB48D29EDBE0E006E750C /* NoteParser.swift */,
+				C94A5E142A716A6D00B6EC5D /* EditableNoteText.swift */,
 				C9AC31AC2A55E0BD00A94E5A /* NotificationViewModel.swift */,
 				C9CF23162A38A58B00EBEC31 /* ParseQueue.swift */,
 				C9DEBFD3298941000078B43A /* Persistence.swift */,
@@ -945,7 +950,6 @@
 				C9DEC06C2989668E0078B43A /* Relay+CoreDataClass.swift */,
 				C973AB592A323167002AED16 /* Relay+CoreDataProperties.swift */,
 				C9C2B78429E073E300548B4A /* RelaySubscription.swift */,
-				5B503F612A291A1A0098805A /* JSONRelayMetadata.swift */,
 				C9E37E142A1E8143003D4B0A /* Report.swift */,
 				C936B4572A4C7B7C00DF1EB9 /* Nos.xcdatamodeld */,
 			);
@@ -1455,6 +1459,7 @@
 				CD76865329B793F400085358 /* DiscoverSearchBar.swift in Sources */,
 				C905EA382A33623F006F1E99 /* SetUpUNSBanner.swift in Sources */,
 				5B8C96AC29D52AD200B73AEC /* AuthorListView.swift in Sources */,
+				C94A5E152A716A6D00B6EC5D /* EditableNoteText.swift in Sources */,
 				DC5F20412A6AE31000F8D73F /* ImagePicker.swift in Sources */,
 				5BFF66B42A58853D00AA79DD /* PublishedEventsView.swift in Sources */,
 				C987F85B29BA9ED800B44E7A /* Font.swift in Sources */,
@@ -1611,6 +1616,7 @@
 				CD09A74E29A521BE0063464F /* NoteCard.swift in Sources */,
 				5B39E64429EDBF8100464830 /* NoteParser.swift in Sources */,
 				3F30021329C3BFDB003D4F8B /* OnboardingStartView.swift in Sources */,
+				C94A5E162A716A6D00B6EC5D /* EditableNoteText.swift in Sources */,
 				CD09A74F29A521BE0063464F /* BioView.swift in Sources */,
 				C960C57229F3236200929990 /* LikeButton.swift in Sources */,
 				CD09A74D29A521A70063464F /* CardStyle.swift in Sources */,

--- a/Nos/Models/EditableNoteText.swift
+++ b/Nos/Models/EditableNoteText.swift
@@ -1,0 +1,97 @@
+//
+//  EditableNoteText.swift
+//  Nos
+//
+//  Created by Matthew Lorentz on 7/26/23.
+//
+
+import Foundation
+import UIKit
+
+/// A model for the unpublished `contents` field of a Nostr note. This model wraps an `AttributedString` and provides 
+/// functions to safely append raw `String` content as well as mentions of nostr entities like other notes or authors.
+struct EditableNoteText: Equatable {
+    
+    /// The underlying string with attributes like font and color.
+    private(set) var attributedString: AttributedString
+    
+    var nsAttributedString: NSAttributedString {
+        NSAttributedString(attributedString)
+    }
+    
+    var string: String {
+        nsAttributedString.string
+    }
+    
+    private static var font = UIFont.preferredFont(forTextStyle: .body)
+    
+    lazy var defaultAttributes: AttributeContainer = {
+        AttributeContainer(defaultNSAttributes)
+    }()
+    
+    var defaultNSAttributes: [NSAttributedString.Key: Any] = [
+        .font: font,
+        .foregroundColor: UIColor.primaryTxt
+    ]
+    
+    var isEmpty: Bool {
+        nsAttributedString.string.isEmpty
+    }
+    
+    // MARK: - Init
+    
+    init() {
+        self.attributedString = AttributedString()
+    }
+    
+    init(string: String) {
+        self.attributedString = AttributedString(string)
+    }
+    
+    init(nsAttributedString: NSAttributedString) {
+        self.attributedString = AttributedString(nsAttributedString)
+    }
+    
+    // MARK: - Modifying the contents
+    
+    /// Appends the given string and adds the the default styling attributes.
+    mutating func append(string: String) {
+        attributedString.append(AttributedString(string, attributes: defaultAttributes))
+    }
+    
+    /// Inserts the mention of an author as a link at the given index of the string. The `index` should be the index 
+    /// after a `@` character, which this function will replace.
+    mutating func insertMention(of author: Author, at index: AttributedString.Index) {
+        guard let url = author.uri else {
+            return
+        }
+        
+        let mention = AttributedString(
+            "@\(author.safeName)",
+            attributes: defaultAttributes.merging(
+                AttributeContainer([NSAttributedString.Key.link: url.absoluteString])
+            )
+        )
+        
+        attributedString.replaceSubrange((attributedString.index(beforeCharacter: index))..<index, with: mention)
+    }
+    
+    // MARK: - Helpers
+    
+    func character(before offset: Int) -> Character? {
+        let newText = nsAttributedString.string
+        if offset > 0 {
+            let index = newText.index(newText.startIndex, offsetBy: offset - 1)
+            return newText[safe: index] 
+        }
+        return nil
+    }
+    
+    func difference(from other: EditableNoteText) -> CollectionDifference<String.Element> {
+        nsAttributedString.string.difference(from: other.string)
+    }
+    
+    static func == (lhs: EditableNoteText, rhs: EditableNoteText) -> Bool {
+        lhs.attributedString == rhs.attributedString
+    }
+}

--- a/Nos/Views/ExpandingTextFieldAndSubmitButton.swift
+++ b/Nos/Views/ExpandingTextFieldAndSubmitButton.swift
@@ -13,7 +13,7 @@ struct ExpandingTextFieldAndSubmitButton: View {
     @Environment(\.managedObjectContext) private var viewContext
 
     var placeholder: any Localizable
-    @Binding var reply: NSAttributedString
+    @Binding var reply: EditableNoteText
     var focus: FocusState<Bool>.Binding
     var action: () async -> Void
     
@@ -35,7 +35,7 @@ struct ExpandingTextFieldAndSubmitButton: View {
                         focus.wrappedValue = false
                         Task {
                             await action()
-                            reply = NSAttributedString("")
+                            reply = EditableNoteText()
                             disabled = false
                         }
                     },
@@ -55,7 +55,7 @@ struct ExpandingTextFieldAndSubmitButton: View {
 
 struct ExpandingTextFieldAndSubmitButton_Previews: PreviewProvider {
 
-    @State static var reply = NSAttributedString("Hello World")
+    @State static var reply = EditableNoteText(string: "Hello World")
     @FocusState static var isFocused: Bool
 
     static var previews: some View {

--- a/Nos/Views/New Note/ComposerActionBar.swift
+++ b/Nos/Views/New Note/ComposerActionBar.swift
@@ -11,7 +11,7 @@ import SwiftUI
 struct ComposerActionBar: View {
     
     @Binding var expirationTime: TimeInterval?
-    @Binding var postText: NSAttributedString
+    @Binding var text: EditableNoteText
     @State var fileStorageAPI: FileStorageAPI = NostrBuildFileStorageAPI()
     
     enum SubMenu {
@@ -42,12 +42,7 @@ struct ComposerActionBar: View {
                             subMenu = .uploadingImage
                             let attachedFile = AttachedFile(image: image)
                             let url = try await fileStorageAPI.upload(file: attachedFile)
-                            let tmpPostText = NSMutableAttributedString(attributedString: self.postText)
-                            if !tmpPostText.string.isEmpty {
-                                tmpPostText.append(NSAttributedString(string: " "))
-                            }
-                            tmpPostText.append(NSAttributedString(string: url.absoluteString))
-                            self.postText = tmpPostText
+                            text.append(string: url.absoluteString)
                             subMenu = .none
                         } catch {
                             subMenu = .none
@@ -122,14 +117,14 @@ struct ComposerActionBar_Previews: PreviewProvider {
     
     @State static var emptyExpirationTime: TimeInterval?
     @State static var setExpirationTime: TimeInterval? = 60 * 60
-    @State static var postText = NSAttributedString()
+    @State static var postText = EditableNoteText()
     
     static var previews: some View {
         VStack {
             Spacer()
-            ComposerActionBar(expirationTime: $emptyExpirationTime, postText: $postText)
+            ComposerActionBar(expirationTime: $emptyExpirationTime, text: $postText)
             Spacer()
-            ComposerActionBar(expirationTime: $setExpirationTime, postText: $postText)
+            ComposerActionBar(expirationTime: $setExpirationTime, text: $postText)
             Spacer()
         }
         .frame(maxWidth: .infinity)

--- a/Nos/Views/RepliesView.swift
+++ b/Nos/Views/RepliesView.swift
@@ -22,7 +22,7 @@ struct RepliesView: View {
     @EnvironmentObject private var currentUser: CurrentUser
     @Dependency(\.analytics) private var analytics
 
-    @State private var reply = NSAttributedString("")
+    @State private var reply = EditableNoteText()
     
     @State private var alert: AlertState<Never>?
     
@@ -166,7 +166,7 @@ struct RepliesView: View {
         .background(Color.appBg)
     }
     
-    func postReply(_ replyText: NSAttributedString) async {
+    func postReply(_ replyText: EditableNoteText) async {
         do {
             guard !replyText.string.isEmpty else {
                 return
@@ -186,7 +186,7 @@ struct RepliesView: View {
                 return
             }
 
-            var (content, tags) = NoteParser.parse(attributedText: AttributedString(replyText))
+            var (content, tags) = NoteParser.parse(attributedText: replyText.attributedString)
 
             // TODO: Append ptags for all authors involved in the thread
             tags.append(["p", authorHex])


### PR DESCRIPTION
The reason `EditableText` wasn't automatically applying the attributes to the appended link is because it relies on the `UITextView.typingAttributes` to add the attributes as they are typed, and appending to the string from code doesn't count as typing. A quick fix would've been to just add the font and color attributes at the time of appending in ComposerActionBar, but that would've meant copying the definitions of those attributes to a relatively unrelated class.

So I decided to write a model class for the note's text, which I think we will need soon anyway to add more types of mentions. The model is called `EditableNoteText` and it abstracts the default AttributedString attributes away from the views and provides functions to safely mutate it by adding a mention or a raw string.