### PR TITLE
Fix search bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Fixed an issue where the app could become slow after searching for a user.
+
 ## [0.1 (83)] - 2023-10-16Z
 
 - Fixed crash on launch

--- a/Nos/Controller/SearchController.swift
+++ b/Nos/Controller/SearchController.swift
@@ -46,7 +46,7 @@ class SearchController: ObservableObject {
                     if let searchSubscriptionID = self.searchSubscriptionID {
                         await self.relayService.decrementSubscriptionCount(for: searchSubscriptionID)
                     }
-                    let searchFilter = Filter(kinds: [.metaData], search: query)
+                    let searchFilter = Filter(kinds: [.metaData], search: query, limit: 100)
                     self.searchSubscriptionID = await self.relayService.openSubscription(with: searchFilter)
                 }
                 return query


### PR DESCRIPTION
I found out that our search filter was downloading hundreds of thousands of events from the relays sometimes and clogging up the app. I fixed it by limiting the number of results we get.