### PR TITLE
Disable intermittently failing tests

### DIFF
--- a/NosTests/EventObservationTests.swift
+++ b/NosTests/EventObservationTests.swift
@@ -49,6 +49,7 @@ final class EventObservationTests: SQLiteStoreTestCase {
     /// This tests that the same event created in two separate contexts will update correctly in the view when both
     /// contexts are saved. This test exhibits bug https://github.com/planetary-social/nos/issues/697.  
     func testDuplicateEventMergingGivenViewContextSavesFirst() throws {
+        XCTExpectFailure("This test is failing intermittently, see #703", options: .nonStrict())
         // Arrange
         let viewContext = persistenceController.viewContext
         let parseContext = persistenceController.parseContext

--- a/NosTests/SocialGraphTests.swift
+++ b/NosTests/SocialGraphTests.swift
@@ -60,6 +60,8 @@ final class SocialGraphTests: XCTestCase {
     }
     
     func testFollow() async throws {
+        XCTExpectFailure("This test is failing intermittently, see #671", options: .nonStrict())
+
         // Arrange
         let alice = try Author.findOrCreate(by: KeyFixture.alice.publicKeyHex, context: testContext)
         let bob = try Author.findOrCreate(by: KeyFixture.bob.publicKeyHex, context: testContext)
@@ -84,6 +86,8 @@ final class SocialGraphTests: XCTestCase {
     }
     
     func testTwoFollows() async throws {
+        XCTExpectFailure("This test is failing intermittently, see #671", options: .nonStrict())
+
         // Arrange
         let alice = try Author.findOrCreate(by: KeyFixture.alice.publicKeyHex, context: testContext)
         let bob = try Author.findOrCreate(by: KeyFixture.bob.publicKeyHex, context: testContext)


### PR DESCRIPTION
We have two tests that are failing intermittently. This PR disables them. We have tickets #671 and #703 to fix and re-enable them in the future.