### PR TITLE
Fix hang in ProfileView

### DIFF
--- a/Nos/Views/ProfileView.swift
+++ b/Nos/Views/ProfileView.swift
@@ -205,6 +205,11 @@ struct ProfileView: View {
             await refreshProfileFeed()
             await computeUnmutedEvents()
         }
+        .onChange(of: author.muted) { _ in
+            Task {
+                await computeUnmutedEvents()
+            }
+        }
         .onDisappear {
             Task(priority: .userInitiated) {
                 await relayService.decrementSubscriptionCount(for: subscriptionIds)

--- a/Nos/Views/ProfileView.swift
+++ b/Nos/Views/ProfileView.swift
@@ -210,6 +210,11 @@ struct ProfileView: View {
                 await computeUnmutedEvents()
             }
         }
+        .onChange(of: author.events.count) { _ in
+            Task {
+                await computeUnmutedEvents()
+            }
+        }
         .onDisappear {
             Task(priority: .userInitiated) {
                 await relayService.decrementSubscriptionCount(for: subscriptionIds)


### PR DESCRIPTION
ProfileView hangs consistently in my iPhone. But not after computing the unmuted events in a similar fashion to what we did in RepliesView.