### PR TITLE
Add confirmation dialog to reposts and ability to delete them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Added a confirmation before reposting a note.
+- Added the ability to delete your reposts by tapping the repost button again.
+- Fixed some cases where deleted notes were still being displayed.
+
 ## [0.1 (88)] - 2023-10-27Z
 
 - Added a content warning when a user you follow has reported the content

--- a/Nos/Models/Event+CoreDataClass.swift
+++ b/Nos/Models/Event+CoreDataClass.swift
@@ -167,7 +167,7 @@ public class Event: NosManagedObject {
         let featuredPredicate = NSPredicate(
             format: "kind IN %@ AND eventReferences.@count = 0 AND author.hexadecimalPublicKey IN %@ " +
                 "AND NOT author IN %@.follows.destination AND NOT author = %@ AND receivedAt <= %@ AND " +
-                "author.muted = false",
+                "author.muted = false AND deletedOn.@count = 0",
             discoverKinds.map { $0.rawValue },
             featuredAuthors.compactMap {
                 PublicKey(npub: $0)?.hex
@@ -180,7 +180,7 @@ public class Event: NosManagedObject {
         let twoHopsPredicate = NSPredicate(
             format: "kind IN %@ AND eventReferences.@count = 0 AND author.muted = false " +
                 "AND ANY author.followers.source IN %@.follows.destination AND NOT author IN %@.follows.destination " +
-                "AND receivedAt <= %@",
+                "AND receivedAt <= %@ AND deletedOn.@count = 0",
             discoverKinds.map { $0.rawValue },
             currentUser,
             currentUser,
@@ -220,7 +220,7 @@ public class Event: NosManagedObject {
         }
         
         return NSPredicate(
-            format: "kind = %i AND ANY authorReferences.pubkey = %@",
+            format: "kind = %i AND ANY authorReferences.pubkey = %@ AND deletedOn.@count = 0",
             EventKind.text.rawValue,
             publicKey
         )
@@ -232,14 +232,18 @@ public class Event: NosManagedObject {
         fetchRequest.predicate = NSPredicate(
             format: "author.hexadecimalPublicKey = %@ AND " +
             "SUBQUERY(shouldBePublishedTo, $relay, TRUEPREDICATE).@count != " +
-            "SUBQUERY(seenOnRelays, $relay, TRUEPREDICATE).@count",
+            "SUBQUERY(seenOnRelays, $relay, TRUEPREDICATE).@count AND " +
+            "deletedOn.@count = 0",
             user.hexadecimalPublicKey ?? ""
         )
         return fetchRequest
     }
     
     @nonobjc public class func allRepliesPredicate(for user: Author) -> NSPredicate {
-        NSPredicate(format: "kind = 1 AND ANY eventReferences.referencedEvent.author = %@", user)
+        NSPredicate(
+            format: "kind = 1 AND ANY eventReferences.referencedEvent.author = %@ AND deletedOn.@count = 0", 
+            user
+        )
     }
     
     @nonobjc public class func all(notifying user: Author, since: Date? = nil) -> NSFetchRequest<Event> {
@@ -321,7 +325,7 @@ public class Event: NosManagedObject {
     @nonobjc public class func homeFeedPredicate(for user: Author, before: Date) -> NSPredicate {
         NSPredicate(
             // swiftlint:disable line_length
-            format: "((kind = 1 AND SUBQUERY(eventReferences, $reference, $reference.marker = 'root' OR $reference.marker = 'reply' OR $reference.marker = nil).@count = 0) OR kind = 6 OR kind = 30023) AND (ANY author.followers.source = %@ OR author = %@) AND author.muted = 0 AND (receivedAt == nil OR receivedAt <= %@)",
+            format: "((kind = 1 AND SUBQUERY(eventReferences, $reference, $reference.marker = 'root' OR $reference.marker = 'reply' OR $reference.marker = nil).@count = 0) OR kind = 6 OR kind = 30023) AND (ANY author.followers.source = %@ OR author = %@) AND author.muted = 0 AND (receivedAt == nil OR receivedAt <= %@ AND deletedOn.@count = 0)",
             // swiftlint:enable line_length
             user,
             user,
@@ -343,7 +347,7 @@ public class Event: NosManagedObject {
         fetchRequest.sortDescriptors = [NSSortDescriptor(keyPath: \Event.createdAt, ascending: false)]
         let noteIsLikedByUserPredicate = NSPredicate(
             // swiftlint:disable line_length
-            format: "kind = \(String(EventKind.like.rawValue)) AND author.hexadecimalPublicKey = %@ AND SUBQUERY(eventReferences, $reference, $reference.eventId = %@).@count > 0",
+            format: "kind = \(String(EventKind.like.rawValue)) AND author.hexadecimalPublicKey = %@ AND SUBQUERY(eventReferences, $reference, $reference.eventId = %@).@count > 0  AND deletedOn.@count = 0",
             // swiftlint:enable line_length
             userPubKey,
             noteId
@@ -370,7 +374,7 @@ public class Event: NosManagedObject {
         fetchRequest.sortDescriptors = [NSSortDescriptor(keyPath: \Event.createdAt, ascending: false)]
         let noteIsLikedByUserPredicate = NSPredicate(
             // swiftlint:disable line_length
-            format: "kind = \(String(EventKind.repost.rawValue)) AND SUBQUERY(eventReferences, $reference, $reference.eventId = %@).@count > 0",
+            format: "kind = \(String(EventKind.repost.rawValue)) AND SUBQUERY(eventReferences, $reference, $reference.eventId = %@).@count > 0 AND deletedOn.@count = 0",
             // swiftlint:enable line_length
             noteID
         )
@@ -467,7 +471,7 @@ public class Event: NosManagedObject {
     func reportsRequest() -> NSFetchRequest<Event> {
         let request = NSFetchRequest<Event>(entityName: "Event")
         request.predicate = NSPredicate(
-            format: "kind = %i AND ANY eventReferences.referencedEvent = %@", 
+            format: "kind = %i AND ANY eventReferences.referencedEvent = %@ AND deletedOn.@count = 0", 
             EventKind.report.rawValue,
             self
         )

--- a/Nos/Views/NoteCard.swift
+++ b/Nos/Views/NoteCard.swift
@@ -122,9 +122,7 @@ struct NoteCard: View {
                                 }
                             }
                             Spacer()
-                            RepostButton(note: note) {
-                                await repostNote()
-                            }
+                            RepostButton(note: note) 
                             LikeButton(note: note)
                             ReplyButton(note: note, replyAction: replyAction)
                         }
@@ -182,33 +180,6 @@ struct NoteCard: View {
         }
         .listRowInsets(EdgeInsets())
         .cornerRadius(cornerRadius)
-    }
-
-    func repostNote() async {
-        guard let keyPair = currentUser.keyPair else {
-            return
-        }
-        
-        var tags: [[String]] = []
-        if let id = note.identifier {
-            tags.append(["e", id] + note.seenOnRelayURLs)
-        }
-        if let pubKey = note.author?.publicKey?.hex {
-            tags.append(["p", pubKey])
-        }
-        
-        let jsonEvent = JSONEvent(
-            pubKey: keyPair.publicKeyHex,
-            kind: .repost,
-            tags: tags,
-            content: note.jsonString ?? ""
-        )
-        
-        do {
-            try await relayService.publishToAll(event: jsonEvent, signingKey: keyPair, context: viewContext)
-        } catch {
-            Log.info("Error creating event for like")
-        }
     }
 
     var cornerRadius: CGFloat {

--- a/Nos/Views/RepostButton.swift
+++ b/Nos/Views/RepostButton.swift
@@ -6,19 +6,25 @@
 //
 
 import SwiftUI
+import SwiftUINavigation
+import Logger
 
 struct RepostButton: View {
     
     var note: Event
-    var action: () async -> Void
+    
     @FetchRequest private var reposts: FetchedResults<Event>
     @EnvironmentObject private var currentUser: CurrentUser
+    @EnvironmentObject private var relayService: RelayService
+    @Environment(\.managedObjectContext) private var viewContext
+    
     /// We use this to give instant feedback when the button is tapped, even though the action it performs is async.
     @State private var tapped = false
+    @State private var shouldConfirmRepost = false
+    @State private var shouldConfirmDelete = false
     
-    internal init(note: Event, action: @escaping () async -> Void) {
+    internal init(note: Event) {
         self.note = note
-        self.action = action
         _reposts = FetchRequest(fetchRequest: Event.reposts(noteID: note.identifier ?? ""))
     }
     
@@ -30,9 +36,8 @@ struct RepostButton: View {
 
     var body: some View {
         Button { 
-            tapped = true
             Task {
-                await action()
+                await buttonPressed()
             }
         } label: {
             HStack {
@@ -51,6 +56,71 @@ struct RepostButton: View {
             .padding(.horizontal, 10)
             .padding(.vertical, 12)
         }
-        .disabled(currentUserRepostedNote || tapped)
+        .disabled(tapped)
+        .confirmationDialog("Repost", isPresented: $shouldConfirmRepost) { 
+            Button("Repost") { 
+                Task { await repostNote() }
+            }
+            Button(Localized.cancel.string, role: .cancel) {
+                tapped = false
+            }
+        }
+        .confirmationDialog("Delete repost", isPresented: $shouldConfirmDelete) { 
+            Button("Delete repost", role: .destructive) { 
+                Task { await deleteReposts() }
+            }
+        }
+    }
+    
+    func buttonPressed() async {
+        if !tapped && !currentUserRepostedNote {
+            tapped = true
+            shouldConfirmRepost = true
+        } else if !tapped && currentUserRepostedNote {
+            shouldConfirmDelete = true
+        } else {
+            // The repost is currently being published, don't do anything.
+        }
+    }
+    
+    func repostNote() async {
+        defer { tapped = false }
+        guard let keyPair = currentUser.keyPair else {
+            return
+        }
+        
+        var tags: [[String]] = []
+        if let id = note.identifier {
+            tags.append(["e", id] + note.seenOnRelayURLs)
+        }
+        if let pubKey = note.author?.publicKey?.hex {
+            tags.append(["p", pubKey])
+        }
+        
+        let jsonEvent = JSONEvent(
+            pubKey: keyPair.publicKeyHex,
+            kind: .repost,
+            tags: tags,
+            content: note.jsonString ?? ""
+        )
+        
+        do {
+            try await relayService.publishToAll(event: jsonEvent, signingKey: keyPair, context: viewContext)
+        } catch {
+            Log.error(error, "Error creating event for repost")
+        }
+    }
+    
+    func deleteReposts() async {
+        reposts
+            .filter {
+                $0.author?.hexadecimalPublicKey == currentUser.author?.hexadecimalPublicKey
+            }
+            .compactMap { $0.identifier }
+            .forEach { noteIdentifier in
+                Task {
+                    await currentUser.publishDelete(for: [noteIdentifier])
+                }
+            }
     }
 }


### PR DESCRIPTION
This adds a confirmation dialog before deleting a repost, and allows you to delete them. I also fixed some cases where deleted events were still showing (we need to refactor the way we do deletes).

Part of #286