### PR TITLE
Database cleanup improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Fix an issue with the database cleanup script that was causing performance issues.
+
 ## [0.1 (73)] - 2023-08-25Z
 
 - Fixed potential crashes when using Universal Names API.

--- a/Nos/Models/Persistence.swift
+++ b/Nos/Models/Persistence.swift
@@ -177,9 +177,9 @@ class PersistenceController {
             Log.info("Database statistics: \(try databaseStatistics(from: context).sorted(by: { $0.key < $1.key }))")
             
             // Delete all but the most recent n events
-            let eventsToKeep = 10_000
+            let eventsToKeep = 1000
             let fetchFirstEventToDelete = Event.allEventsRequest()
-            fetchFirstEventToDelete.sortDescriptors = [NSSortDescriptor(keyPath: \Event.receivedAt, ascending: true)]
+            fetchFirstEventToDelete.sortDescriptors = [NSSortDescriptor(keyPath: \Event.receivedAt, ascending: false)]
             fetchFirstEventToDelete.fetchLimit = 1
             fetchFirstEventToDelete.fetchOffset = eventsToKeep
             fetchFirstEventToDelete.predicate = NSPredicate(format: "receivedAt != nil")
@@ -199,8 +199,7 @@ class PersistenceController {
                 let oldEventsRequest = NSFetchRequest<NSFetchRequestResult>(entityName: "Event")
                 oldEventsRequest.sortDescriptors = [NSSortDescriptor(keyPath: \Event.receivedAt, ascending: true)]
                 oldEventsRequest.predicate = NSPredicate(
-                    format: "author != %@ AND (receivedAt <= %@ OR receivedAt == nil)", 
-                    currentAuthor,
+                    format: "receivedAt <= %@ OR receivedAt == nil", 
                     deleteBefore as CVarArg
                 )
                 

--- a/Nos/NosApp.swift
+++ b/Nos/NosApp.swift
@@ -35,6 +35,9 @@ struct NosApp: App {
                 .environmentObject(appController)
                 .environmentObject(currentUser)
                 .environmentObject(pushNotificationService)
+                .task {
+                    persistenceController.cleanupEntities()
+                }
                 .onChange(of: scenePhase) { newPhase in
                     // TODO: save all contexts, not just the view and background.
                     if newPhase == .inactive {


### PR DESCRIPTION
Part of #526, this makes some improvements to the database cleanup routine:
- The code that started it was accidentally removed a couple releases ago (by me)
- The code to find all events was sorting in the wrong direction resulting in only 10k events being deleted instead of 10k events being kept.
- I reduced the number of events to keep from 10k to 1k because nobody is looking at 10k events
- I removed the code that kept all of the logged-in user's events forever because it doesn't seem to have any adverse effect on the UX (I could still scroll back really far on my profile page).

Having a smaller db makes all our db queries faster and really improved performance on my Mac.