### PR TITLE
Retain up to two newlines in notes instead of one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - Fixed incorrect ellipsis applied to long notes.
+- Changed note rendering to retain more newlines. 
 
 ## [0.1 (86)] - 2023-10-25Z
 

--- a/Nos/Extensions/String+Markdown.swift
+++ b/Nos/Extensions/String+Markdown.swift
@@ -58,7 +58,7 @@ extension String {
         
         replaceOccurrences(of: "^\\s*", with: "", in: mutableString)
         replaceOccurrences(of: "\\s*$", with: "", in: mutableString)
-        replaceOccurrences(of: "\\n{2,}", with: "\n", in: mutableString)
+        replaceOccurrences(of: "\\n{3,}", with: "\n\n", in: mutableString)
         
         return (mutableString as String, urls)
     }

--- a/NosTests/NoteParserTests.swift
+++ b/NosTests/NoteParserTests.swift
@@ -387,9 +387,20 @@ final class NoteNoteParserTests: XCTestCase {
         XCTAssertEqual(actualURLs, expectedURLs)
     }
     
-    func testExtractURLsRemovesDuplicateNewlines() throws {
+    func testExtractURLsRetainsUpToTwoDuplicateNewlines() throws {
         let string = "Hello!\n\nWorld!"
-        let expectedString = "Hello!\nWorld!"
+        let expectedString = "Hello!\n\nWorld!"
+        let expectedURLs: [URL] = []
+
+        // Act
+        let (actualString, actualURLs) = string.extractURLs()
+        XCTAssertEqual(actualString, expectedString)
+        XCTAssertEqual(actualURLs, expectedURLs)
+    }
+    
+    func testExtractURLsReducesTooManyDuplicateNewlinesToTwo() throws {
+        let string = "Hello!\n\n\nWorld!"
+        let expectedString = "Hello!\n\nWorld!"
         let expectedURLs: [URL] = []
 
         // Act


### PR DESCRIPTION
It makes sense to let people have blank newlines in notes to create paragraphs. I do that often.