### PR TITLE
Fix bug in Follow.upsert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Fixed bug when parsing malformed contact lists.
 - Fixed the launch screen layout on iPad
 - Added support for pasting profile and note references when composing notes
 - Fixed a small issue when mentioning profiles in the reply text box.

--- a/Nos/Models/Follow+CoreDataClass.swift
+++ b/Nos/Models/Follow+CoreDataClass.swift
@@ -66,12 +66,21 @@ public class Follow: NosManagedObject {
         jsonTag: [String],
         context: NSManagedObjectContext
     ) throws -> Follow {
+        guard let followedKey = jsonTag[safe: 1] else {
+            throw DecodingError.valueNotFound(
+                Follow.self,
+                DecodingError.Context(
+                    codingPath: [],
+                    debugDescription: "Encoded tags did not have a key at position 1"
+                )
+            )
+        }
         var follow: Follow
         let fetchRequest = NSFetchRequest<Follow>(entityName: "Follow")
         fetchRequest.predicate = NSPredicate(
             format: "source.hexadecimalPublicKey = %@ AND destination.hexadecimalPublicKey = %@",
             author.hexadecimalPublicKey!,
-            jsonTag[1]
+            followedKey
         )
         fetchRequest.fetchLimit = 1
         if let existingFollow = try context.fetch(fetchRequest).first {
@@ -81,8 +90,7 @@ public class Follow: NosManagedObject {
         }
         
         follow.source = author
-        
-        let followedKey = jsonTag[1]
+
         let followedAuthor = try Author.findOrCreate(by: followedKey, context: context)
         follow.destination = followedAuthor
         


### PR DESCRIPTION
Closes #511 

Follow.upsert assumes that the tags of a contact list events always have an element in position 1, but its is crashing in the wild because apparently some events have tags with no more than 1 elements, maybe of the form ["p"] or something like that. 