### PR TITLE
add support for searching for & looking up fediverse users via mostr.pub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Added the ability to search for Mastodon usernames on the Discover tab. 
+
 ## [0.1 (76)] - 2023-09-08Z
 
 - Minor crash fixes and optimizations

--- a/Nos/Views/DiscoverView.swift
+++ b/Nos/Views/DiscoverView.swift
@@ -240,7 +240,7 @@ struct DiscoverView: View {
         if searchController.query.contains("@") {
             Task(priority: .userInitiated) {
                 if let publicKeyHex =
-                    await relayService.retrieveInternetIdentifierPublicKeyHex(searchController.query.lowercased()),
+                    await relayService.retrievePublicKeyFromUsername(searchController.query.lowercased()),
                     let author = author(fromPublicKey: publicKeyHex) {
                     router.push(author)
                 }

--- a/Nos/Views/ProfileHeader.swift
+++ b/Nos/Views/ProfileHeader.swift
@@ -181,7 +181,7 @@ struct ProfileHeader: View {
         .task(priority: .userInitiated) {
             if let nip05Identifier = author.nip05,
                 let publicKey = author.publicKey?.hex {
-                let verifiedNip05Identifier = await relayService.verifyInternetIdentifier(
+                let verifiedNip05Identifier = await relayService.verifyNIP05(
                     identifier: nip05Identifier,
                     userPublicKey: publicKey
                 )


### PR DESCRIPTION
Now users can put in any fediverse user name in search and it'll let you follow them via the mostr.pub gateway. 

Fixes #500 