### PR TITLE
Fix spinners harder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Fixed some cases where a note's contents would never load.
+
 ## [0.1 (99)] - 2023-12-07Z
 
 - Fix profile pictures not loading after creating a new account.

--- a/Nos.xcodeproj/project.pbxproj
+++ b/Nos.xcodeproj/project.pbxproj
@@ -72,6 +72,7 @@
 		C913DA0A2AEAF52B003BDD6D /* NoteWarningController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C913DA092AEAF52B003BDD6D /* NoteWarningController.swift */; };
 		C913DA0C2AEB2EBF003BDD6D /* FetchRequestPublisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = C913DA0B2AEB2EBF003BDD6D /* FetchRequestPublisher.swift */; };
 		C913DA0E2AEB3265003BDD6D /* WarningView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C913DA0D2AEB3265003BDD6D /* WarningView.swift */; };
+		C91565C12B2368FA0068EECA /* ViewInspector in Frameworks */ = {isa = PBXBuildFile; productRef = C91565C02B2368FA0068EECA /* ViewInspector */; };
 		C92DF80529C25DE900400561 /* URL+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C92DF80429C25DE900400561 /* URL+Extensions.swift */; };
 		C92DF80629C25DE900400561 /* URL+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C92DF80429C25DE900400561 /* URL+Extensions.swift */; };
 		C92DF80829C25FA900400561 /* SquareImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = C92DF80729C25FA900400561 /* SquareImage.swift */; };
@@ -278,6 +279,20 @@
 		C9B71DC22A9003670031ED9F /* CrashReporting.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9B71DC12A9003670031ED9F /* CrashReporting.swift */; };
 		C9B71DC32A9003670031ED9F /* CrashReporting.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9B71DC12A9003670031ED9F /* CrashReporting.swift */; };
 		C9B71DC52A9008300031ED9F /* Sentry in Frameworks */ = {isa = PBXBuildFile; productRef = C9B71DC42A9008300031ED9F /* Sentry */; };
+		C9BA85912B23628300AFC2C3 /* Logger in Frameworks */ = {isa = PBXBuildFile; productRef = C9BA85902B23628300AFC2C3 /* Logger */; };
+		C9BA85932B23628B00AFC2C3 /* Dependencies in Frameworks */ = {isa = PBXBuildFile; productRef = C9BA85922B23628B00AFC2C3 /* Dependencies */; };
+		C9BA85952B2362C100AFC2C3 /* SDWebImageSwiftUI in Frameworks */ = {isa = PBXBuildFile; productRef = C9BA85942B2362C100AFC2C3 /* SDWebImageSwiftUI */; };
+		C9BA85972B23638700AFC2C3 /* Starscream in Frameworks */ = {isa = PBXBuildFile; productRef = C9BA85962B23638700AFC2C3 /* Starscream */; };
+		C9BA85992B23638700AFC2C3 /* secp256k1 in Frameworks */ = {isa = PBXBuildFile; productRef = C9BA85982B23638700AFC2C3 /* secp256k1 */; };
+		C9BA859B2B23638700AFC2C3 /* SwiftUINavigation in Frameworks */ = {isa = PBXBuildFile; productRef = C9BA859A2B23638700AFC2C3 /* SwiftUINavigation */; };
+		C9BA859D2B23638700AFC2C3 /* PostHog in Frameworks */ = {isa = PBXBuildFile; productRef = C9BA859C2B23638700AFC2C3 /* PostHog */; };
+		C9BA859F2B23638700AFC2C3 /* DequeModule in Frameworks */ = {isa = PBXBuildFile; productRef = C9BA859E2B23638700AFC2C3 /* DequeModule */; };
+		C9BA85A12B23638700AFC2C3 /* SentrySwiftUI in Frameworks */ = {isa = PBXBuildFile; productRef = C9BA85A02B23638700AFC2C3 /* SentrySwiftUI */; };
+		C9BA85A32B23638700AFC2C3 /* WalletConnect in Frameworks */ = {isa = PBXBuildFile; productRef = C9BA85A22B23638700AFC2C3 /* WalletConnect */; };
+		C9BA85A52B23638700AFC2C3 /* Web3 in Frameworks */ = {isa = PBXBuildFile; productRef = C9BA85A42B23638700AFC2C3 /* Web3 */; };
+		C9BA85A72B23638700AFC2C3 /* StarscreamOld in Frameworks */ = {isa = PBXBuildFile; productRef = C9BA85A62B23638700AFC2C3 /* StarscreamOld */; };
+		C9BA85A92B2363A900AFC2C3 /* WalletConnectModal in Frameworks */ = {isa = PBXBuildFile; productRef = C9BA85A82B2363A900AFC2C3 /* WalletConnectModal */; };
+		C9BA85AB2B2363CA00AFC2C3 /* Sentry in Frameworks */ = {isa = PBXBuildFile; productRef = C9BA85AA2B2363CA00AFC2C3 /* Sentry */; };
 		C9BAB09B2996FBA10003A84E /* EventProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9BAB09A2996FBA10003A84E /* EventProcessor.swift */; };
 		C9BAB09C2996FBA10003A84E /* EventProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9BAB09A2996FBA10003A84E /* EventProcessor.swift */; };
 		C9BCF1C12AC72020009BDE06 /* UNSWizardChooseNameView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9BCF1C02AC72020009BDE06 /* UNSWizardChooseNameView.swift */; };
@@ -289,6 +304,7 @@
 		C9C2B78329E0735400548B4A /* RelaySubscriptionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9C2B78129E0735400548B4A /* RelaySubscriptionManager.swift */; };
 		C9C2B78529E073E300548B4A /* RelaySubscription.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9C2B78429E073E300548B4A /* RelaySubscription.swift */; };
 		C9C2B78629E073E300548B4A /* RelaySubscription.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9C2B78429E073E300548B4A /* RelaySubscription.swift */; };
+		C9C45E162B23741E00F523DA /* EventObservationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9C45E152B23741E00F523DA /* EventObservationTests.swift */; };
 		C9C547512A4F1CC3006B0741 /* SearchController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9C547502A4F1CC3006B0741 /* SearchController.swift */; };
 		C9C547552A4F1CDB006B0741 /* SearchController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9C547502A4F1CC3006B0741 /* SearchController.swift */; };
 		C9C547592A4F1D8C006B0741 /* NosNotification+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9C547572A4F1D8C006B0741 /* NosNotification+CoreDataClass.swift */; };
@@ -632,6 +648,7 @@
 		C9C2B77E29E0731600548B4A /* AsyncTimer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncTimer.swift; sourceTree = "<group>"; };
 		C9C2B78129E0735400548B4A /* RelaySubscriptionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelaySubscriptionManager.swift; sourceTree = "<group>"; };
 		C9C2B78429E073E300548B4A /* RelaySubscription.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelaySubscription.swift; sourceTree = "<group>"; };
+		C9C45E152B23741E00F523DA /* EventObservationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventObservationTests.swift; sourceTree = "<group>"; };
 		C9C547502A4F1CC3006B0741 /* SearchController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchController.swift; sourceTree = "<group>"; };
 		C9C547562A4F1D1A006B0741 /* Nos 9.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Nos 9.xcdatamodel"; sourceTree = "<group>"; };
 		C9C547572A4F1D8C006B0741 /* NosNotification+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NosNotification+CoreDataClass.swift"; sourceTree = "<group>"; };
@@ -760,6 +777,7 @@
 				C9646EA929B7A4F2007239A4 /* PostHog in Frameworks */,
 				C9646EAC29B7A520007239A4 /* Dependencies in Frameworks */,
 				C905B0752A619367009B8A78 /* DequeModule in Frameworks */,
+				C91565C12B2368FA0068EECA /* ViewInspector in Frameworks */,
 				C9646E9C29B79E4D007239A4 /* Logger in Frameworks */,
 				CDDA1F7D29A527650047ACD8 /* SwiftUINavigation in Frameworks */,
 			);
@@ -769,6 +787,20 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C9BA85A52B23638700AFC2C3 /* Web3 in Frameworks */,
+				C9BA85952B2362C100AFC2C3 /* SDWebImageSwiftUI in Frameworks */,
+				C9BA85A12B23638700AFC2C3 /* SentrySwiftUI in Frameworks */,
+				C9BA85992B23638700AFC2C3 /* secp256k1 in Frameworks */,
+				C9BA859D2B23638700AFC2C3 /* PostHog in Frameworks */,
+				C9BA85AB2B2363CA00AFC2C3 /* Sentry in Frameworks */,
+				C9BA859B2B23638700AFC2C3 /* SwiftUINavigation in Frameworks */,
+				C9BA85912B23628300AFC2C3 /* Logger in Frameworks */,
+				C9BA85A32B23638700AFC2C3 /* WalletConnect in Frameworks */,
+				C9BA85A92B2363A900AFC2C3 /* WalletConnectModal in Frameworks */,
+				C9BA859F2B23638700AFC2C3 /* DequeModule in Frameworks */,
+				C9BA85A72B23638700AFC2C3 /* StarscreamOld in Frameworks */,
+				C9BA85932B23628B00AFC2C3 /* Dependencies in Frameworks */,
+				C9BA85972B23638700AFC2C3 /* Starscream in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -976,6 +1008,7 @@
 				C9C9443A29F6E420002F2C7A /* Test Helpers */,
 				C9DEC0042989477A0078B43A /* Fixtures */,
 				C9DEBFE8298941020078B43A /* EventTests.swift */,
+				C9C45E152B23741E00F523DA /* EventObservationTests.swift */,
 				C9ADB132299287D60075E7F8 /* KeyPairTests.swift */,
 				5B6EB48F29EDBEC1006E750C /* NoteParserTests.swift */,
 				5B80BE9D29F9864000A363E4 /* Bech32Tests.swift */,
@@ -1335,6 +1368,7 @@
 				C905B0742A619367009B8A78 /* DequeModule */,
 				C9B71DC42A9008300031ED9F /* Sentry */,
 				C99DBF7F2A9E8BCF00F7068F /* SDWebImageSwiftUI */,
+				C91565C02B2368FA0068EECA /* ViewInspector */,
 			);
 			productName = NosTests;
 			productReference = C9DEBFE4298941020078B43A /* NosTests.xctest */;
@@ -1354,6 +1388,22 @@
 				C9DEBFF0298941020078B43A /* PBXTargetDependency */,
 			);
 			name = NosUITests;
+			packageProductDependencies = (
+				C9BA85902B23628300AFC2C3 /* Logger */,
+				C9BA85922B23628B00AFC2C3 /* Dependencies */,
+				C9BA85942B2362C100AFC2C3 /* SDWebImageSwiftUI */,
+				C9BA85962B23638700AFC2C3 /* Starscream */,
+				C9BA85982B23638700AFC2C3 /* secp256k1 */,
+				C9BA859A2B23638700AFC2C3 /* SwiftUINavigation */,
+				C9BA859C2B23638700AFC2C3 /* PostHog */,
+				C9BA859E2B23638700AFC2C3 /* DequeModule */,
+				C9BA85A02B23638700AFC2C3 /* SentrySwiftUI */,
+				C9BA85A22B23638700AFC2C3 /* WalletConnect */,
+				C9BA85A42B23638700AFC2C3 /* Web3 */,
+				C9BA85A62B23638700AFC2C3 /* StarscreamOld */,
+				C9BA85A82B2363A900AFC2C3 /* WalletConnectModal */,
+				C9BA85AA2B2363CA00AFC2C3 /* Sentry */,
+			);
 			productName = NosUITests;
 			productReference = C9DEBFEE298941020078B43A /* NosUITests.xctest */;
 			productType = "com.apple.product-type.bundle.ui-testing";
@@ -1416,6 +1466,7 @@
 				C95F0AC82ABA379700A0D9CE /* XCRemoteSwiftPackageReference "WalletConnectSwiftV2" */,
 				C9AA1BB82ABB62EB00E8BD6D /* XCRemoteSwiftPackageReference "Web3" */,
 				C9332C642ADED0D700AD7B0E /* XCLocalSwiftPackageReference "StarscreamOld" */,
+				C91565BF2B2368FA0068EECA /* XCRemoteSwiftPackageReference "ViewInspector" */,
 			);
 			productRefGroup = C9DEBFCF298941000078B43A /* Products */;
 			projectDirPath = "";
@@ -1836,6 +1887,7 @@
 				C93EC2F829C351470012EE2A /* Optional+Unwrap.swift in Sources */,
 				C9C5475C2A4F1D8C006B0741 /* NosNotification+CoreDataProperties.swift in Sources */,
 				C9B678DF29EEC35B00303F33 /* Foundation+Sendable.swift in Sources */,
+				C9C45E162B23741E00F523DA /* EventObservationTests.swift in Sources */,
 				A3B943D7299D6DB700A15A08 /* Follow+CoreDataClass.swift in Sources */,
 				C9ADB13E29929EEF0075E7F8 /* Bech32.swift in Sources */,
 				C9DEC05A2989509B0078B43A /* Persistence.swift in Sources */,
@@ -2272,7 +2324,7 @@
 				DEVELOPMENT_TEAM = GZCZBKH7MY;
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 16.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				MACOSX_DEPLOYMENT_TARGET = 13.1;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.verse.NosUITests;
@@ -2296,7 +2348,7 @@
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = GZCZBKH7MY;
 				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 16.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				MACOSX_DEPLOYMENT_TARGET = 13.1;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.verse.NosUITests;
@@ -2368,6 +2420,14 @@
 /* End XCLocalSwiftPackageReference section */
 
 /* Begin XCRemoteSwiftPackageReference section */
+		C91565BF2B2368FA0068EECA /* XCRemoteSwiftPackageReference "ViewInspector" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/nalexn/ViewInspector";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.9.9;
+			};
+		};
 		C94D855D29914D2300749478 /* XCRemoteSwiftPackageReference "swiftui-navigation" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/pointfreeco/swiftui-navigation";
@@ -2488,6 +2548,11 @@
 			package = C96CB98A2A6040C500498C4E /* XCRemoteSwiftPackageReference "swift-collections" */;
 			productName = DequeModule;
 		};
+		C91565C02B2368FA0068EECA /* ViewInspector */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = C91565BF2B2368FA0068EECA /* XCRemoteSwiftPackageReference "ViewInspector" */;
+			productName = ViewInspector;
+		};
 		C9332C622ADECFA700AD7B0E /* StarscreamOld */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = StarscreamOld;
@@ -2597,6 +2662,76 @@
 			productName = SentrySwiftUI;
 		};
 		C9B71DC42A9008300031ED9F /* Sentry */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = C9B71DBC2A8E9BAD0031ED9F /* XCRemoteSwiftPackageReference "sentry-cocoa" */;
+			productName = Sentry;
+		};
+		C9BA85902B23628300AFC2C3 /* Logger */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = C9646E9829B79E04007239A4 /* XCRemoteSwiftPackageReference "logger-ios" */;
+			productName = Logger;
+		};
+		C9BA85922B23628B00AFC2C3 /* Dependencies */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = C9646EA529B7A3DD007239A4 /* XCRemoteSwiftPackageReference "swift-dependencies" */;
+			productName = Dependencies;
+		};
+		C9BA85942B2362C100AFC2C3 /* SDWebImageSwiftUI */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = C99DBF7C2A9E81CF00F7068F /* XCRemoteSwiftPackageReference "SDWebImageSwiftUI" */;
+			productName = SDWebImageSwiftUI;
+		};
+		C9BA85962B23638700AFC2C3 /* Starscream */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = C9DEC066298965270078B43A /* XCRemoteSwiftPackageReference "Starscream" */;
+			productName = Starscream;
+		};
+		C9BA85982B23638700AFC2C3 /* secp256k1 */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = C97797BA298AB1890046BD25 /* XCRemoteSwiftPackageReference "secp256k1" */;
+			productName = secp256k1;
+		};
+		C9BA859A2B23638700AFC2C3 /* SwiftUINavigation */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = C94D855D29914D2300749478 /* XCRemoteSwiftPackageReference "swiftui-navigation" */;
+			productName = SwiftUINavigation;
+		};
+		C9BA859C2B23638700AFC2C3 /* PostHog */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = C9646EA229B7A24A007239A4 /* XCRemoteSwiftPackageReference "posthog-ios" */;
+			productName = PostHog;
+		};
+		C9BA859E2B23638700AFC2C3 /* DequeModule */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = C96CB98A2A6040C500498C4E /* XCRemoteSwiftPackageReference "swift-collections" */;
+			productName = DequeModule;
+		};
+		C9BA85A02B23638700AFC2C3 /* SentrySwiftUI */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = C9B71DBC2A8E9BAD0031ED9F /* XCRemoteSwiftPackageReference "sentry-cocoa" */;
+			productName = SentrySwiftUI;
+		};
+		C9BA85A22B23638700AFC2C3 /* WalletConnect */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = C95F0AC82ABA379700A0D9CE /* XCRemoteSwiftPackageReference "WalletConnectSwiftV2" */;
+			productName = WalletConnect;
+		};
+		C9BA85A42B23638700AFC2C3 /* Web3 */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = C9AA1BB82ABB62EB00E8BD6D /* XCRemoteSwiftPackageReference "Web3" */;
+			productName = Web3;
+		};
+		C9BA85A62B23638700AFC2C3 /* StarscreamOld */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = C9332C642ADED0D700AD7B0E /* XCLocalSwiftPackageReference "StarscreamOld" */;
+			productName = StarscreamOld;
+		};
+		C9BA85A82B2363A900AFC2C3 /* WalletConnectModal */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = C95F0AC82ABA379700A0D9CE /* XCRemoteSwiftPackageReference "WalletConnectSwiftV2" */;
+			productName = WalletConnectModal;
+		};
+		C9BA85AA2B2363CA00AFC2C3 /* Sentry */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = C9B71DBC2A8E9BAD0031ED9F /* XCRemoteSwiftPackageReference "sentry-cocoa" */;
 			productName = Sentry;

--- a/Nos.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Nos.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -280,6 +280,15 @@
       }
     },
     {
+      "identity" : "viewinspector",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/nalexn/ViewInspector",
+      "state" : {
+        "revision" : "a1422d4749ccf7f32b1d14a9ec19ec9a0b0fd337",
+        "version" : "0.9.9"
+      }
+    },
+    {
       "identity" : "walletconnectswiftv2",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/WalletConnect/WalletConnectSwiftV2",

--- a/Nos.xcodeproj/xcshareddata/xcschemes/NosUITests.xcscheme
+++ b/Nos.xcodeproj/xcshareddata/xcschemes/NosUITests.xcscheme
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1500"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "C9DEBFED298941020078B43A"
+               BuildableName = "NosUITests.xctest"
+               BlueprintName = "NosUITests"
+               ReferencedContainer = "container:Nos.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Nos/Models/Event+CoreDataClass.swift
+++ b/Nos/Models/Event+CoreDataClass.swift
@@ -942,21 +942,16 @@ public class Event: NosManagedObject {
     }
 
     class func attributedContentAndURLs(
-        noteID: String?, 
+        note: Event, 
         context: NSManagedObjectContext
     ) async -> (AttributedString, [URL])? {
-        guard let noteID else {
+        guard let content = note.content else {
             return nil
         }
+        let tags = note.allTags as? [[String]] ?? []
         
         return await context.perform {
-            guard let note = try? Event.findOrCreateStubBy(id: noteID, context: context),
-                let content = note.content else {
-                return nil
-            }
-            try? context.saveIfNeeded()
-            let tags = note.allTags as? [[String]] ?? []
-            return NoteParser.parse(content: content, tags: tags, context: context)
+            NoteParser.parse(content: content, tags: tags, context: context)
         }
     }
     

--- a/Nos/Models/Persistence.swift
+++ b/Nos/Models/Persistence.swift
@@ -35,7 +35,11 @@ class PersistenceController {
     
     /// A context for parsing Nostr events from relays.
     lazy var parseContext = {
-        self.newBackgroundContext()
+        let context = NSManagedObjectContext(.privateQueue)
+        context.parent = viewContext
+        context.automaticallyMergesChangesFromParent = true
+        context.mergePolicy = NSMergePolicy.mergeByPropertyObjectTrump
+        return context
     }()
     
     /// A context for Views to do expensive queries that we want to keep off the viewContext.

--- a/Nos/Service/RelayService.swift
+++ b/Nos/Service/RelayService.swift
@@ -35,7 +35,6 @@ final class RelayService: ObservableObject {
         @Dependency(\.persistenceController) var persistenceController
         self.backgroundContext = persistenceController.newBackgroundContext()
         self.parseContext = persistenceController.parseContext
-        parseContext.mergePolicy = NSMergePolicy.mergeByPropertyObjectTrump
         
         self.eventProcessingLoop = Task(priority: .userInitiated) { [weak self] in
             try Task.checkCancellation()
@@ -295,6 +294,7 @@ extension RelayService {
                     _ = try EventProcessor.parse(jsonEvent: event, from: relay, in: self.parseContext) 
                 }
                 try self.parseContext.saveIfNeeded()
+                try self.persistenceController.viewContext.saveIfNeeded()
             }                
             return true
         }

--- a/Nos/Views/CompactNoteView.swift
+++ b/Nos/Views/CompactNoteView.swift
@@ -129,7 +129,7 @@ struct CompactNoteView: View {
         .task {
             let backgroundContext = persistenceController.backgroundViewContext
             if let parsedAttributedContent = await Event.attributedContentAndURLs(
-                noteID: note.identifier,
+                note: note,
                 context: backgroundContext
             ) {
                 withAnimation(.easeIn(duration: 0.1)) {

--- a/Nos/Views/StoryNoteView.swift
+++ b/Nos/Views/StoryNoteView.swift
@@ -150,7 +150,7 @@ struct StoryNoteView: View {
             let backgroundContext = persistenceController.backgroundViewContext
             await Event.markNoteAsRead(noteID: note.identifier, context: backgroundContext)
             if let parsedAttributedContent = await Event.attributedContentAndURLs(
-                noteID: note.identifier,
+                note: note,
                 context: backgroundContext
             ) {
                 withAnimation(.easeIn(duration: 0.1)) {

--- a/NosTests/EventObservationTests.swift
+++ b/NosTests/EventObservationTests.swift
@@ -11,6 +11,8 @@ import SwiftUI
 import ViewInspector
 import Combine
         
+// This is a bit of instrumentation recommended by the ViewInspector package to set up views for asynchronous inspection
+// see https://github.com/nalexn/ViewInspector/blob/0.9.10/guide.md#approach-2
 internal final class Inspection<V> {
     
     let notice = PassthroughSubject<UInt, Never>()
@@ -48,7 +50,7 @@ final class EventObservationTests: XCTestCase {
     func testDuplicateEventMerging() throws {
         // Arrange
         @Dependency(\.persistenceController) var persistenceController
-        let viewContext = persistenceController.viewContext
+        let viewContext = persistenceController.backgroundViewContext
         let parseContext = persistenceController.parseContext
         
         let eventID = "123456"

--- a/NosTests/EventObservationTests.swift
+++ b/NosTests/EventObservationTests.swift
@@ -1,0 +1,81 @@
+//
+//  EventObservationTests.swift
+//  NosTests
+//
+//  Created by Matthew Lorentz on 12/8/23.
+//
+
+import XCTest
+import Dependencies
+import SwiftUI
+import ViewInspector
+import Combine
+        
+internal final class Inspection<V> {
+    
+    let notice = PassthroughSubject<UInt, Never>()
+    var callbacks = [UInt: (V) -> Void]()
+    
+    func visit(_ view: V, _ line: UInt) {
+        if let callback = callbacks.removeValue(forKey: line) {
+            callback(view)
+        }
+    }
+}
+
+extension Inspection: InspectionEmissary { }
+
+struct EventObservationTestView: View {
+    @FetchRequest<Event>(
+        entity: Event.entity(), 
+        sortDescriptors: [NSSortDescriptor(keyPath: \Event.createdAt, ascending: true)]
+    ) var events
+    
+    internal let inspection = Inspection<Self>() 
+    var body: some View {
+        List(events) { event in 
+            Text(event.content ?? "null")
+        }
+        .onReceive(inspection.notice) { self.inspection.visit(self, $0) } 
+    }
+}
+
+/// Testing that our SwiftUI Views can successfully observe Event changes from Core Data
+final class EventObservationTests: XCTestCase {
+    
+    /// This tests that the same event created in two separate contexts will update correctly in the view when both
+    /// contexts are saved. This test exhibits bug https://github.com/planetary-social/nos/issues/697.  
+    func testDuplicateEventMerging() throws {
+        // Arrange
+        @Dependency(\.persistenceController) var persistenceController
+        let viewContext = persistenceController.viewContext
+        let parseContext = persistenceController.parseContext
+        
+        let eventID = "123456"
+        let eventContent = "foo bar"
+        
+        // Act
+        let eventStub = try Event.findOrCreateStubBy(id: eventID, context: viewContext)
+        let eventStubObjectID = eventStub.objectID
+        let fullEvent = try Event.findOrCreateStubBy(id: eventID, context: parseContext)
+        let fullEventObjectID = fullEvent.objectID
+        fullEvent.content = eventContent
+        
+        let view = EventObservationTestView()
+        ViewHosting.host(view: view.environment(\.managedObjectContext, persistenceController.container.viewContext))
+        let expectNullContent = view.inspection.inspect { view in
+            let eventContentInView = try view.find(ViewType.Text.self).string()
+            XCTAssertEqual(eventContentInView, "null")
+        }
+        wait(for: [expectNullContent], timeout: 0.1)
+        
+        try viewContext.save()
+        try parseContext.save()
+        
+        let expectContent = view.inspection.inspect { view in
+            let eventContentInView = try view.find(ViewType.Text.self).string()
+            XCTAssertEqual(eventContentInView, eventContent)
+        }
+        wait(for: [expectContent], timeout: 0.1)
+    }
+}

--- a/NosTests/EventObservationTests.swift
+++ b/NosTests/EventObservationTests.swift
@@ -50,7 +50,7 @@ final class EventObservationTests: XCTestCase {
     func testDuplicateEventMerging() throws {
         // Arrange
         @Dependency(\.persistenceController) var persistenceController
-        let viewContext = persistenceController.backgroundViewContext
+        let viewContext = persistenceController.viewContext
         let parseContext = persistenceController.parseContext
         
         let eventID = "123456"
@@ -58,9 +58,7 @@ final class EventObservationTests: XCTestCase {
         
         // Act
         let eventStub = try Event.findOrCreateStubBy(id: eventID, context: viewContext)
-        let eventStubObjectID = eventStub.objectID
         let fullEvent = try Event.findOrCreateStubBy(id: eventID, context: parseContext)
-        let fullEventObjectID = fullEvent.objectID
         fullEvent.content = eventContent
         
         let view = EventObservationTestView()

--- a/NosTests/EventTests.swift
+++ b/NosTests/EventTests.swift
@@ -391,7 +391,6 @@ final class EventTests: XCTestCase {
         XCTAssertNil(testEvent.referencedNote())
     }
     
-<<<<<<< Updated upstream
     func testRepostedNote() throws {
         let testContext = persistenceController.container.viewContext
         let testEvent = try createTestEvent(in: testContext)
@@ -421,8 +420,9 @@ final class EventTests: XCTestCase {
         testEvent.addToEventReferences(mention)
         
         XCTAssertEqual(testEvent.repostedNote()?.identifier, nil)
-=======
-    // MARK: - Context merging
+    }
+        
+        // MARK: - Context merging
     
     func testDuplicateEventMerging() throws {
         // Arrange
@@ -445,7 +445,6 @@ final class EventTests: XCTestCase {
         
         XCTAssertEqual(eventStub.objectID, fullEventObjectID)
         XCTAssertEqual(eventStub.objectID, fullEvent.objectID)
->>>>>>> Stashed changes
     }
 
     // MARK: - Helpers

--- a/NosTests/EventTests.swift
+++ b/NosTests/EventTests.swift
@@ -391,6 +391,7 @@ final class EventTests: XCTestCase {
         XCTAssertNil(testEvent.referencedNote())
     }
     
+<<<<<<< Updated upstream
     func testRepostedNote() throws {
         let testContext = persistenceController.container.viewContext
         let testEvent = try createTestEvent(in: testContext)
@@ -420,6 +421,31 @@ final class EventTests: XCTestCase {
         testEvent.addToEventReferences(mention)
         
         XCTAssertEqual(testEvent.repostedNote()?.identifier, nil)
+=======
+    // MARK: - Context merging
+    
+    func testDuplicateEventMerging() throws {
+        // Arrange
+        let viewContext = persistenceController.viewContext
+        let parseContext = persistenceController.parseContext
+        
+        let eventID = "123456"
+        let eventContent = "foo bar"
+        
+        // Act
+        let eventStub = try Event.findOrCreateStubBy(id: eventID, context: viewContext)
+        let eventStubObjectID = eventStub.objectID
+        let fullEvent = try Event.findOrCreateStubBy(id: eventID, context: parseContext)
+        let fullEventObjectID = fullEvent.objectID
+        fullEvent.content = eventContent
+        XCTAssertNotEqual(eventStubObjectID, fullEventObjectID) // sanity check
+        
+        try parseContext.save()
+        try viewContext.save()
+        
+        XCTAssertEqual(eventStub.objectID, fullEventObjectID)
+        XCTAssertEqual(eventStub.objectID, fullEvent.objectID)
+>>>>>>> Stashed changes
     }
 
     // MARK: - Helpers

--- a/NosTests/EventTests.swift
+++ b/NosTests/EventTests.swift
@@ -421,31 +421,6 @@ final class EventTests: XCTestCase {
         
         XCTAssertEqual(testEvent.repostedNote()?.identifier, nil)
     }
-        
-        // MARK: - Context merging
-    
-    func testDuplicateEventMerging() throws {
-        // Arrange
-        let viewContext = persistenceController.viewContext
-        let parseContext = persistenceController.parseContext
-        
-        let eventID = "123456"
-        let eventContent = "foo bar"
-        
-        // Act
-        let eventStub = try Event.findOrCreateStubBy(id: eventID, context: viewContext)
-        let eventStubObjectID = eventStub.objectID
-        let fullEvent = try Event.findOrCreateStubBy(id: eventID, context: parseContext)
-        let fullEventObjectID = fullEvent.objectID
-        fullEvent.content = eventContent
-        XCTAssertNotEqual(eventStubObjectID, fullEventObjectID) // sanity check
-        
-        try parseContext.save()
-        try viewContext.save()
-        
-        XCTAssertEqual(eventStub.objectID, fullEventObjectID)
-        XCTAssertEqual(eventStub.objectID, fullEvent.objectID)
-    }
 
     // MARK: - Helpers
     


### PR DESCRIPTION
This is another fix for notes failing to load and showing infinite spinners. I started by writing a good test to exhibit the issue, which required me to pull in the ViewObservation swift package. Then I started playing with the contexts and found that changing the `parseContext.parent` to `viewContext` instead of nil fixed the issue where the `NSManagedObjectID` being held by the view would change on disk and the view would never be notified of changes to the object.

I did some testing to see if this had any negative side effects (like my last attempt did, #632) and I haven't seen any yet. But let's keep an eye out. This should close #697 and #703.