### PR TITLE
Update Logger library to 1.1.0

### DIFF
--- a/Nos.xcodeproj/project.pbxproj
+++ b/Nos.xcodeproj/project.pbxproj
@@ -2234,7 +2234,7 @@
 			repositoryURL = "https://github.com/planetary-social/logger-ios";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 1.0.0;
+				minimumVersion = 1.1.0;
 			};
 		};
 		C9646EA229B7A24A007239A4 /* XCRemoteSwiftPackageReference "posthog-ios" */ = {

--- a/Nos.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Nos.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/CocoaLumberjack/CocoaLumberjack.git",
       "state" : {
-        "revision" : "0188d31089b5881a269e01777be74c7316924346",
-        "version" : "3.8.0"
+        "revision" : "67ec5818a757aba4d7c534e21a905d878d128dbf",
+        "version" : "3.8.1"
       }
     },
     {
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/planetary-social/logger-ios",
       "state" : {
-        "revision" : "77b1df4808a711e02e9980600cd8206e46b5af29",
-        "version" : "1.0.0"
+        "revision" : "d25fb7d95d76953b8bbbc2ce167b26914bc5264b",
+        "version" : "1.1.0"
       }
     },
     {

--- a/Nos/Service/EventProcessor.swift
+++ b/Nos/Service/EventProcessor.swift
@@ -75,7 +75,7 @@ enum EventProcessor {
                     events.append(event)
                 }
             } catch {
-                print("Error parsing eventJSON: \(jsonEvent): \(error.localizedDescription)")
+                Log.error("Error parsing eventJSON: \(jsonEvent): \(error.localizedDescription)")
             }
         }
         

--- a/Nos/Service/RelayService.swift
+++ b/Nos/Service/RelayService.swift
@@ -407,7 +407,7 @@ extension RelayService {
     private func publish(from client: WebSocketClient, jsonEvent: JSONEvent) async throws {
         // Keep track of this so if it fails we can retry N times
         let requestString = try jsonEvent.buildPublishRequest()
-        Log.info(requestString)
+        Log.info("publishing \(requestString)")
         client.write(string: requestString)
     }
     

--- a/Nos/Service/RelaySubscriptionManager.swift
+++ b/Nos/Service/RelaySubscriptionManager.swift
@@ -153,7 +153,7 @@ actor RelaySubscriptionManager {
             start(subscription: subscription, relays: relays)
         }
         
-        Log.info("\(active.count) active subscriptions. \(all.count - active.count) subscriptions waiting in queue.")
+        Log.debug("\(active.count) active subscriptions. \(all.count - active.count) subscriptions waiting in queue.")
     }
     
     func queueSubscription(with filter: Filter, to overrideRelays: [URL]? = nil) async -> RelaySubscription.ID {
@@ -175,7 +175,7 @@ actor RelaySubscriptionManager {
         var subscription = subscription
         subscription.subscriptionStartDate = .now
         updateSubscriptions(with: subscription)
-        Log.info("starting subscription: \(subscription.id)")
+        Log.debug("starting subscription: \(subscription.id)")
         relays.forEach { relayURL in
             if let socket = socket(for: relayURL) {
                 requestEvents(from: socket, subscription: subscription)
@@ -190,10 +190,10 @@ actor RelaySubscriptionManager {
             let request: [Any] = ["REQ", subscription.id, subscription.filter.dictionary]
             let requestData = try JSONSerialization.data(withJSONObject: request)
             let requestString = String(data: requestData, encoding: .utf8)!
-            Log.info("REQ for \(subscription.id) sent to \(socket.host)")
+            Log.debug("REQ for \(subscription.id) sent to \(socket.host)")
             socket.write(string: requestString)
         } catch {
-            print("Error: Could not send request \(error.localizedDescription)")
+            Log.error("Error: Could not send request \(error.localizedDescription)")
         }
     }
 }


### PR DESCRIPTION
This updates to the latest version of the Logger library which works better with Xcode 15's filters. I also changed a lot of the noisiest log messages (mostly relay stuff) to the `DEBUG` log level which means you can filter down to INFO in the log viewer and get much less output.