### PR TITLE
Revert creation context in Event and Author

### DIFF
--- a/Nos.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Nos.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -86,8 +86,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/SDWebImage/SDWebImage.git",
       "state" : {
-        "revision" : "36e484b317522667a4b2de9b50daaa01dfa30809",
-        "version" : "5.18.0"
+        "revision" : "1b9a2e902cbde5fdf362faa0f4fd76ea74d74305",
+        "version" : "5.18.5"
       }
     },
     {
@@ -95,8 +95,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/SDWebImage/SDWebImageSwiftUI",
       "state" : {
-        "revision" : "e837c37d45449fbd3b4745c10c5b5274e73edead",
-        "version" : "2.2.3"
+        "revision" : "aee64ef39b570c44ccf0f884c440fc6494a23c76",
+        "version" : "2.2.5"
       }
     },
     {
@@ -113,8 +113,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/getsentry/sentry-cocoa.git",
       "state" : {
-        "revision" : "d062d9b31ccabdec706134f2216476d1996caf11",
-        "version" : "8.10.0"
+        "revision" : "a3e15ba9fd6c8efc6515ad9d6f3337bb2dc2e1e3",
+        "version" : "8.17.0"
       }
     },
     {
@@ -158,8 +158,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections.git",
       "state" : {
-        "revision" : "937e904258d22af6e447a0b72c0bc67583ef64a2",
-        "version" : "1.0.4"
+        "revision" : "a902f1823a7ff3c9ab2fba0f992396b948eda307",
+        "version" : "1.0.5"
       }
     },
     {
@@ -181,6 +181,15 @@
       }
     },
     {
+      "identity" : "swift-http-types",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-http-types",
+      "state" : {
+        "revision" : "99d066e29effa8845e4761dd3f2f831edfdf8925",
+        "version" : "1.0.0"
+      }
+    },
+    {
       "identity" : "swift-log",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log.git",
@@ -194,8 +203,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
       "state" : {
-        "revision" : "3db5c4aeee8100d2db6f1eaf3864afdad5dc68fd",
-        "version" : "2.59.0"
+        "revision" : "702cd7c56d5d44eeba73fdf83918339b26dc855c",
+        "version" : "2.62.0"
       }
     },
     {
@@ -203,8 +212,17 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-extras.git",
       "state" : {
-        "revision" : "fb70a0f5e984f23be48b11b4f1909f3bee016178",
-        "version" : "1.19.1"
+        "revision" : "798c962495593a23fdea0c0c63fd55571d8dff51",
+        "version" : "1.20.0"
+      }
+    },
+    {
+      "identity" : "swift-nio-http2",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-http2.git",
+      "state" : {
+        "revision" : "3bd9004b9d685ed6b629760fc84903e48efec806",
+        "version" : "1.29.0"
       }
     },
     {
@@ -221,8 +239,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-transport-services.git",
       "state" : {
-        "revision" : "e7403c35ca6bb539a7ca353b91cc2d8ec0362d58",
-        "version" : "1.19.0"
+        "revision" : "ebf8b9c365a6ce043bf6e6326a04b15589bd285e",
+        "version" : "1.20.0"
       }
     },
     {

--- a/Nos/Models/Event+CoreDataClass.swift
+++ b/Nos/Models/Event+CoreDataClass.swift
@@ -488,28 +488,11 @@ public class Event: NosManagedObject {
             }
             return existingEvent
         } else {
-            @Dependency(\.crashReporting) var crashReporting
-            @Dependency(\.persistenceController) var persistenceController
-
-            /// Always create events in the creationContext first to make sure we never end up with two identical
-            /// Events in different contexts with the same objectID, because this messes up SwiftUI's observation
-            /// of changes.
-            let creationContext = persistenceController.creationContext
-            let objectID = try creationContext.performAndWait {
-                let event = Event(context: creationContext)
-                event.identifier = jsonEvent.id
-                try creationContext.save()
-                return event.objectID
-            }
-            guard let fetchedEvent = context.object(with: objectID) as? Event else {
-                let error = EventError.coreData
-                crashReporting.report(error)
-                throw error
-            }
-            
-            fetchedEvent.receivedAt = .now
-            try fetchedEvent.hydrate(from: jsonEvent, relay: relay, in: context)
-            return fetchedEvent
+            let event = Event(context: context)
+            event.identifier = jsonEvent.id
+            event.receivedAt = .now
+            try event.hydrate(from: jsonEvent, relay: relay, in: context)
+            return event
         }
     }
     
@@ -524,25 +507,9 @@ public class Event: NosManagedObject {
         if let existingEvent = try context.fetch(Event.event(by: id)).first {
             return existingEvent
         } else {
-            @Dependency(\.crashReporting) var crashReporting
-            @Dependency(\.persistenceController) var persistenceController
-
-            /// Always create events in the creationContext first to make sure we never end up with two identical
-            /// Events in different contexts with the same objectID, because this messes up SwiftUI's observation
-            /// of changes.
-            let creationContext = persistenceController.creationContext
-            let objectID = try creationContext.performAndWait {
-                let event = Event(context: creationContext)
-                event.identifier = id
-                try creationContext.save()
-                return event.objectID
-            }
-            guard let fetchedEvent = context.object(with: objectID) as? Event else {
-                let error = EventError.coreData
-                crashReporting.report(error)
-                throw error
-            }
-            return fetchedEvent
+            let event = Event(context: context)
+            event.identifier = id
+            return event
         }
     }
     

--- a/Nos/Models/Persistence.swift
+++ b/Nos/Models/Persistence.swift
@@ -33,11 +33,6 @@ class PersistenceController {
         container.viewContext
     }
     
-    /// A context to synchronize creation of Events and Authors so we don't end up with duplicates.
-    lazy var creationContext = {
-        newBackgroundContext()
-    }()
-    
     /// A context for parsing Nostr events from relays.
     lazy var parseContext = {
         self.newBackgroundContext()
@@ -86,7 +81,6 @@ class PersistenceController {
         }
         setUp()
         viewContext.reset()
-        creationContext = newBackgroundContext()
         backgroundViewContext = newBackgroundContext()
         parseContext = newBackgroundContext()
     }


### PR DESCRIPTION
This reverts the fix I made in #632 because it is causing the database to deadlock. I tried finding a better solution but I'm out of ideas right now. I think deadlock is worse than the bug #632 fixed, which was mainly linked notes sometimes failing to load. I opened #697 to pick it back up in the future.