### PR TITLE
Disappearing message icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated search results to show mutual followers and sort by the most followers in common.
 - Change links to notes so that they don't display the long note id and instead it's a pretty link. 
 - Redesigned the Universal Names registration flow
+- Added more relays to the recommended list
+- Added an icon to indicate expiring notes, and the timestamp they display is the time until they expire.
 
 ## [0.1 (83)] - 2023-10-16Z
 

--- a/Nos/Extensions/Date+Elapsed.swift
+++ b/Nos/Extensions/Date+Elapsed.swift
@@ -10,7 +10,7 @@ import Foundation
 
 extension Date {
 
-    func elapsedTimeFromNowString() -> String {
+    func distanceFromNowString() -> String {
 
         // from and to dates
         var calendar = Calendar.current
@@ -22,14 +22,9 @@ extension Date {
         // TODO this is off by one hour during the daylight savings switch (for 24 hours only)
         // compute delta
         let delta = calendar.dateComponents([.timeZone, .minute, .hour, .day], from: from, to: to)
-        let minutes = delta.minute ?? -1
-        let hours = delta.hour ?? -1
-        let day = delta.day ?? -1
-
-        // catch any future dates
-        if minutes < 0 || hours < 0 || day < 0 {
-            return "In the future"
-        }
+        let minutes = abs(delta.minute ?? 0)
+        let hours = abs(delta.hour ?? 0)
+        let day = abs(delta.day ?? 0)
 
         switch day {
         case 0:

--- a/Nos/Models/Relay+CoreDataClass.swift
+++ b/Nos/Models/Relay+CoreDataClass.swift
@@ -23,6 +23,10 @@ public class Relay: NosManagedObject {
         "wss://relay.damus.io",
         "wss://e.nos.lol",
         "wss://purplepag.es",
+        "wss://relay.current.fyi",
+        "wss://relay.nos.social",
+        "wss://relayable.org",
+        "wss://relay.snort.social",
         ]
     }
     
@@ -42,6 +46,8 @@ public class Relay: NosManagedObject {
         "wss://e.nos.lol",
         "wss://purplepag.es",
         "wss://soloco.nl",
+        "wss://relayable.org",
+        "wss://relay.nos.social",
         ]
     }
     

--- a/Nos/Views/AuthorStoryView.swift
+++ b/Nos/Views/AuthorStoryView.swift
@@ -110,7 +110,16 @@ struct AuthorStoryView: View {
                     HStack(alignment: .center) {
                         AuthorLabel(author: author)
                             .padding(0)
-                        if let elapsedTime = selectedNote?.createdAt?.elapsedTimeFromNowString() {
+                        if let expirationTime = selectedNote?.expirationDate?.distanceFromNowString() {
+                            Image.disappearingMessages
+                                .resizable()
+                                .foregroundColor(.secondaryText)
+                                .frame(width: 25, height: 25)
+                            Text(expirationTime)
+                                .lineLimit(1)
+                                .font(.body)
+                                .foregroundColor(.secondaryText)
+                        } else if let elapsedTime = selectedNote?.createdAt?.distanceFromNowString() {
                             Text(elapsedTime)
                                 .lineLimit(1)
                                 .font(.body)

--- a/Nos/Views/NoteButton.swift
+++ b/Nos/Views/NoteButton.swift
@@ -69,7 +69,7 @@ struct NoteButton: View {
                     HStack(alignment: .center) {
                         AuthorLabel(author: author)
                         Image.repostSymbol
-                        if let elapsedTime = repost.createdAt?.elapsedTimeFromNowString() {
+                        if let elapsedTime = repost.createdAt?.distanceFromNowString() {
                             Text(elapsedTime)
                                 .lineLimit(1)
                                 .font(.body)

--- a/Nos/Views/NoteCard.swift
+++ b/Nos/Views/NoteCard.swift
@@ -233,6 +233,7 @@ struct NoteCard_Previews: PreviewProvider {
                     NoteCard(note: previewData.shortNote, hideOutOfNetwork: false)
                     NoteCard(note: previewData.longNote, hideOutOfNetwork: false)
                     NoteCard(note: previewData.imageNote, hideOutOfNetwork: false)
+                    NoteCard(note: previewData.expiringNote, hideOutOfNetwork: false)
                     NoteCard(note: previewData.verticalImageNote, hideOutOfNetwork: false)
                     NoteCard(note: previewData.veryWideImageNote, hideOutOfNetwork: false)
                     NoteCard(note: previewData.imageNote, style: .golden, hideOutOfNetwork: false)

--- a/Nos/Views/NoteCardHeader.swift
+++ b/Nos/Views/NoteCardHeader.swift
@@ -16,7 +16,16 @@ struct NoteCardHeader: View {
         HStack(alignment: .center) {
             AuthorLabel(author: author, note: note)
             Spacer()
-            if let elapsedTime = note.createdAt?.elapsedTimeFromNowString() {
+            if let expirationTime = note.expirationDate?.distanceFromNowString() {
+                Image.disappearingMessages
+                    .resizable()
+                    .foregroundColor(.secondaryText)
+                    .frame(width: 25, height: 25)
+                Text(expirationTime)
+                    .lineLimit(1)
+                    .font(.body)
+                    .foregroundColor(.secondaryText)
+            } else if let elapsedTime = note.createdAt?.distanceFromNowString() {
                 Text(elapsedTime)
                     .lineLimit(1)
                     .font(.body)
@@ -27,9 +36,12 @@ struct NoteCardHeader: View {
     }
 }
 
-struct AuthorHeader_Previews: PreviewProvider {
+struct NoteCardHeader_Previews: PreviewProvider {
     static var previewData = PreviewData()
     static var previews: some View {
         NoteCardHeader(note: previewData.imageNote, author: previewData.previewAuthor)
+            .inject(previewData: previewData)
+        NoteCardHeader(note: previewData.expiringNote, author: previewData.previewAuthor)
+            .inject(previewData: previewData)
     }
 }

--- a/Nos/Views/NotificationCard.swift
+++ b/Nos/Views/NotificationCard.swift
@@ -64,7 +64,7 @@ struct NotificationCard: View {
                 
                 VStack {
                     Spacer()
-                    Text(viewModel.date.elapsedTimeFromNowString())
+                    Text(viewModel.date.distanceFromNowString())
                         .lineLimit(1)
                         .font(.body)
                         .foregroundColor(.secondaryText)

--- a/Nos/Views/PreviewData.swift
+++ b/Nos/Views/PreviewData.swift
@@ -85,6 +85,23 @@ struct PreviewData {
         return note
     }()
     
+    lazy var expiringNote: Event = {
+        let note = Event(context: previewContext)
+        note.identifier = "1"
+        note.kind = EventKind.text.rawValue
+        note.content = "Hello, world!"
+        note.author = previewAuthor
+        note.createdAt = .now
+        let currentDate = Date() 
+        let calendar = Calendar.current 
+        var dateComponents = DateComponents() 
+        dateComponents.day = 1 
+        let tomorrow = calendar.date(byAdding: dateComponents, to: currentDate)!
+        note.expirationDate = tomorrow
+        try? previewContext.save()
+        return note
+    }()
+    
     lazy var imageNote: Event = {
         let note = Event(context: previewContext)
         note.identifier = "2"

--- a/Nos/Views/RelayDetailView.swift
+++ b/Nos/Views/RelayDetailView.swift
@@ -62,7 +62,7 @@ struct RelayDetailView: View {
             } footer: {
                 #if DEBUG
                 if let date = relay.metadataFetchedAt {
-                    Text("\(Localized.fetchedAt.string): \(date.elapsedTimeFromNowString())")
+                    Text("\(Localized.fetchedAt.string): \(date.distanceFromNowString())")
                 }
                 #endif
             }


### PR DESCRIPTION
Closes #444 and #599. I added the relays because I was getting the message that none of my relays supported expiring messages on my test account - so I added some that do.