### PR TITLE
Try to pin an old version of swiftlint

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,4 +38,4 @@ jobs:
       - name: SwiftLint
         uses: docker://norionomura/swiftlint:0.53.0
         with:
-          args: --strict
+          args: swiftlint --strict --reporter github-actions-logging

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,6 +36,6 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: SwiftLint
-        uses: norio-nomura/action-swiftlint@3.2.1
+        uses: docker://norionomura/swiftlint:0.53.0
         with:
           args: --strict


### PR DESCRIPTION
[Swiftlint is having problems](https://github.com/Homebrew/homebrew-core/pull/153931) deploying their latest version to homebrew. This pins the old version so our local swiftlint errors match up with what Github CI is using.