### PR TITLE
Avatar image optimizations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - Fix an issue with the database cleanup script that was causing performance issues.
+- Optimize loading of profile pictures
 
 ## [0.1 (73)] - 2023-08-25Z
 

--- a/Nos.xcodeproj/project.pbxproj
+++ b/Nos.xcodeproj/project.pbxproj
@@ -229,16 +229,17 @@
 		C987F85529BA951E00B44E7A /* ClarityCity-Thin.otf in Resources */ = {isa = PBXBuildFile; fileRef = C987F83129BA951E00B44E7A /* ClarityCity-Thin.otf */; };
 		C987F85A29BA9ED800B44E7A /* Font.swift in Sources */ = {isa = PBXBuildFile; fileRef = C987F85729BA981800B44E7A /* Font.swift */; };
 		C987F85B29BA9ED800B44E7A /* Font.swift in Sources */ = {isa = PBXBuildFile; fileRef = C987F85729BA981800B44E7A /* Font.swift */; };
-		C987F85F29BAB66900B44E7A /* CachedAsyncImage in Frameworks */ = {isa = PBXBuildFile; productRef = C987F85E29BAB66900B44E7A /* CachedAsyncImage */; };
 		C987F86129BABAF800B44E7A /* String+Markdown.swift in Sources */ = {isa = PBXBuildFile; fileRef = C987F86029BABAF800B44E7A /* String+Markdown.swift */; };
 		C987F86229BABAF800B44E7A /* String+Markdown.swift in Sources */ = {isa = PBXBuildFile; fileRef = C987F86029BABAF800B44E7A /* String+Markdown.swift */; };
-		C987F86429BAC3C500B44E7A /* CachedAsyncImage in Frameworks */ = {isa = PBXBuildFile; productRef = C987F86329BAC3C500B44E7A /* CachedAsyncImage */; };
 		C98A32272A05795E00E3FA13 /* Task+Timeout.swift in Sources */ = {isa = PBXBuildFile; fileRef = C98A32262A05795E00E3FA13 /* Task+Timeout.swift */; };
 		C98A32282A05795E00E3FA13 /* Task+Timeout.swift in Sources */ = {isa = PBXBuildFile; fileRef = C98A32262A05795E00E3FA13 /* Task+Timeout.swift */; };
 		C98B8B4029FBF83B009789C8 /* NotificationCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = C98B8B3F29FBF83B009789C8 /* NotificationCard.swift */; };
 		C98B8B4129FBF85F009789C8 /* NotificationCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = C98B8B3F29FBF83B009789C8 /* NotificationCard.swift */; };
 		C98DC9BB2A795CAD004E5F0F /* ActionBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = C98DC9BA2A795CAD004E5F0F /* ActionBanner.swift */; };
 		C98DC9BC2A795CAD004E5F0F /* ActionBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = C98DC9BA2A795CAD004E5F0F /* ActionBanner.swift */; };
+		C99DBF7E2A9E81CF00F7068F /* SDWebImageSwiftUI in Frameworks */ = {isa = PBXBuildFile; productRef = C99DBF7D2A9E81CF00F7068F /* SDWebImageSwiftUI */; };
+		C99DBF802A9E8BCF00F7068F /* SDWebImageSwiftUI in Frameworks */ = {isa = PBXBuildFile; productRef = C99DBF7F2A9E8BCF00F7068F /* SDWebImageSwiftUI */; };
+		C99DBF822A9E8BDE00F7068F /* SDWebImageSwiftUI in Frameworks */ = {isa = PBXBuildFile; productRef = C99DBF812A9E8BDE00F7068F /* SDWebImageSwiftUI */; };
 		C99E80CD2A0C2C6400187474 /* PreviewData.swift in Sources */ = {isa = PBXBuildFile; fileRef = C94BC09A2A0AC74A0098F6F1 /* PreviewData.swift */; };
 		C99E80CE2A0C2C9100187474 /* PreviewData.swift in Sources */ = {isa = PBXBuildFile; fileRef = C94BC09A2A0AC74A0098F6F1 /* PreviewData.swift */; };
 		C9A0DADA29C685E500466635 /* SideMenuButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9A0DAD929C685E500466635 /* SideMenuButton.swift */; };
@@ -686,6 +687,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C99DBF822A9E8BDE00F7068F /* SDWebImageSwiftUI in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -699,8 +701,8 @@
 				C9B71DBE2A8E9BAD0031ED9F /* Sentry in Frameworks */,
 				C9646E9A29B79E04007239A4 /* Logger in Frameworks */,
 				C9646EA729B7A3DD007239A4 /* Dependencies in Frameworks */,
-				C987F85F29BAB66900B44E7A /* CachedAsyncImage in Frameworks */,
 				C96CB98C2A6040C500498C4E /* DequeModule in Frameworks */,
+				C99DBF7E2A9E81CF00F7068F /* SDWebImageSwiftUI in Frameworks */,
 				C9646EA429B7A24A007239A4 /* PostHog in Frameworks */,
 				C94D855F29914D2300749478 /* SwiftUINavigation in Frameworks */,
 			);
@@ -710,12 +712,12 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C99DBF802A9E8BCF00F7068F /* SDWebImageSwiftUI in Frameworks */,
 				C97797BF298ABE060046BD25 /* secp256k1 in Frameworks */,
 				CDDA1F7B29A527650047ACD8 /* Starscream in Frameworks */,
 				C9B71DC52A9008300031ED9F /* Sentry in Frameworks */,
 				C9646EA929B7A4F2007239A4 /* PostHog in Frameworks */,
 				C9646EAC29B7A520007239A4 /* Dependencies in Frameworks */,
-				C987F86429BAC3C500B44E7A /* CachedAsyncImage in Frameworks */,
 				C905B0752A619367009B8A78 /* DequeModule in Frameworks */,
 				C9646E9C29B79E4D007239A4 /* Logger in Frameworks */,
 				CDDA1F7D29A527650047ACD8 /* SwiftUINavigation in Frameworks */,
@@ -1140,6 +1142,9 @@
 				C90862C229E9804B00C35A71 /* PBXTargetDependency */,
 			);
 			name = NosPerformanceTests;
+			packageProductDependencies = (
+				C99DBF812A9E8BDE00F7068F /* SDWebImageSwiftUI */,
+			);
 			productName = NosPerformanceTests;
 			productReference = C90862BB29E9804B00C35A71 /* NosPerformanceTests.xctest */;
 			productType = "com.apple.product-type.bundle.ui-testing";
@@ -1166,10 +1171,10 @@
 				C9646E9929B79E04007239A4 /* Logger */,
 				C9646EA329B7A24A007239A4 /* PostHog */,
 				C9646EA629B7A3DD007239A4 /* Dependencies */,
-				C987F85E29BAB66900B44E7A /* CachedAsyncImage */,
 				C96CB98B2A6040C500498C4E /* DequeModule */,
 				C9B71DBD2A8E9BAD0031ED9F /* Sentry */,
 				C9B71DBF2A8E9BAD0031ED9F /* SentrySwiftUI */,
+				C99DBF7D2A9E81CF00F7068F /* SDWebImageSwiftUI */,
 			);
 			productName = Nos;
 			productReference = C9DEBFCE298941000078B43A /* Nos.app */;
@@ -1196,9 +1201,9 @@
 				C9646E9B29B79E4D007239A4 /* Logger */,
 				C9646EA829B7A4F2007239A4 /* PostHog */,
 				C9646EAB29B7A520007239A4 /* Dependencies */,
-				C987F86329BAC3C500B44E7A /* CachedAsyncImage */,
 				C905B0742A619367009B8A78 /* DequeModule */,
 				C9B71DC42A9008300031ED9F /* Sentry */,
+				C99DBF7F2A9E8BCF00F7068F /* SDWebImageSwiftUI */,
 			);
 			productName = NosTests;
 			productReference = C9DEBFE4298941020078B43A /* NosTests.xctest */;
@@ -1273,9 +1278,9 @@
 				C9646E9829B79E04007239A4 /* XCRemoteSwiftPackageReference "logger-ios" */,
 				C9646EA229B7A24A007239A4 /* XCRemoteSwiftPackageReference "posthog-ios" */,
 				C9646EA529B7A3DD007239A4 /* XCRemoteSwiftPackageReference "swift-dependencies" */,
-				C987F85D29BAB66900B44E7A /* XCRemoteSwiftPackageReference "swiftui-cached-async-image" */,
 				C96CB98A2A6040C500498C4E /* XCRemoteSwiftPackageReference "swift-collections" */,
 				C9B71DBC2A8E9BAD0031ED9F /* XCRemoteSwiftPackageReference "sentry-cocoa" */,
+				C99DBF7C2A9E81CF00F7068F /* XCRemoteSwiftPackageReference "SDWebImageSwiftUI" */,
 			);
 			productRefGroup = C9DEBFCF298941000078B43A /* Products */;
 			projectDirPath = "";
@@ -2278,9 +2283,9 @@
 				minimumVersion = 0.9.2;
 			};
 		};
-		C987F85D29BAB66900B44E7A /* XCRemoteSwiftPackageReference "swiftui-cached-async-image" */ = {
+		C99DBF7C2A9E81CF00F7068F /* XCRemoteSwiftPackageReference "SDWebImageSwiftUI" */ = {
 			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/lorenzofiamingo/swiftui-cached-async-image";
+			repositoryURL = "https://github.com/SDWebImage/SDWebImageSwiftUI";
 			requirement = {
 				kind = upToNextMajorVersion;
 				minimumVersion = 2.0.0;
@@ -2368,15 +2373,20 @@
 			package = C97797BA298AB1890046BD25 /* XCRemoteSwiftPackageReference "secp256k1" */;
 			productName = secp256k1;
 		};
-		C987F85E29BAB66900B44E7A /* CachedAsyncImage */ = {
+		C99DBF7D2A9E81CF00F7068F /* SDWebImageSwiftUI */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = C987F85D29BAB66900B44E7A /* XCRemoteSwiftPackageReference "swiftui-cached-async-image" */;
-			productName = CachedAsyncImage;
+			package = C99DBF7C2A9E81CF00F7068F /* XCRemoteSwiftPackageReference "SDWebImageSwiftUI" */;
+			productName = SDWebImageSwiftUI;
 		};
-		C987F86329BAC3C500B44E7A /* CachedAsyncImage */ = {
+		C99DBF7F2A9E8BCF00F7068F /* SDWebImageSwiftUI */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = C987F85D29BAB66900B44E7A /* XCRemoteSwiftPackageReference "swiftui-cached-async-image" */;
-			productName = CachedAsyncImage;
+			package = C99DBF7C2A9E81CF00F7068F /* XCRemoteSwiftPackageReference "SDWebImageSwiftUI" */;
+			productName = SDWebImageSwiftUI;
+		};
+		C99DBF812A9E8BDE00F7068F /* SDWebImageSwiftUI */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = C99DBF7C2A9E81CF00F7068F /* XCRemoteSwiftPackageReference "SDWebImageSwiftUI" */;
+			productName = SDWebImageSwiftUI;
 		};
 		C9B71DBD2A8E9BAD0031ED9F /* Sentry */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Nos.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Nos.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -46,6 +46,24 @@
       }
     },
     {
+      "identity" : "sdwebimage",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/SDWebImage/SDWebImage.git",
+      "state" : {
+        "revision" : "633996a807442ec28df9d33b0f88ce57a0e2fdbf",
+        "version" : "5.17.0"
+      }
+    },
+    {
+      "identity" : "sdwebimageswiftui",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/SDWebImage/SDWebImageSwiftUI",
+      "state" : {
+        "revision" : "e837c37d45449fbd3b4745c10c5b5274e73edead",
+        "version" : "2.2.3"
+      }
+    },
+    {
       "identity" : "secp256k1.swift",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/GigaBitcoin/secp256k1.swift",
@@ -124,15 +142,6 @@
       "state" : {
         "revision" : "32e8d724467f8fe623624570367e3d50c5638e46",
         "version" : "1.5.2"
-      }
-    },
-    {
-      "identity" : "swiftui-cached-async-image",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/lorenzofiamingo/swiftui-cached-async-image",
-      "state" : {
-        "revision" : "467a3d17479887943ab917a379e62bbaff60ac8a",
-        "version" : "2.1.1"
       }
     },
     {

--- a/Nos.xcodeproj/xcshareddata/xcbaselines/C90862BA29E9804B00C35A71.xcbaseline/41B8D931-3C6A-4659-AE31-1CB6867EF225.plist
+++ b/Nos.xcodeproj/xcshareddata/xcbaselines/C90862BA29E9804B00C35A71.xcbaseline/41B8D931-3C6A-4659-AE31-1CB6867EF225.plist
@@ -60,6 +60,13 @@
 					<key>baselineIntegrationDisplayName</key>
 					<string>Apr 14, 2023 at 5:21:11 PM</string>
 				</dict>
+				<key>com.apple.dt.XCTMetric_OSSignpost-Scroll_DraggingAndDeceleration.animation.hitch.time.ratio</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>21.829512</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
 			</dict>
 		</dict>
 	</dict>

--- a/Nos.xcodeproj/xcshareddata/xcbaselines/C90862BA29E9804B00C35A71.xcbaseline/41B8D931-3C6A-4659-AE31-1CB6867EF225.plist
+++ b/Nos.xcodeproj/xcshareddata/xcbaselines/C90862BA29E9804B00C35A71.xcbaseline/41B8D931-3C6A-4659-AE31-1CB6867EF225.plist
@@ -11,9 +11,9 @@
 				<key>com.apple.dt.XCTMetric_ApplicationLaunch-AppLaunch.duration</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>0.186815</real>
+					<real>0.483000</real>
 					<key>baselineIntegrationDisplayName</key>
-					<string>Apr 14, 2023 at 8:42:50 AM</string>
+					<string>Local Baseline</string>
 				</dict>
 			</dict>
 			<key>testScrollingAnimationPerformance()</key>
@@ -63,9 +63,11 @@
 				<key>com.apple.dt.XCTMetric_OSSignpost-Scroll_DraggingAndDeceleration.animation.hitch.time.ratio</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>21.829512</real>
+					<real>7.900000</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
+					<key>maxPercentRelativeStandardDeviation</key>
+					<real>40.000000</real>
 				</dict>
 			</dict>
 		</dict>

--- a/Nos/Views/AvatarView.swift
+++ b/Nos/Views/AvatarView.swift
@@ -6,12 +6,7 @@
 //
 
 import SwiftUI
-import CachedAsyncImage
-
-extension URLCache {
-    // TODO: allow the user to clear this
-    static let imageCache = URLCache(memoryCapacity: 512 * 1000 * 1000, diskCapacity: 1 * 1000 * 1000 * 1000)
-}
+import SDWebImageSwiftUI
 
 struct AvatarView: View {
     
@@ -19,29 +14,16 @@ struct AvatarView: View {
     var size: CGFloat
     
     var body: some View {
-        Group {
-            let emptyAvatar = Image.emptyAvatar
-                .resizable()
-                .renderingMode(.original)
-            
-            if let imageURL = imageUrl {
-                CachedAsyncImage(url: imageURL, urlCache: .imageCache) { phase in
-                    if let image = phase.image {
-                        image
-                            .resizable()
-                            .aspectRatio(contentMode: .fill)
-                    } else if phase.error != nil {
-                        emptyAvatar
-                    } else {
-                        ProgressView()
-                    }
-                }
-            } else {
-                emptyAvatar
+        WebImage(url: imageUrl)
+            .resizable()
+            .placeholder { 
+                Image.emptyAvatar
+                    .resizable()
+                    .renderingMode(.original)
             }
-        }
-        .frame(width: size, height: size)
-        .clipShape(Circle())
+            .indicator(.activity)
+            .frame(width: size, height: size)
+            .clipShape(Circle())
     }
 }
 

--- a/Nos/Views/SquareImage.swift
+++ b/Nos/Views/SquareImage.swift
@@ -6,7 +6,7 @@
 //
 
 import SwiftUI
-import CachedAsyncImage
+import SDWebImageSwiftUI
 
 struct SquareImage: View {
     var url: URL
@@ -18,20 +18,13 @@ struct SquareImage: View {
             .aspectRatio(1, contentMode: .fit)
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .overlay {
-                CachedAsyncImage(url: url, urlCache: .imageCache) { phase in
-                    if let image = phase.image {
-                        image
-                            .resizable()
-                    } else if phase.error != nil {
-                        EmptyView()
-                    } else {
-                        ProgressView()
+                WebImage(url: url)
+                    .resizable()
+                    .indicator(.activity)
+                    .aspectRatio(contentMode: .fill)
+                    .onTapGesture {
+                        onTap?()
                     }
-                }
-                .aspectRatio(contentMode: .fill)
-                .onTapGesture {
-                    onTap?()
-                }
             }
             .clipShape(Rectangle())
     }

--- a/NosPerformanceTests/NosPerformanceTests.swift
+++ b/NosPerformanceTests/NosPerformanceTests.swift
@@ -6,6 +6,7 @@
 //
 
 import XCTest
+import SDWebImageSwiftUI
 
 final class NosPerformanceTests: XCTestCase {
 
@@ -13,14 +14,6 @@ final class NosPerformanceTests: XCTestCase {
         try super.setUpWithError()
         // In UI tests it is usually best to stop immediately when a failure occurs.
         continueAfterFailure = false
-    }
-
-    func testExample() throws {
-        // UI tests must launch the application that they test.
-        let app = XCUIApplication()
-        app.launch()
-
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
     }
 
     func testLaunchPerformance() throws {
@@ -36,6 +29,8 @@ final class NosPerformanceTests: XCTestCase {
         let app = XCUIApplication()
         app.launch()
         let homeFeed = app.scrollViews["home feed"]
+        SDImageCache.shared.clearMemory()
+        SDImageCache.shared.clearDisk()
             
         measure(metrics: [XCTOSSignpostMetric.scrollDecelerationMetric]) {
             homeFeed.swipeUp(velocity: .fast)

--- a/NosPerformanceTests/NosPerformanceTests.swift
+++ b/NosPerformanceTests/NosPerformanceTests.swift
@@ -32,7 +32,9 @@ final class NosPerformanceTests: XCTestCase {
         SDImageCache.shared.clearMemory()
         SDImageCache.shared.clearDisk()
             
-        measure(metrics: [XCTOSSignpostMetric.scrollDecelerationMetric]) {
+        measure(metrics: [XCTOSSignpostMetric.scrollingAndDecelerationMetric]) {
+            homeFeed.swipeUp(velocity: .fast)
+            homeFeed.swipeUp(velocity: .fast)
             homeFeed.swipeUp(velocity: .fast)
         }
     }


### PR DESCRIPTION
Part of #526. After doing some performance measurements in Instruments I found that rendering the avatar images was causing about 50% of our scroll hitches. I played around with a few optimizations like using an image CDN to downscale them but in the end I found that the SDWebImage library spends less time rendering and seems to do a much better job of caching them than the CachedAsyncImage library we were using before.

The hitch time ratio is now down from about 20ms/s to 10ms/s, although there is a high standard deviation in our performance tests. I spent several hours trying to get a static set of test data for the performance tests but kept running into problems. I think we should do it eventually but I just felt like it was taking too long for this ticket.