### PR TITLE
Fix reposts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Fixed a bug where reposts wouldn't be displayed in the stories.
 - Localized relative times on note cards.
 - Added a context menu for the stories in the Home Feed to open the Profile.
 - Update the color palette.

--- a/Nos/Views/AuthorStoryView.swift
+++ b/Nos/Views/AuthorStoryView.swift
@@ -112,6 +112,9 @@ struct AuthorStoryView: View {
                     HStack(alignment: .center) {
                         AuthorLabel(author: author)
                             .padding(0)
+                        if selectedNote?.kind == EventKind.repost.rawValue {
+                            Image.repostSymbol
+                        } 
                         if let expirationTime = selectedNote?.expirationDate?.distanceString() {
                             Image.disappearingMessages
                                 .resizable()


### PR DESCRIPTION
#689 

Fixes the fetch request query we were using. We were querying for empty eventReferences to filter root notes, but that is not compatible with reposts bc these do have an eventReference. So I moved the eventReferences subquery to be performed only for kind = 1.

Also, it displays a repost icon in the header.