### PR TITLE
Support mentions when pasting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+<<<<<<< Updated upstream
+=======
+- Fixed the launch screen layout on iPad
+- Added support for pasting profile and note references when composing notes
+
+## [0.1 (59)] - 2023-07-21Z
+
+>>>>>>> Stashed changes
 - Add a loading placeholder for note contents.
 - Fixed the launch screen layout on iPad
 - Added Dutch, Japanese, and Persian translations. Thanks matata, yutaro, and eru-desu! 

--- a/Nos/Models/EditableNoteText.swift
+++ b/Nos/Models/EditableNoteText.swift
@@ -75,6 +75,19 @@ struct EditableNoteText: Equatable {
         
         attributedString.replaceSubrange((attributedString.index(beforeCharacter: index))..<index, with: mention)
     }
+
+    /// Inserts the mention of an author as a link at the given index of the string. The `index` should be the index
+    /// after a `@` character, which this function will replace.
+    mutating func insertMention(npub: String, at range: Range<AttributedString.Index>) {
+        let mention = AttributedString(
+            "@\(npub)",
+            attributes: defaultAttributes.merging(
+                AttributeContainer([NSAttributedString.Key.link: "nostr:\(npub)"])
+            )
+        )
+        attributedString.replaceSubrange(range, with: mention)
+        // attributedString.insert(mention, at: index)
+    }
     
     // MARK: - Helpers
     

--- a/Nos/Models/EditableNoteText.swift
+++ b/Nos/Models/EditableNoteText.swift
@@ -80,9 +80,22 @@ struct EditableNoteText: Equatable {
     /// after a `@` character, which this function will replace.
     mutating func insertMention(npub: String, at range: Range<AttributedString.Index>) {
         let mention = AttributedString(
-            "@\(npub)",
+            "@\(npub.prefix(10).appending("..."))",
             attributes: defaultAttributes.merging(
                 AttributeContainer([NSAttributedString.Key.link: "nostr:\(npub)"])
+            )
+        )
+        attributedString.replaceSubrange(range, with: mention)
+        // attributedString.insert(mention, at: index)
+    }
+
+    /// Inserts the mention of an author as a link at the given index of the string. The `index` should be the index
+    /// after a `@` character, which this function will replace.
+    mutating func insertMention(note: String, at range: Range<AttributedString.Index>) {
+        let mention = AttributedString(
+            "@\(note.prefix(10).appending("..."))",
+            attributes: defaultAttributes.merging(
+                AttributeContainer([NSAttributedString.Key.link: "nostr:\(note)"])
             )
         )
         attributedString.replaceSubrange(range, with: mention)

--- a/Nos/Views/EditableText.swift
+++ b/Nos/Views/EditableText.swift
@@ -122,12 +122,15 @@ struct EditableText: UIViewRepresentable {
             false
         }
 
-        func textView(_ textView: UITextView, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {
-            if text.count > 1, let ransge = Range(range, in: self.text.wrappedValue.attributedString) {
+        func textView(_ textView: UITextView, shouldChangeTextIn nsRange: NSRange, replacementText text: String) -> Bool {
+            if text.count > 1, let range = Range(nsRange, in: self.text.wrappedValue.attributedString) {
                 do {
                     let (humanReadablePart, _) = try Bech32.decode(text)
-                    if humanReadablePart == Nostr.publicKeyPrefix || humanReadablePart == Nostr.notePrefix {
-                        self.text.wrappedValue.insertMention(npub: text, at: ransge)
+                    if humanReadablePart == Nostr.publicKeyPrefix {
+                        self.text.wrappedValue.insertMention(npub: text, at: range)
+                        return false
+                    } else if humanReadablePart == Nostr.notePrefix {
+                        self.text.wrappedValue.insertMention(note: text, at: range)
                         return false
                     }
                     return true

--- a/Nos/Views/EditableText.swift
+++ b/Nos/Views/EditableText.swift
@@ -122,7 +122,11 @@ struct EditableText: UIViewRepresentable {
             false
         }
 
-        func textView(_ textView: UITextView, shouldChangeTextIn nsRange: NSRange, replacementText text: String) -> Bool {
+        func textView(
+            _ textView: UITextView,
+            shouldChangeTextIn nsRange: NSRange,
+            replacementText text: String) -> Bool
+        {
             if text.count > 1, let range = Range(nsRange, in: self.text.wrappedValue.attributedString) {
                 do {
                     let (humanReadablePart, _) = try Bech32.decode(text)

--- a/Nos/Views/EditableText.swift
+++ b/Nos/Views/EditableText.swift
@@ -121,6 +121,23 @@ struct EditableText: UIViewRepresentable {
         ) -> Bool {
             false
         }
+
+        func textView(_ textView: UITextView, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {
+            if text.count > 1, let ransge = Range(range, in: self.text.wrappedValue.attributedString) {
+                do {
+                    let (humanReadablePart, _) = try Bech32.decode(text)
+                    if humanReadablePart == Nostr.publicKeyPrefix || humanReadablePart == Nostr.notePrefix {
+                        self.text.wrappedValue.insertMention(npub: text, at: ransge)
+                        return false
+                    }
+                    return true
+                } catch {
+                    return true
+                }
+            } else {
+                return true
+            }
+        }
     }
 }
 


### PR DESCRIPTION
I'm using `upload-files` as base branch because it has useful mechanism to append contents to notes while editing.

This PR closes #154 

It detects if the user pastes a note or npub string in the editor and inserts a mention in place. It really eases note composition.

I added #486 to evaluate if we need that bc we would need to refactor a little bit the code to support showing a row for an unknown author just with its npub id without adding it to the managed context.