### PR TITLE
Fix starscream error and limit updates to next major version

### DIFF
--- a/Nos.xcodeproj/project.pbxproj
+++ b/Nos.xcodeproj/project.pbxproj
@@ -2349,8 +2349,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/daltoniam/Starscream.git";
 			requirement = {
-				branch = master;
-				kind = branch;
+				kind = upToNextMajorVersion;
+				minimumVersion = 4.0.6;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Nos.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Nos.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -86,8 +86,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/daltoniam/Starscream.git",
       "state" : {
-        "branch" : "master",
-        "revision" : "c68359159dcf0b5de9b536b9a959e9e435e968d3"
+        "revision" : "ac6c0fc9da221873e01bd1a0d4818498a71eef33",
+        "version" : "4.0.6"
       }
     },
     {

--- a/Nos/Service/RelayService.swift
+++ b/Nos/Service/RelayService.swift
@@ -682,7 +682,7 @@ extension RelayService: WebSocketDelegate {
                 await parseResponse(string, socket)
             case .binary:
                 break
-            case .ping, .pong, .viabilityChanged, .reconnectSuggested:
+            case .ping, .pong, .viabilityChanged, .reconnectSuggested, .peerClosed:
                 break
             case .cancelled:
                 await subscriptions.remove(socket)


### PR DESCRIPTION
This fixes a compiler error caused by the latest version of Starscream and changes our upgrade rules to only upgrade minor versions (it was tracking master for some reason).