### PR TITLE
Add analytics to stories

### DIFF
--- a/Nos/Service/Analytics.swift
+++ b/Nos/Service/Analytics.swift
@@ -85,7 +85,29 @@ class Analytics {
     func showedSupport() {
         track("Contact Support Tapped")
     }
-    
+
+    // MARK: - Stories
+
+    func enteredStories() {
+        track("Stories Entered")
+    }
+
+    func closedStories() {
+        track("Stories Closed")
+    }
+
+    func storiesSwitchedToNextUser() {
+        track("Stories Switched To Next User")
+    }
+
+    func openedNoteFromStories() {
+        track("Opened Note From Stories")
+    }
+
+    func openedProfileFromStories() {
+        track("Opened Profile From Stories")
+    }
+
     // MARK: - Actions
     
     func generatedKey() {
@@ -226,7 +248,11 @@ class Analytics {
     func deletedNote() {
         track("Deleted Note")
     }
-    
+
+    func likedNote() {
+        track("Liked Note")
+    }
+
     // MARK: Uploads
     func selectedUploadFromCamera() {
         track("Selected Upload From Camera")

--- a/Nos/Views/AuthorStoryView.swift
+++ b/Nos/Views/AuthorStoryView.swift
@@ -28,7 +28,8 @@ struct AuthorStoryView: View {
 
     @EnvironmentObject private var router: Router
     @EnvironmentObject private var relayService: RelayService
-    
+    @ObservationIgnored @Dependency(\.analytics) private var analytics
+
     init(
         author: Author,
         cutoffDate: Binding<Date>,
@@ -106,6 +107,7 @@ struct AuthorStoryView: View {
                 .padding(.horizontal, 10)
                 Button {
                     router.push(author)
+                    analytics.openedProfileFromStories()
                 } label: {
                     HStack(alignment: .center) {
                         AuthorLabel(author: author)

--- a/Nos/Views/HomeFeedView.swift
+++ b/Nos/Views/HomeFeedView.swift
@@ -202,7 +202,7 @@ struct HomeFeedView: View {
             if newValue {
                 analytics.enteredStories()
             } else {
-                analytics.closedStories(
+                analytics.closedStories()
                 stories = authors.map { $0 }
             }
         }

--- a/Nos/Views/HomeFeedView.swift
+++ b/Nos/Views/HomeFeedView.swift
@@ -16,8 +16,8 @@ struct HomeFeedView: View {
     @EnvironmentObject private var relayService: RelayService
     @EnvironmentObject private var router: Router
     @Environment(CurrentUser.self) var currentUser
-    @Dependency(\.analytics) private var analytics
-    
+    @ObservationIgnored @Dependency(\.analytics) private var analytics
+
     @FetchRequest var events: FetchedResults<Event>
     @FetchRequest private var authors: FetchedResults<Author>
     
@@ -199,7 +199,10 @@ struct HomeFeedView: View {
             }
         }
         .onChange(of: isShowingStories) { _, newValue in
-            if !newValue {
+            if newValue {
+                analytics.enteredStories()
+            } else {
+                analytics.closedStories(
                 stories = authors.map { $0 }
             }
         }

--- a/Nos/Views/LikeButton.swift
+++ b/Nos/Views/LikeButton.swift
@@ -5,6 +5,7 @@
 //  Created by Matthew Lorentz on 4/21/23.
 //
 
+import Dependencies
 import Logger
 import SwiftUI
 
@@ -17,7 +18,8 @@ struct LikeButton: View {
     @EnvironmentObject private var relayService: RelayService
     @Environment(CurrentUser.self) private var currentUser
     @Environment(\.managedObjectContext) private var viewContext
-    
+    @ObservationIgnored @Dependency(\.analytics) private var analytics
+
     internal init(note: Event) {
         self.note = note
         if let noteID = note.identifier {
@@ -111,6 +113,7 @@ struct LikeButton: View {
 
         do {
             try await relayService.publishToAll(event: jsonEvent, signingKey: keyPair, context: viewContext)
+            analytics.likedNote()
         } catch {
             Log.info("Error creating event for like")
         }

--- a/Nos/Views/StoriesView.swift
+++ b/Nos/Views/StoriesView.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import Dependencies
 
 /// Shows a list of authors with stories in a carousel
 struct StoriesView: View {
@@ -25,7 +26,9 @@ struct StoriesView: View {
     @State private var selectedAuthor: Author
 
     @Binding private var cutoffDate: Date
-    
+
+    @ObservationIgnored @Dependency(\.analytics) private var analytics
+
     init(
         cutoffDate: Binding<Date>,
         authors: [Author],
@@ -79,6 +82,7 @@ struct StoriesView: View {
         let nextIndex = authors.index(after: selectedAuthorIndex)
         if let nextAuthor = authors[safe: nextIndex] {
             self.selectedAuthor = nextAuthor
+            analytics.storiesSwitchedToNextUser()
         } else {
             selectedAuthorInStories = nil
             return
@@ -96,6 +100,7 @@ struct StoriesView: View {
         let previousIndex = authors.index(before: selectedAuthorIndex)
         if let previousAuthor = authors[safe: previousIndex] {
             selectedAuthor = previousAuthor
+            analytics.storiesSwitchedToNextUser()
         } else {
             selectedAuthorInStories = nil
             return

--- a/Nos/Views/StoryNoteView.swift
+++ b/Nos/Views/StoryNoteView.swift
@@ -30,6 +30,7 @@ struct StoryNoteView: View {
     @EnvironmentObject private var router: Router
     @Environment(\.managedObjectContext) private var viewContext
     @Dependency(\.persistenceController) private var persistenceController
+    @ObservationIgnored @Dependency(\.analytics) private var analytics
 
     internal init(note: Event, minHeight: CGFloat) {
         self.note = note
@@ -90,6 +91,7 @@ struct StoryNoteView: View {
                 .contentShape(Rectangle())
                 .onTapGesture {
                     router.push(note)
+                    analytics.openedNoteFromStories()
                 }
             VStack {
                 if shouldShowSpacing {


### PR DESCRIPTION
Closes #672 

A discussion is needed on the convenience of tracking the time the user spent using the stories. Do we really need this number? How are we going to use it? What are we going to compare it to?

Tracking the time is not trivial, we need to track when the user switched to another tab or sent the app to the background and evaluate if there are more events we would need to track down and stop the timer accordingly. So I'd like to re-check if we are indeed going to user these times to do something useful before proceeding.

All other events are being tracked