### PR TITLE
Fix profile pictures not loading after creating a new account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Fix profile pictures not loading after creating a new account.
+
 ## [0.1 (98)] - 2023-12-04Z
 
 - Fixed a bug where the app could become unresponsive.

--- a/Nos/Service/CurrentUser.swift
+++ b/Nos/Service/CurrentUser.swift
@@ -185,20 +185,7 @@ enum CurrentUserError: Error {
         guard let key = publicKeyHex, let author else {
             return
         }
-        
-        let overrideRelays: [URL]?
-        let userRelays = author.relays 
-        if userRelays.isEmpty {
-            overrideRelays = Relay.allKnown
-                .compactMap {
-                    try? Relay.findOrCreate(by: $0, context: viewContext)
-                }
-                .compactMap { $0.addressURL }
-            try? viewContext.saveIfNeeded()
-        } else {
-            overrideRelays = nil
-        }
-        
+       
         // Close out stale requests
         if !subscriptions.isEmpty {
             await relayService.decrementSubscriptionCount(for: subscriptions)
@@ -214,10 +201,10 @@ enum CurrentUserError: Error {
         let contactFilter = Filter(
             authorKeys: [key],
             kinds: [.contactList],
-            limit: 1,
+            limit: 2,
             since: author.lastUpdatedContactList
         )
-        subscriptions.append(await relayService.openSubscription(with: contactFilter, to: overrideRelays))
+        subscriptions.append(await relayService.openSubscription(with: contactFilter))
         
         // Listen for notifications
         await pushNotificationService.listen(for: self)

--- a/Nos/Service/CurrentUser.swift
+++ b/Nos/Service/CurrentUser.swift
@@ -201,7 +201,7 @@ enum CurrentUserError: Error {
         let contactFilter = Filter(
             authorKeys: [key],
             kinds: [.contactList],
-            limit: 2,
+            limit: 2, // small hack to make sure this filter doesn't get closed for being stale
             since: author.lastUpdatedContactList
         )
         subscriptions.append(await relayService.openSubscription(with: contactFilter))

--- a/Nos/Service/RelayService.swift
+++ b/Nos/Service/RelayService.swift
@@ -546,11 +546,14 @@ extension RelayService {
     }
     
     @discardableResult @MainActor private func openSockets(overrideRelays: [URL]? = nil) async -> [URL] {
-        let relayAddresses: [URL]
+        var relayAddresses: [URL]
         if let overrideRelays {
             relayAddresses = overrideRelays
         } else {
             relayAddresses = await relays(for: self.currentUser)
+            if relayAddresses.isEmpty {
+                relayAddresses = Relay.allKnown.compactMap { URL(string: $0) }
+            }
         }
         
         for relayAddress in relayAddresses {

--- a/Nos/Views/Onboarding/OnboardingView.swift
+++ b/Nos/Views/Onboarding/OnboardingView.swift
@@ -42,8 +42,6 @@ struct OnboardingView: View {
     
     @State private var selectedTab: OnboardingStep = .onboardingStart
     
-    @State var flow: OnboardingFlow = .createAccount
-    
     var body: some View {
         NavigationStack(path: $state.path) {
             OnboardingStartView()


### PR DESCRIPTION
Fixes #707. I think there was a race condition where sometimes the RelayService would try to read the user's relay list from Core Data after their account was created but before we had added the default relays. In this case there wouldn't be any sockets connected and so we wouldn't be getting anything from the relays.

I moved the fallback to `allKnown` relays into the RelayService, so any time we don't have any relays for the current user we will just open sockets to the `allKnown` list and use that until we find some.