### PR TITLE
Show reposts in stories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed incorrect ellipsis applied to long notes.
 - Changed note rendering to retain more newlines. 
+- Show reposts in stories.
 
 ## [0.1 (86)] - 2023-10-25Z
 

--- a/Nos/Assets/Assets.xcassets/New Colors/stories-bg-bottom.colorset/Contents.json
+++ b/Nos/Assets/Assets.xcassets/New Colors/stories-bg-bottom.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0xF4",
-          "green" : "0xF5",
-          "red" : "0xFC"
+          "blue" : "0xE6",
+          "green" : "0xE7",
+          "red" : "0xF2"
         }
       },
       "idiom" : "universal"

--- a/Nos/Assets/Assets.xcassets/New Colors/stories-bg-top.colorset/Contents.json
+++ b/Nos/Assets/Assets.xcassets/New Colors/stories-bg-top.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0xF7",
-          "green" : "0xF8",
-          "red" : "0xFF"
+          "blue" : "0xE9",
+          "green" : "0xE9",
+          "red" : "0xF2"
         }
       },
       "idiom" : "universal"

--- a/Nos/Views/AuthorStoryView.swift
+++ b/Nos/Views/AuthorStoryView.swift
@@ -47,7 +47,7 @@ struct AuthorStoryView: View {
             ScrollView(.vertical, showsIndicators: false) {
                 Group {
                     if let selectedNote {
-                        StoryNoteView(note: selectedNote, minHeight: geometry.size.height)
+                        StoryNoteView(note: selectedNote, minHeight: geometry.size.height - 40)
                     } else {
                         EmptyView()
                     }
@@ -69,7 +69,7 @@ struct AuthorStoryView: View {
             } label: {
                 Color.red.opacity(0)
             }
-            .frame(maxWidth: 100, maxHeight: .infinity)
+            .frame(maxWidth: 60, maxHeight: .infinity)
         }
         .overlay(alignment: .trailing) {
             Button {
@@ -85,7 +85,7 @@ struct AuthorStoryView: View {
             } label: {
                 Color.green.opacity(0)
             }
-            .frame(maxWidth: 100, maxHeight: .infinity)
+            .frame(maxWidth: 60, maxHeight: .infinity)
         }
         .overlay(alignment: .topLeading) {
             VStack {
@@ -147,7 +147,7 @@ struct AuthorStoryView: View {
             }
         }
         .overlay(alignment: .bottomLeading) {
-            if let selectedNote {
+            if let selectedNote, selectedNote.kind != EventKind.repost.rawValue {
                 BottomOverlay(note: selectedNote)
             } else {
                 EmptyView()

--- a/Nos/Views/StoryNoteView.swift
+++ b/Nos/Views/StoryNoteView.swift
@@ -95,18 +95,37 @@ struct StoryNoteView: View {
                 if shouldShowSpacing {
                     Spacer(minLength: 85)
                 }
-                if note.kind == EventKind.text.rawValue, !contentLinks.isEmpty {
-                    TabView {
-                        ForEach(contentLinks, id: \.self.absoluteURL) { url in
-                            LinkPreview(url: url)
-                                .padding(.horizontal, 15)
-                                .padding(.vertical, 0)
-                        }
+                if note.kind == EventKind.repost.rawValue, let repostedNote = note.referencedNote() {
+                    Button {
+                        router.push(repostedNote)
+                    } label: {
+                        NoteCard(
+                            note: repostedNote,
+                            style: .compact,
+                            showFullMessage: false,
+                            hideOutOfNetwork: true,
+                            showReplyCount: true,
+                            replyAction: nil
+                        )
                     }
-                    .tabViewStyle(.page)
-                    .frame(height: 320)
+                    .buttonStyle(CardButtonStyle(style: .compact))
+                    .fixedSize(horizontal: false, vertical: true)
+                    .padding(.horizontal)
+                    .readabilityPadding()
+                } else {
+                    if note.kind == EventKind.text.rawValue, !contentLinks.isEmpty {
+                        TabView {
+                            ForEach(contentLinks, id: \.self.absoluteURL) { url in
+                                LinkPreview(url: url)
+                                    .padding(.horizontal, 15)
+                                    .padding(.vertical, 0)
+                            }
+                        }
+                        .tabViewStyle(.page)
+                        .frame(height: 320)
+                    }
+                    formattedText
                 }
-                formattedText
                 if shouldShowSpacing {
                     Spacer(minLength: 55)
                 }


### PR DESCRIPTION
Show reposted notes as cards in stories and coordinated with Sebastian to update stories background colors (in light) to add contrast.

Also decreased a little bit the width of the tappable areas to go back and forth because I received multiple complains about them

And decreased minHeight so that we catch some stories whose height are near the stories' height that display below the top overlay