### PR TITLE
Add option to copy NIP-05 identifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Added the option to copy the NIP-05 identifier when browsing a profile.
 - Fixed a bug where a root note could be rendered as a reply
 - Added the option to copy the text content while browsing a note.
 - Fixed UI bugs when displaying the root note of replies.

--- a/Nos/Views/NIP05View.swift
+++ b/Nos/Views/NIP05View.swift
@@ -41,6 +41,17 @@ struct NIP05View: View {
                 }
                 .font(.claritySubheadline)
                 .multilineTextAlignment(.leading)
+                .contextMenu {
+                    Button {
+                        UIPasteboard.general.string = formattedNIP05
+                    } label: {
+                        Localized.copy.view
+                    }
+                } preview: {
+                    PlainText(formattedNIP05)
+                        .foregroundColor(.primaryTxt)
+                        .padding()
+                }
                 .task(priority: .userInitiated) {
                     if let nip05Identifier = author.nip05,
                         let publicKey = author.publicKey?.hex {


### PR DESCRIPTION
It partially addresses #564 

Given that the copy icon is not ready yet, I'm adding the ability to copy the nip05 identifier by force touching the identifier and selecting the copy option so at least we add this feature in this sprint. We can add the copy icon after it is ready, and that would not invalidate this PR. The combined solution would be remarkably similar to kow Damus allows the user to copy the npub identifier