### PR TITLE
Refactor directReplies

### DIFF
--- a/Nos/Views/RepliesView.swift
+++ b/Nos/Views/RepliesView.swift
@@ -34,9 +34,11 @@ struct RepliesView: View {
     var repliesRequest: FetchRequest<Event>
     /// All replies
     var replies: FetchedResults<Event> { repliesRequest.wrappedValue }
+
+    @State private var directReplies: [Event] = []
     
-    var directReplies: [Event] {
-        replies.filter { (reply: Event) in
+    func computeDirectReplies() async {
+        directReplies = replies.filter { (reply: Event) in
             guard let eventReferences = reply.eventReferences.array as? [EventReference] else {
                 return false
             }
@@ -161,6 +163,11 @@ struct RepliesView: View {
                             .foregroundColor(.primaryTxt)
                     })
                 }
+            }
+        }
+        .task {
+            Task {
+                await computeDirectReplies()
             }
         }
         .background(Color.appBg)

--- a/Nos/Views/RepliesView.swift
+++ b/Nos/Views/RepliesView.swift
@@ -166,9 +166,7 @@ struct RepliesView: View {
             }
         }
         .task {
-            Task {
-                await computeDirectReplies()
-            }
+            await computeDirectReplies()
         }
         .background(Color.appBg)
     }


### PR DESCRIPTION
directReplies is computed several times when opening a note because SwiftUI updates the inner views everytime the parent changes. It consistently hangs in my iPhone.

And it consistently not hangs with the suggested change that computes the directReplies property just inside a task modifier