### PR TITLE
Updating feed view cards to use carousel gallery with fixed height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Updated link previews in feed to use the stories ui with fixed height and carousel gallery. 
 - Add Stories view to the Home Feed
 - Fixed an issue where the app could become slow after searching for a user.
 - Updated search results to show mutual followers and sort by the most followers in common.

--- a/Nos/Views/CompactNoteView.swift
+++ b/Nos/Views/CompactNoteView.swift
@@ -119,13 +119,15 @@ struct CompactNoteView: View {
                 .padding(EdgeInsets(top: 0, leading: 0, bottom: 10, trailing: 0))
             }
             if note.kind == EventKind.text.rawValue, !contentLinks.isEmpty {
-                VStack {
+                TabView {
                     ForEach(contentLinks, id: \.self.absoluteURL) { url in
                         LinkPreview(url: url)
-                            .fixedSize(horizontal: false, vertical: true)
                             .padding(.horizontal, 15)
+                            .padding(.vertical, 0)
                     }
                 }
+                .tabViewStyle(.page)
+                .frame(height: 320)
                 .padding(.bottom, 15)
             }
         }

--- a/Nos/Views/CompactNoteView.swift
+++ b/Nos/Views/CompactNoteView.swift
@@ -119,16 +119,23 @@ struct CompactNoteView: View {
                 .padding(EdgeInsets(top: 0, leading: 0, bottom: 10, trailing: 0))
             }
             if note.kind == EventKind.text.rawValue, !contentLinks.isEmpty {
-                TabView {
-                    ForEach(contentLinks, id: \.self.absoluteURL) { url in
-                        LinkPreview(url: url)
-                            .padding(.horizontal, 15)
-                            .padding(.vertical, 0)
+                if contentLinks.count == 1, let url = contentLinks.first {
+                    LinkPreview(url: url)
+                        .padding(.horizontal, 15)
+                        .padding(.vertical, 0)
+                        .padding(.bottom, 15)
+                } else {
+                    TabView {
+                        ForEach(contentLinks, id: \.self.absoluteURL) { url in
+                            LinkPreview(url: url)
+                                .padding(.horizontal, 15)
+                                .padding(.vertical, 0)
+                        }
                     }
+                    .tabViewStyle(.page)
+                    .frame(height: 320)
+                    .padding(.bottom, 15)
                 }
-                .tabViewStyle(.page)
-                .frame(height: 320)
-                .padding(.bottom, 15)
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)


### PR DESCRIPTION
Swaps in @martindsq's gallery for viewing preview links at a fixed height in the feed view. Fixes the problem of the feed size changing as items load and when there are lots of links seeing a page of previews. 