### PR TITLE
Add attempt to fix crash in router

### DIFF
--- a/Nos/Views/DiscoverView.swift
+++ b/Nos/Views/DiscoverView.swift
@@ -239,9 +239,12 @@ struct DiscoverView: View {
         if searchController.query.contains("@") {
             Task(priority: .userInitiated) {
                 if let publicKeyHex =
-                    await relayService.retrievePublicKeyFromUsername(searchController.query.lowercased()),
-                    let author = author(fromPublicKey: publicKeyHex) {
-                    router.push(author)
+                    await relayService.retrievePublicKeyFromUsername(searchController.query.lowercased()) {
+                    Task { @MainActor in
+                        if let author = author(fromPublicKey: publicKeyHex) {
+                            router.push(author)
+                        }
+                    }
                 }
             }
         } else {


### PR DESCRIPTION
Attempt to fix #550 

I don't know if this is the cause, because we don't know yet how to reproduce it, but it is an attempt.
The crash only affects the Discover path, so it should be in code only used in the Discover view. We don't have many views only used there. This is one piece of code, that it is only used in the DiscoverView and it is modifying the router and fetching objects from a different thread (I didn't find information about what thread userInititiated is exactly, but it doesn't look like the main thread). So I just make it use the main thread, and lets see if we continue to see the crash.