### PR TITLE
Improve performance of SocialGrapheCache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Fixed some performance issues for users who follow a large number of accounts.
+
 ## [0.1 (95)] - 2023-11-27Z
 
 - Fixed a bug where a root note could be rendered as a reply

--- a/Nos.xcodeproj/project.pbxproj
+++ b/Nos.xcodeproj/project.pbxproj
@@ -1011,6 +1011,7 @@
 				C9671D72298DB94C00EE7E12 /* Data+Encoding.swift */,
 				C9F84C1B298DBBF400C6714D /* Data+Sha.swift */,
 				C942566829B66A2800C4202C /* Date+Elapsed.swift */,
+				C913DA0B2AEB2EBF003BDD6D /* FetchRequestPublisher.swift */,
 				C987F85729BA981800B44E7A /* Font.swift */,
 				C9B678DD29EEC35B00303F33 /* Foundation+Sendable.swift */,
 				C9F0BB6829A5039D000547FC /* Int+Bool.swift */,
@@ -1019,6 +1020,7 @@
 				C97A1C8D29E58EC7009D9E8D /* NSManagedObjectContext+Nos.swift */,
 				C93EC2F329C34C860012EE2A /* NSPredicate+Bool.swift */,
 				C93EC2F629C351470012EE2A /* Optional+Unwrap.swift */,
+				C99721CA2AEBED26004EBEAB /* String+Empty.swift */,
 				C9F204662ADEDBA80029A858 /* String+Extra.swift */,
 				C9ADB13729928CC30075E7F8 /* String+Hex.swift */,
 				C9DEC002298945150078B43A /* String+Lorem.swift */,
@@ -1028,8 +1030,6 @@
 				C92DF80429C25DE900400561 /* URL+Extensions.swift */,
 				C9F204622ADEDB910029A858 /* Web3Utils.swift */,
 				C9C2B77B29E072E400548B4A /* WebSocket+Nos.swift */,
-				C913DA0B2AEB2EBF003BDD6D /* FetchRequestPublisher.swift */,
-				C99721CA2AEBED26004EBEAB /* String+Empty.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";

--- a/Nos/Controller/NoteWarningController.swift
+++ b/Nos/Controller/NoteWarningController.swift
@@ -25,14 +25,20 @@ extension Publisher {
     }
 }
 
-@Observable class NoteWarningController {
+@Observable @MainActor class NoteWarningController {
     
-    var showWarning = false
-    var userHidWarning = false {
-        didSet {
-            computeShowWarning()
+    var showWarning: Bool {
+        if userHidWarning {
+            return false
+        } else if showReportWarnings && !(noteReports.isEmpty || !authorReports.isEmpty) {
+            return true
+        } else if shouldHideOutOfNetwork && showOutOfNetworkWarning && outOfNetwork {
+            return true
+        } else {
+            return false
         }
     }
+    var userHidWarning = false 
     var outOfNetwork = false
     
     var note: Event? {
@@ -48,16 +54,8 @@ extension Publisher {
     @ObservationIgnored @Dependency(\.persistenceController) var persistenceController
     @ObservationIgnored @Dependency(\.userDefaults) var userDefaults
     
-    var noteReports = [Event]() {
-        didSet {
-            computeShowWarning()
-        }
-    }
-    var authorReports = [Event]() {
-        didSet {
-            computeShowWarning()
-        }
-    }
+    var noteReports = [Event]() 
+    var authorReports = [Event]() 
     private var cancellables = [AnyCancellable]()
     private var noteReportsWatcher: NSFetchedResultsController<Event>?
     private var authorReportsWatcher: NSFetchedResultsController<Event>?
@@ -96,14 +94,12 @@ extension Publisher {
                 FetchedResultsControllerPublisher(fetchedResultsController: noteReportsWatcher)
                     .publisher
                     .asyncMap { (events: [Event]?) -> [Event] in
-                        await MainActor.run {
-                            var eventsFromFollowedAuthors = [Event]()
-                            for event in events ?? [] where
-                                self.currentUser.socialGraph.follows(event.author?.hexadecimalPublicKey) {
-                                    eventsFromFollowedAuthors.append(event)
-                            }
-                            return eventsFromFollowedAuthors
+                        var eventsFromFollowedAuthors = [Event]()
+                        for event in events ?? [] where
+                        await self.currentUser.socialGraph.follows(event.author?.hexadecimalPublicKey) {
+                            eventsFromFollowedAuthors.append(event)
                         }
+                        return eventsFromFollowedAuthors
                     } 
                     .receive(on: DispatchQueue.main)
                     .sink(receiveValue: { [weak self] followedReports in
@@ -123,14 +119,12 @@ extension Publisher {
                     FetchedResultsControllerPublisher(fetchedResultsController: authorReportsWatcher)
                         .publisher
                         .asyncMap { (events: [Event]?) -> [Event] in
-                            await MainActor.run {
-                                var eventsFromFollowedAuthors = [Event]()
-                                for event in events ?? [] where 
-                                self.currentUser.socialGraph.follows(event.author?.hexadecimalPublicKey) {
-                                    eventsFromFollowedAuthors.append(event)
-                                }
-                                return eventsFromFollowedAuthors
+                            var eventsFromFollowedAuthors = [Event]()
+                            for event in events ?? [] where 
+                            await self.currentUser.socialGraph.follows(event.author?.hexadecimalPublicKey) {
+                                eventsFromFollowedAuthors.append(event)
                             }
+                            return eventsFromFollowedAuthors
                         } 
                         .receive(on: DispatchQueue.main)
                         .sink(receiveValue: { [weak self] followedReports in
@@ -145,7 +139,7 @@ extension Publisher {
             .sink { note in
                 Task { @MainActor in 
                     if let authorKey = note?.author?.hexadecimalPublicKey {
-                        self.outOfNetwork = !self.currentUser.socialGraph.contains(authorKey)
+                        self.outOfNetwork = await !self.currentUser.socialGraph.isInNetwork(authorKey)
                     } else {
                         self.outOfNetwork = false
                     }
@@ -168,17 +162,5 @@ extension Publisher {
                 showOutOfNetworkWarning = userDefaults.object(forKey: showOutOfNetworkWarningKey) as? Bool ?? true
             }
             .store(in: &cancellables)
-    }
-    
-    func computeShowWarning() {
-        if userHidWarning {
-            self.showWarning = false
-        } else if showReportWarnings && !(noteReports.isEmpty || !authorReports.isEmpty) {
-            self.showWarning = true
-        } else if shouldHideOutOfNetwork && showOutOfNetworkWarning && outOfNetwork {
-            self.showWarning = true
-        } else {
-            self.showWarning = false
-        }
     }
 }

--- a/Nos/Models/Author+CoreDataClass.swift
+++ b/Nos/Models/Author+CoreDataClass.swift
@@ -16,9 +16,9 @@ enum AuthorError: Error {
 }
 
 @objc(Author)
-public class Author: NosManagedObject {
+@Observable public class Author: NosManagedObject {
     
-    @Dependency(\.currentUser) var currentUser
+    @Dependency(\.currentUser) @ObservationIgnored var currentUser
     
     var npubString: String? {
         publicKey?.npub

--- a/Nos/Models/Event+CoreDataClass.swift
+++ b/Nos/Models/Event+CoreDataClass.swift
@@ -1091,27 +1091,37 @@ public class Event: NosManagedObject {
     
     /// Returns a list of the authors this event was reported by if any of them are followed by the given user.
     /// This isn't very performant so use sparingly.
-    @MainActor func reportingAuthors(followedBy currentUser: CurrentUser) -> [Author] {
-        let events = referencingEvents
+    @MainActor func reportingAuthors(followedBy currentUser: CurrentUser) async -> [Author] {
+        let allReferencingEvents = referencingEvents
             .compactMap { $0.referencingEvent }
-            .filter { (event: Event) in event.kind == EventKind.report.rawValue }
-            .compactMap { $0.author }
-            .filter { currentUser.socialGraph.follows($0.hexadecimalPublicKey) }
-        return events
+        
+        var reportingAuthors = [Author]()
+        for event in allReferencingEvents {
+            let isReportEvent = event.kind == EventKind.report.rawValue
+            let isFollowed = await currentUser.socialGraph.follows(event.author?.hexadecimalPublicKey ?? "")
+            if isReportEvent && isFollowed, let author = event.author {
+                reportingAuthors.append(author)
+            }
+        }
+        return reportingAuthors
     }
     
     /// Returns a list of reports for this event from authors followed by the given user.
     /// This isn't very performant so use sparingly.
     @MainActor
-    func reports(followedBy currentUser: CurrentUser) -> [Event] {
-        let reportEvents = referencingEvents
+    func reports(followedBy currentUser: CurrentUser) async -> [Event] {
+        let allReferencingEvents = referencingEvents
             .compactMap { $0.referencingEvent }
-            .filter { event in
-                let isReportEvent = event.kind == EventKind.report.rawValue
-                let isFollowed = currentUser.socialGraph.follows(event.author?.hexadecimalPublicKey ?? "")
-                return isReportEvent && isFollowed
+        
+        var followedReportEvents = [Event]()
+        for event in allReferencingEvents {
+            let isReportEvent = event.kind == EventKind.report.rawValue
+            let isFollowed = await currentUser.socialGraph.follows(event.author?.hexadecimalPublicKey ?? "")
+            if isReportEvent && isFollowed {
+                followedReportEvents.append(event)
             }
-        return reportEvents
+        }
+        return followedReportEvents
     }
 }
 // swiftlint:enable type_body_length

--- a/Nos/Models/Event+CoreDataClass.swift
+++ b/Nos/Models/Event+CoreDataClass.swift
@@ -131,14 +131,18 @@ public class Event: NosManagedObject {
         "npub12hcytyr8fumy3axde8wgeced523gyp6v6zczqktwuqeaztfc2xzsz3rdp4": ["NoGood"],
         "npub1l9kr6ajfwp6vfjp60vuzxwqwwlw884dff98a9cznujs520shsf9s35xfwh": ["Karine"],
         "npub1rfdkj37rhymcrr5jk9jjaae5c3yj8l24jtr8a27q0chh2y2aq42snhh53u": ["eolaí"],
-        "npub17amtesfzwxl8nlr3ke2l8jl7kw52z60n8msnxh7vps3g9xgpmf9qx5nldk": ["Malos10"],
         "npub1uch5rxswzes8h9hlzrktqqjf4a75k6w86ys7fvzpxrrpejvccvhq4sl7fj": ["muneomi"],
         "npub1p458ltjfrxmcymk4j3plsmsksaqsf62cggdqvhv9cphk0wdglzts80t20a": ["Adhhafi"],
         "npub19mduaf5569jx9xz555jcx3v06mvktvtpu0zgk47n4lcpjsz43zzqhj6vzk": ["Nostr Report"],
         "npub15c7vxfun6g3450qpvx4pt68mf90t3fc08rd3nc5ldhfz6af60m5qftlahr": ["Matt Cengia"],
         "npub1erhg86xl307d46pla66aycr6sjpy9esnrffysr98l5pjvt2fdgeq8wru26": ["farfallica"],
         "npub12h5xc0usentknjnldce6a80tq0m475u6ucgwhlk2zsfqax3x94fsmx0rvt": ["Weisheiten"],
-        "npub166l9t9ckan9yh6j8pku0stszkekt0s8uhqwvddz4qr92r9w0wxcs59u7c3": ["taylan"]
+        "npub166l9t9ckan9yh6j8pku0stszkekt0s8uhqwvddz4qr92r9w0wxcs59u7c3": ["taylan"],
+        "npub1pmwz736ys3mfhjdld4r36xqwfc5qkz7dwxdkmfu3qqd7kucvludsrm4nu6": ["lizsweig"],
+        "npub1zwulrffp23wle3tl25dt0jr2q376k0k8vhe9xzjl5jnxnag5tc2sr2hjds": ["Love of Nature"],
+        "npub1ylccvgzdlan2vyh4snx9u8kjpk8580tm2ecxmvv72mzem3xevt9qw0z7ks": ["Elon Musk's Jet"],
+        "npub1lunaq893u4hmtpvqxpk8hfmtkqmm7ggutdtnc4hyuux2skr4ttcqr827lj": ["Stuart Bowman"],
+        "npub1c878wu04lfqcl5avfy3p5x83ndpvedaxv0dg7pxthakq3jqdyzcs2n8avm": ["Ben Arc"],
     ]
     
     // MARK: - Fetching
@@ -166,7 +170,7 @@ public class Event: NosManagedObject {
         guard let currentUser = currentUser.author else {
             return NSPredicate.false
         }
-        let featuredPredicate = NSPredicate(
+        return NSPredicate(
             format: "kind IN %@ AND eventReferences.@count = 0 AND author.hexadecimalPublicKey IN %@ " +
                 "AND NOT author IN %@.follows.destination AND NOT author = %@ AND receivedAt <= %@ AND " +
                 "author.muted = false AND deletedOn.@count = 0",
@@ -178,21 +182,6 @@ public class Event: NosManagedObject {
             currentUser,
             before as CVarArg
         )
-        
-        let twoHopsPredicate = NSPredicate(
-            format: "kind IN %@ AND eventReferences.@count = 0 AND author.muted = false " +
-                "AND ANY author.followers.source IN %@.follows.destination AND NOT author IN %@.follows.destination " +
-                "AND receivedAt <= %@ AND deletedOn.@count = 0",
-            discoverKinds.map { $0.rawValue },
-            currentUser,
-            currentUser,
-            before as CVarArg
-        )
-
-        return NSCompoundPredicate(orPredicateWithSubpredicates: [
-            featuredPredicate,
-            twoHopsPredicate
-        ])
     }
     
     @nonobjc public class func seen(on relay: Relay, before: Date, exceptFrom author: Author?) -> NSPredicate {

--- a/Nos/Service/CurrentUser.swift
+++ b/Nos/Service/CurrentUser.swift
@@ -421,7 +421,7 @@ enum CurrentUserError: Error {
 
         Log.debug("Following \(followKey)")
 
-        var followKeys = Array(socialGraph.followedKeys)
+        var followKeys = await Array(socialGraph.followedKeys)
         followKeys.append(followKey)
         
         // Update author to add the new follow
@@ -449,7 +449,7 @@ enum CurrentUserError: Error {
 
         Log.debug("Unfollowing \(unfollowedKey)")
         
-        let stillFollowingKeys = Array(socialGraph.followedKeys)
+        let stillFollowingKeys = await Array(socialGraph.followedKeys)
             .filter { $0 != unfollowedKey }
         
         // Update author to only follow those still following

--- a/Nos/Service/CurrentUser.swift
+++ b/Nos/Service/CurrentUser.swift
@@ -421,7 +421,7 @@ enum CurrentUserError: Error {
 
         Log.debug("Following \(followKey)")
 
-        var followKeys = socialGraph.followedKeys
+        var followKeys = Array(socialGraph.followedKeys)
         followKeys.append(followKey)
         
         // Update author to add the new follow
@@ -449,7 +449,7 @@ enum CurrentUserError: Error {
 
         Log.debug("Unfollowing \(unfollowedKey)")
         
-        let stillFollowingKeys = socialGraph.followedKeys
+        let stillFollowingKeys = Array(socialGraph.followedKeys)
             .filter { $0 != unfollowedKey }
         
         // Update author to only follow those still following

--- a/Nos/Service/CurrentUser.swift
+++ b/Nos/Service/CurrentUser.swift
@@ -102,7 +102,7 @@ enum CurrentUserError: Error {
         super.init()
         self.viewContext = persistenceController.viewContext
         self.backgroundContext = persistenceController.newBackgroundContext()
-        self.socialGraph = SocialGraphCache(userKey: nil, context: backgroundContext)
+        self.socialGraph = SocialGraphCache(userKey: nil, context: persistenceController.newBackgroundContext())
         if let privateKeyData = KeyChain.load(key: KeyChain.keychainPrivateKey) {
             Log.info("CurrentUser loaded a private key from keychain")
             let hexString = String(decoding: privateKeyData, as: UTF8.self)

--- a/Nos/Service/SocialGraphCache.swift
+++ b/Nos/Service/SocialGraphCache.swift
@@ -8,26 +8,61 @@
 import Foundation
 import CoreData
 import Logger
+import UIKit
 
 /// A representation of the people a given user follows and the people they follow designed to cache this data in 
 /// memory and make it cheap to access. This class watches the database for changes to the social graph and updates 
 /// itself accordingly.
-@Observable class SocialGraphCache: NSObject, NSFetchedResultsControllerDelegate {
+actor SocialGraphCache: NSObject, NSFetchedResultsControllerDelegate {
     
     // MARK: Public interface 
     
-    var followedKeys: Set<HexadecimalString> {
-        get {
-            oneHopKeys
-        }
-    }
+    private(set) var followedKeys = Set<HexadecimalString>()
     
-    func contains(_ key: HexadecimalString?) -> Bool {
+    func isInNetwork(_ key: HexadecimalString?) -> Bool {
         guard let key, let userKey else {
             return false
         }
         
-        return twoHopKeys.contains(key) || oneHopKeys.contains(key) || userKey == key
+        if followedKeys.contains(key) || twoHopKeys.contains(key) {
+            Log.debug("cache hit: inNetwork")
+            return true
+        }
+        
+        if outOfNetworkKeys.contains(key) {
+            Log.debug("cache hit: outOfNetwork")
+            return false
+        }
+        
+        // We haven't cached this key. Make a db request
+        Log.debug("cache miss")
+        do {
+            let inNetwork = try context.performAndWait {
+                guard let currentUser = try Author.find(by: userKey, context: context),
+                    let author = try Author.find(by: key, context: context) else {
+                    outOfNetworkKeys.insert(key)
+                    return false
+                }
+                let fetchRequest = NSFetchRequest<Author>(entityName: "Author")
+                fetchRequest.predicate = NSPredicate(
+                    format: "ANY %@.follows.destination.follows = %@",
+                    currentUser,
+                    author
+                )
+                return try context.count(for: fetchRequest) > 0
+            }
+            
+            if inNetwork {
+                twoHopKeys.insert(key)
+            } else {
+                outOfNetworkKeys.insert(key)
+            }
+            
+            return inNetwork
+        } catch {
+            Log.optional(error, "Could not figure out if \(key) is inNetwork")
+            return false
+        }
     }
     
     func follows(_ key: HexadecimalString?) -> Bool {
@@ -35,7 +70,7 @@ import Logger
             return false
         }
         
-        return oneHopKeys.contains(key) || userKey == key
+        return followedKeys.contains(key) || userKey == key
     }
     
     // MARK: - Private properties
@@ -44,123 +79,91 @@ import Logger
     private let context: NSManagedObjectContext
     
     private var userWatcher: NSFetchedResultsController<Author>?
-    private var oneHopWatcher: NSFetchedResultsController<Author>?
+    private var twoHopKeys = Set<HexadecimalString>()
+    private var outOfNetworkKeys = Set<HexadecimalString>()
     
-    private(set) var oneHopKeys: Set<HexadecimalString>
-    private(set) var twoHopKeys: Set<HexadecimalString>
+    // MARK: - Setup
     
-    private var twoHopReferences: [HexadecimalString: Int]
-
     init(userKey: HexadecimalString?, context: NSManagedObjectContext) {
         self.userKey = userKey
         self.context = context
-        self.oneHopKeys = Set()
-        self.twoHopKeys = Set()
-        self.twoHopReferences = [:]
+        super.init()
         
-        guard let userKey else {
-            super.init()
-            return
+        Task {
+            await initializeFollowList()
         }
         
-        super.init()
-
-        let startDate = Date.now
-        Task(priority: .utility) {
-            do {
-                try await context.perform {
-                    let user = try Author.findOrCreate(by: userKey, context: context)
-                    self.oneHopKeys.insert(userKey)
-                    self.userWatcher = NSFetchedResultsController(
-                        fetchRequest: Author.request(by: userKey),
-                        managedObjectContext: context,
-                        sectionNameKeyPath: nil,
-                        cacheName: "SocialGraphCache.userWatcher"
-                    )
-                    self.oneHopWatcher = NSFetchedResultsController(
-                        fetchRequest: Author.oneHopRequest(for: user),
-                        managedObjectContext: context,
-                        sectionNameKeyPath: nil,
-                        cacheName: "SocialGraphCache.oneHopWatcher"
-                    )
-                }
-            } catch {
-                Log.error(error.localizedDescription)
-            }
-            
-            userWatcher?.delegate = self
-            oneHopWatcher?.delegate = self
-            do {
-                try self.userWatcher?.performFetch()
-                try self.oneHopWatcher?.performFetch()
-                await context.perform {
-                    self.oneHopWatcher?.fetchedObjects?.forEach { author in
-                        guard let followedKey = author.hexadecimalPublicKey else {
-                            return
-                        }
-                        let twoHopsKeys = author.followedKeys
-                        self.process(user: userKey, followed: followedKey, whoFollows: twoHopsKeys)
-                    }
-                }
-            } catch {
-                Log.error(error.localizedDescription)
-                return
-            }
-            
-            let elapsedTime = Date.now.timeIntervalSince1970 - startDate.timeIntervalSince1970 
-            Log.info("Finished SocialGraphCache init in \(elapsedTime) seconds.")
+        Task { @MainActor in
+            NotificationCenter.default.addObserver(
+                self, 
+                selector: #selector(didReceiveMemoryWarning), 
+                name: UIApplication.didReceiveMemoryWarningNotification, 
+                object: nil
+            )
         }
     }
     
-    // MARK: - Processing Changes
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
     
-    /// Takes an author that the `user` has followed and updates our cache of one-hop and two-hop authors appropriately.
+    @objc nonisolated func didReceiveMemoryWarning() {
+        Task {
+            await clearCache()
+        }
+    }
+    
+    // MARK: - Processing changes
+    
+    func clearCache() {
+        twoHopKeys.removeAll()
+        outOfNetworkKeys.removeAll()
+    }
+    
+    func initializeFollowList() async {
+        guard let userKey else {
+            return
+        }
+        let startDate = Date.now
+        
+        await context.perform {
+            let authorRequest = Author.request(by: userKey) 
+            authorRequest.relationshipKeyPathsForPrefetching = ["follows.destination.hexadecimalPublicKey"]
+            self.userWatcher = NSFetchedResultsController(
+                fetchRequest: authorRequest,
+                managedObjectContext: self.context,
+                sectionNameKeyPath: nil,
+                cacheName: "SocialGraphCache.userWatcher"
+            )
+        }
+        
+        userWatcher?.delegate = self
+        do {
+            try self.userWatcher?.performFetch()
+        } catch {
+            Log.error(error.localizedDescription)
+            return
+        }
+        
+        let elapsedTime = Date.now.timeIntervalSince1970 - startDate.timeIntervalSince1970 
+        Log.info("Finished SocialGraphCache init in \(elapsedTime) seconds.")
+    }
+    
+    /// Takes the new set of authors that the `user` has followed and updates our cache appropriately.
     /// - Parameters:
     ///   - user: the key of the user at the center of the social graph  
     ///   - followedKey: the key of the author the user has followed
     ///   - follows: the keys of the authors `followedKey` has followed
     private func process(
         user: HexadecimalString,
-        followed followedKey: HexadecimalString, 
-        whoFollows follows: [HexadecimalString]
+        followed newFollowedKeys: Set<HexadecimalString>
     ) {
-        Log.debug("\(user) followed \(followedKey) whoFollows \(follows.count)")
-        let oneHopKeysCount = oneHopKeys.count
-        let twoHopKeysCount = twoHopKeys.count
-        
-        oneHopKeys.insert(followedKey)
-        follows.forEach { followedKey in
-            twoHopKeys.insert(followedKey)
-            var referenceCount = twoHopReferences[followedKey] ?? 0
-            referenceCount += 1
-            twoHopReferences[followedKey] = referenceCount
+        let unfollowedKeys = followedKeys.subtracting(newFollowedKeys)
+        if !unfollowedKeys.isEmpty {
+            clearCache()
         }
-        Log.debug("\(oneHopKeys.count) one hop keys and \(twoHopKeys.count) two hop keys in cache")
-    }
-    
-    /// Takes an author that the `user` has unfollowed and updates our cache of one-hop and two-hop 
-    /// authors appropriately.
-    /// - Parameters:
-    ///   - user: the key of the user at the center of the social graph  
-    ///   - unfollowedKey: the key of the author the user has unfollowed
-    ///   - follows: the keys of the authors `unfollowedKey` has followed
-    private func process(
-        user: HexadecimalString,
-        unfollowed unfollowedKey: HexadecimalString, 
-        whoFollows follows: [HexadecimalString]
-    ) {
-        Log.debug("\(user) unfollowed \(unfollowedKey) whoFollows \(follows.count)")
-        let oneHopKeysCount = oneHopKeys.count
-        let twoHopKeysCount = twoHopKeys.count
-        
-        oneHopKeys.remove(unfollowedKey)
-        follows.forEach { followedKey in
-            let referenceCount = twoHopReferences[followedKey] ?? 1
-            if referenceCount <= 1 {
-                twoHopKeys.remove(followedKey)
-                twoHopReferences.removeValue(forKey: followedKey)
-            }
-        }
+        followedKeys = newFollowedKeys
+        outOfNetworkKeys = outOfNetworkKeys.subtracting(newFollowedKeys)
     }
     
     // MARK: - NSFetchedResultsControllerDelegate
@@ -172,32 +175,12 @@ import Logger
         for type: NSFetchedResultsChangeType, 
         newIndexPath: IndexPath?
     ) {
-        guard let userKey, 
-            let changedAuthor = anObject as? Author,
-            let authorKey = changedAuthor.hexadecimalPublicKey else {
+        guard let userKey, let changedAuthor = anObject as? Author else {
             return
         }
-        let twoHopsKeys = changedAuthor.followedKeys
-        
-        if controller === self.oneHopWatcher {
-            switch type {
-            case .insert:
-                self.process(user: userKey, followed: authorKey, whoFollows: twoHopsKeys)
-            case .delete:
-                self.process(user: userKey, unfollowed: authorKey, whoFollows: twoHopsKeys)
-            case .update:
-                //self.process(user: userKey, unfollowed: authorKey, whoFollows: twoHopsKeys)
-                //self.process(user: userKey, followed: authorKey, whoFollows: twoHopsKeys)
-                return
-            case .move:
-                return
-            @unknown default:
-                return
-            }
-        } else if controller === self.userWatcher {
-            twoHopsKeys.forEach {
-                self.process(user: authorKey, followed: $0, whoFollows: [])
-            }
+        let newFollowedKeys = Set(changedAuthor.followedKeys)
+        Task {
+            await process(user: userKey, followed: newFollowedKeys)
         }
     }
 }

--- a/Nos/Service/SocialGraphCache.swift
+++ b/Nos/Service/SocialGraphCache.swift
@@ -45,9 +45,8 @@ actor SocialGraphCache: NSObject, NSFetchedResultsControllerDelegate {
                 }
                 let fetchRequest = NSFetchRequest<Author>(entityName: "Author")
                 fetchRequest.predicate = NSPredicate(
-                    format: "ANY %@.follows.destination.follows = %@",
-                    currentUser,
-                    author
+                    format: "ANY followers.source IN %@.follows.destination",
+                    currentUser
                 )
                 return try context.count(for: fetchRequest) > 0
             }
@@ -79,6 +78,7 @@ actor SocialGraphCache: NSObject, NSFetchedResultsControllerDelegate {
     private let context: NSManagedObjectContext
     
     private var userWatcher: NSFetchedResultsController<Author>?
+    private var oneHopWatcher: NSFetchedResultsController<Author>?
     private var twoHopKeys = Set<HexadecimalString>()
     private var outOfNetworkKeys = Set<HexadecimalString>()
     
@@ -127,20 +127,30 @@ actor SocialGraphCache: NSObject, NSFetchedResultsControllerDelegate {
         let startDate = Date.now
         followedKeys.insert(userKey)
         
-        await context.perform {
-            let authorRequest = Author.request(by: userKey) 
-            authorRequest.relationshipKeyPathsForPrefetching = ["follows.destination.hexadecimalPublicKey"]
-            self.userWatcher = NSFetchedResultsController(
-                fetchRequest: authorRequest,
-                managedObjectContext: self.context,
-                sectionNameKeyPath: nil,
-                cacheName: "SocialGraphCache.userWatcher"
-            )
-        }
-        
-        userWatcher?.delegate = self
         do {
+            try await context.perform {
+                let authorRequest = Author.request(by: userKey) 
+                authorRequest.relationshipKeyPathsForPrefetching = ["follows.destination.hexadecimalPublicKey"]
+                self.userWatcher = NSFetchedResultsController(
+                    fetchRequest: authorRequest,
+                    managedObjectContext: self.context,
+                    sectionNameKeyPath: nil,
+                    cacheName: "SocialGraphCache.userWatcher"
+                )
+                if let user = try Author.find(by: userKey, context: self.context) {
+                    self.oneHopWatcher = NSFetchedResultsController(
+                        fetchRequest: Author.oneHopRequest(for: user),
+                        managedObjectContext: self.context,
+                        sectionNameKeyPath: nil,
+                        cacheName: "SocialGraphCache.oneHopWatcher"
+                    )
+                }
+            }
+            
+            userWatcher?.delegate = self
+            oneHopWatcher?.delegate = self
             try self.userWatcher?.performFetch()
+            try self.oneHopWatcher?.performFetch()
             if let author = self.userWatcher?.fetchedObjects?.first {
                 process(user: userKey, followed: Set(author.followedKeys))
             }
@@ -171,6 +181,14 @@ actor SocialGraphCache: NSObject, NSFetchedResultsControllerDelegate {
         outOfNetworkKeys = outOfNetworkKeys.subtracting(newFollowedKeys)
     }
     
+    private func process(
+        followedAuthor: HexadecimalString,
+        followed newFollowedKeys: Set<HexadecimalString>
+    ) async {
+        outOfNetworkKeys.subtract(newFollowedKeys)
+        twoHopKeys.formUnion(newFollowedKeys)
+    }
+    
     // MARK: - NSFetchedResultsControllerDelegate
     
     nonisolated func controller(
@@ -180,12 +198,19 @@ actor SocialGraphCache: NSObject, NSFetchedResultsControllerDelegate {
         for type: NSFetchedResultsChangeType, 
         newIndexPath: IndexPath?
     ) {
-        guard let userKey, let changedAuthor = anObject as? Author else {
+        guard let userKey, 
+            let changedAuthor = anObject as? Author, 
+            let changedAuthorKey = changedAuthor.hexadecimalPublicKey else {
             return
         }
         let newFollowedKeys = Set(changedAuthor.followedKeys)
+        
         Task {
-            await process(user: userKey, followed: newFollowedKeys)
+            if await controller === self.oneHopWatcher {
+                await process(followedAuthor: changedAuthorKey, followed: newFollowedKeys)
+            } else if await controller === self.userWatcher {
+                await process(user: userKey, followed: newFollowedKeys)
+            }
         }
     }
 }

--- a/Nos/Service/SocialGraphCache.swift
+++ b/Nos/Service/SocialGraphCache.swift
@@ -125,6 +125,7 @@ actor SocialGraphCache: NSObject, NSFetchedResultsControllerDelegate {
             return
         }
         let startDate = Date.now
+        followedKeys.insert(userKey)
         
         await context.perform {
             let authorRequest = Author.request(by: userKey) 
@@ -140,6 +141,9 @@ actor SocialGraphCache: NSObject, NSFetchedResultsControllerDelegate {
         userWatcher?.delegate = self
         do {
             try self.userWatcher?.performFetch()
+            if let author = self.userWatcher?.fetchedObjects?.first {
+                process(user: userKey, followed: Set(author.followedKeys))
+            }
         } catch {
             Log.error(error.localizedDescription)
             return
@@ -163,6 +167,7 @@ actor SocialGraphCache: NSObject, NSFetchedResultsControllerDelegate {
             clearCache()
         }
         followedKeys = newFollowedKeys
+        followedKeys.insert(user)
         outOfNetworkKeys = outOfNetworkKeys.subtracting(newFollowedKeys)
     }
     

--- a/Nos/Service/SocialGraphCache.swift
+++ b/Nos/Service/SocialGraphCache.swift
@@ -45,7 +45,8 @@ actor SocialGraphCache: NSObject, NSFetchedResultsControllerDelegate {
                 }
                 let fetchRequest = NSFetchRequest<Author>(entityName: "Author")
                 fetchRequest.predicate = NSPredicate(
-                    format: "ANY followers.source IN %@.follows.destination",
+                    format: "hexadecimalPublicKey = %@ AND ANY followers.source IN %@.follows.destination",
+                    key,
                     currentUser
                 )
                 return try context.count(for: fetchRequest) > 0

--- a/Nos/Views/DiscoverView.swift
+++ b/Nos/Views/DiscoverView.swift
@@ -17,7 +17,6 @@ struct DiscoverView: View {
     @Environment(Router.self) var router
     @Environment(CurrentUser.self) var currentUser
     @Dependency(\.analytics) private var analytics
-    @State private var lastRequestDate: Date?
 
     @State var showRelayPicker = false
     
@@ -59,7 +58,7 @@ struct DiscoverView: View {
             // TODO: Use a since filter
             let singleRelayFilter = Filter(
                 kinds: [.text, .delete],
-                limit: 100
+                limit: 200
             )
             
             subscriptionIDs.append(
@@ -67,40 +66,15 @@ struct DiscoverView: View {
                 await relayService.openSubscription(with: singleRelayFilter, to: [relayAddress])
             )
         } else {
-            
-            var fetchSinceDate: Date?
-            // Make sure the lastRequestDate was more than a minute ago
-            // to make sure we got all the events from it.
-            if let lastRequestDate {
-                if lastRequestDate.distance(to: .now) > 60 {
-                    fetchSinceDate = lastRequestDate
-                    self.lastRequestDate = Date.now
-                }
-            } else {
-                self.lastRequestDate = Date.now
-            }
-            
             let featuredFilter = Filter(
                 authorKeys: featuredAuthors.compactMap {
                     PublicKey(npub: $0)?.hex
                 },
                 kinds: [.text, .delete],
-                limit: 50,
-                since: fetchSinceDate
+                limit: 200
             )
             
             subscriptionIDs.append(await relayService.openSubscription(with: featuredFilter))
-            
-            // this filter just requests everything for now, because I think requesting all the authors within
-            // two hops is too large of a request and causes the websocket to close.
-            let twoHopsFilter = Filter(
-                kinds: Event.discoverKinds,
-                inNetwork: true,
-                limit: 200,
-                since: fetchSinceDate
-            )
-            
-            subscriptionIDs.append(await relayService.openSubscription(with: twoHopsFilter))
         }
     }
     

--- a/Nos/Views/HomeFeedView.swift
+++ b/Nos/Views/HomeFeedView.swift
@@ -52,7 +52,7 @@ struct HomeFeedView: View {
     func subscribeToNewEvents() async {
         await cancelSubscriptions()
         
-        let followedKeys = Array(currentUser.socialGraph.followedKeys)
+        let followedKeys = await Array(currentUser.socialGraph.followedKeys)
             
         if !followedKeys.isEmpty {
             // TODO: we could miss events with this since filter
@@ -207,16 +207,6 @@ struct HomeFeedView: View {
             if isShowingStories {
                 selectedStoryAuthor = nil
             }
-        }
-        .task {
-            currentUser.socialGraph.followedKeys.publisher
-                .removeDuplicates()
-                .debounce(for: 0.2, scheduler: RunLoop.main)
-                .filter { _ in self.isVisible == true }
-                .sink(receiveValue: { _ in
-                    Task { await subscribeToNewEvents() }
-                })
-                .store(in: &cancellables)
         }
     }
 }

--- a/Nos/Views/HomeFeedView.swift
+++ b/Nos/Views/HomeFeedView.swift
@@ -52,7 +52,7 @@ struct HomeFeedView: View {
     func subscribeToNewEvents() async {
         await cancelSubscriptions()
         
-        let followedKeys = currentUser.socialGraph.followedKeys 
+        let followedKeys = Array(currentUser.socialGraph.followedKeys)
             
         if !followedKeys.isEmpty {
             // TODO: we could miss events with this since filter

--- a/Nos/Views/NoteCard.swift
+++ b/Nos/Views/NoteCard.swift
@@ -24,7 +24,6 @@ struct NoteCard: View {
     @State private var userTappedShowOutOfNetwork = false
     @State private var replyCount = 0
     @State private var replyAvatarURLs = [URL]()
-    @State private var reportingAuthors = [Author]()
     @State private var reports = [Event]()
     @State private var warningController = NoteWarningController()
     
@@ -149,8 +148,6 @@ struct NoteCard: View {
             if note.isStub {
                 _ = await relayService.requestEvent(with: note.identifier)
             } 
-            self.reportingAuthors = note.reportingAuthors(followedBy: currentUser)
-            // print(self.reportingAuthors)
         }
         .onAppear {
             Task(priority: .userInitiated) {

--- a/Nos/Views/RelayView.swift
+++ b/Nos/Views/RelayView.swift
@@ -172,7 +172,7 @@ struct RelayView: View {
     }
     
     func publishChanges() async {
-        let followKeys = currentUser.socialGraph.followedKeys 
+        let followKeys = Array(currentUser.socialGraph.followedKeys)
         await currentUser.publishContactList(tags: followKeys.pTags)
     }
 

--- a/Nos/Views/RelayView.swift
+++ b/Nos/Views/RelayView.swift
@@ -172,7 +172,7 @@ struct RelayView: View {
     }
     
     func publishChanges() async {
-        let followKeys = Array(currentUser.socialGraph.followedKeys)
+        let followKeys = await Array(currentUser.socialGraph.followedKeys)
         await currentUser.publishContactList(tags: followKeys.pTags)
     }
 

--- a/NosTests/SocialGraphTests.swift
+++ b/NosTests/SocialGraphTests.swift
@@ -32,12 +32,11 @@ final class SocialGraphTests: XCTestCase {
         _ = try Author.findOrCreate(by: KeyFixture.alice.publicKeyHex, context: testContext)
         
         // Act
-        let sut = await SocialGraphCache(userKey: KeyFixture.alice.publicKeyHex, context: testContext)
+        let sut = SocialGraphCache(userKey: KeyFixture.alice.publicKeyHex, context: testContext)
         try testContext.save()
         
         // Assert
-        let followedKeys = await sut.followedKeys
-        XCTAssertEqual(followedKeys, [KeyFixture.alice.publicKeyHex])
+        try await eventually { await sut.followedKeys == Set([KeyFixture.alice.publicKeyHex]) }
     }
     
     func testOneFollower() async throws {
@@ -52,17 +51,14 @@ final class SocialGraphTests: XCTestCase {
         
         // Add to the current user's follows
         alice.follows.insert(follow)
-        
-        // Add from the current user to the author's followers
-        bob.followers.insert(follow)
-        
-        // Act
-        let sut = await SocialGraphCache(userKey: KeyFixture.alice.publicKeyHex, context: testContext)
         try testContext.save()
         
+        // Act
+        let sut = SocialGraphCache(userKey: KeyFixture.alice.publicKeyHex, context: testContext)
+        
         // Assert
-        let followedKeys = await sut.followedKeys
-        XCTAssertEqual(followedKeys, [KeyFixture.alice.publicKeyHex, KeyFixture.bob.publicKeyHex])
+        let expectedKeys = Set([KeyFixture.alice.publicKeyHex, KeyFixture.bob.publicKeyHex])
+        try await eventually { return await sut.followedKeys == expectedKeys }
     }
     
     func testFollow() async throws {
@@ -71,7 +67,7 @@ final class SocialGraphTests: XCTestCase {
         let bob = try Author.findOrCreate(by: KeyFixture.bob.publicKeyHex, context: testContext)
         
         // Act
-        let sut = await SocialGraphCache(userKey: KeyFixture.alice.publicKeyHex, context: testContext)
+        let sut = SocialGraphCache(userKey: KeyFixture.alice.publicKeyHex, context: testContext)
         try testContext.save()
         
         // Assert
@@ -85,9 +81,8 @@ final class SocialGraphTests: XCTestCase {
         try testContext.save()
         
         // Reassert
-        try await eventually { await sut.followedKeys.count == 2 }
-        let newFollowedKeys = await sut.followedKeys
-        XCTAssertEqual(newFollowedKeys, [KeyFixture.alice.publicKeyHex, KeyFixture.bob.publicKeyHex])
+        let expectedKeys = Set([KeyFixture.alice.publicKeyHex, KeyFixture.bob.publicKeyHex])
+        try await eventually { await sut.followedKeys == expectedKeys }
     }
     
     func testTwoFollows() async throws {
@@ -116,14 +111,13 @@ final class SocialGraphTests: XCTestCase {
         try testContext.save()
         
         // Reassert
-        try await eventually { await sut.followedKeys.count == 3 }
-        let newFollowedKeys = await sut.followedKeys.sorted()
-        let expected = [
+        
+        let expectedKeys = Set([
             KeyFixture.alice.publicKeyHex,
             KeyFixture.eve.publicKeyHex,
             KeyFixture.bob.publicKeyHex
-        ].sorted()
-        XCTAssertEqual(newFollowedKeys, expected)
+        ])
+        try await eventually { await sut.followedKeys == expectedKeys }
     }
 }
 // swiftlint:enable implicitly_unwrapped_optional

--- a/NosTests/SocialGraphTests.swift
+++ b/NosTests/SocialGraphTests.swift
@@ -58,7 +58,7 @@ final class SocialGraphTests: XCTestCase {
         
         // Assert
         let expectedKeys = Set([KeyFixture.alice.publicKeyHex, KeyFixture.bob.publicKeyHex])
-        try await eventually { return await sut.followedKeys == expectedKeys }
+        try await eventually { await sut.followedKeys == expectedKeys }
     }
     
     func testFollow() async throws {
@@ -92,7 +92,7 @@ final class SocialGraphTests: XCTestCase {
         let eve = try Author.findOrCreate(by: KeyFixture.eve.publicKeyHex, context: testContext)
         
         // Act
-        let sut = await SocialGraphCache(userKey: KeyFixture.alice.publicKeyHex, context: testContext)
+        let sut = SocialGraphCache(userKey: KeyFixture.alice.publicKeyHex, context: testContext)
         try testContext.save()
         
         // Assert

--- a/NosTests/SocialGraphTests.swift
+++ b/NosTests/SocialGraphTests.swift
@@ -156,5 +156,28 @@ final class SocialGraphTests: XCTestCase {
         try await eventually { await sut.followedKeys == expectedKeys }
         try await eventually { await sut.isInNetwork(KeyFixture.eve.publicKeyHex) }
     }
+    
+    func testOutOfNetwork() async throws {
+        // Arrange
+        let alice = try Author.findOrCreate(by: KeyFixture.alice.publicKeyHex, context: testContext)
+        let bob = try Author.findOrCreate(by: KeyFixture.bob.publicKeyHex, context: testContext)
+        let eve = try Author.findOrCreate(by: KeyFixture.eve.publicKeyHex, context: testContext)
+        
+        // Act
+        let sut = SocialGraphCache(userKey: KeyFixture.alice.publicKeyHex, context: testContext)
+        try testContext.save()
+        
+        // Assert
+        // assert twice for each key - first time hits db, second time hits cache
+        var isInNetwwork = await sut.isInNetwork(KeyFixture.eve.publicKeyHex)
+        XCTAssertFalse(isInNetwwork)
+        isInNetwwork = await sut.isInNetwork(KeyFixture.eve.publicKeyHex)
+        XCTAssertFalse(isInNetwwork)
+        
+        isInNetwwork = await sut.isInNetwork(KeyFixture.bob.publicKeyHex)
+        XCTAssertFalse(isInNetwwork)
+        isInNetwwork = await sut.isInNetwork(KeyFixture.bob.publicKeyHex)
+        XCTAssertFalse(isInNetwwork)
+    }
 }
 // swiftlint:enable implicitly_unwrapped_optional


### PR DESCRIPTION
This fixes some performance issues for people with large two hops social graphs. It closes #675, and makes some major changes to the Discover tab algorithm.

The SocialGraphCache was trying to greedily cache the two hops graph on init. This was too expensive if your two hops graph has 17,000 keys in it like Rabble's. It was also sometimes causing hangs in the app after init when processing changes to the follow graph due to some poor coding on my part.

This changes it's caching strategy so we only greedily cache the people you are following, and we do this off the main thread. For people two hops away we hit the database to determine if they are in network, but we cache the result of that in memory. 

The downside of this more opportunistic caching is that it isn't performant enough to handle the Discover tab firehose. The Discover tab streams in all events from all relays and tries to drop the out of network ones. This means it has to hit the db for thousands of out of network users, and I was seeing some sort of deadlock issue between NSManagedObjectContexts when this happened. I spent some time trying to fix it but decided to try a simpler thing first: changing the Discover tab algorithm. It's been problematic from the start and has only gotten worse as the network and user's social graphs have grown. It's also anecdotally not surfacing content that people are interested it, so it was ripe for disruption anyway. I changed it to just show content from our list of featured users for now. This does not fix #551 or #531. I would like to keep discussing how we can improve the Discover tab experience, but this seems like a good step forward for now.