### PR TITLE
Fix warnings in project

### DIFF
--- a/Nos.xcodeproj/project.pbxproj
+++ b/Nos.xcodeproj/project.pbxproj
@@ -1439,7 +1439,7 @@
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
 				LastSwiftUpdateCheck = 1420;
-				LastUpgradeCheck = 1500;
+				LastUpgradeCheck = 1510;
 				TargetAttributes = {
 					C90862BA29E9804B00C35A71 = {
 						CreatedOnToolsVersion = 14.2;

--- a/Nos.xcodeproj/xcshareddata/xcschemes/Nos Diagnostics.xcscheme
+++ b/Nos.xcodeproj/xcshareddata/xcschemes/Nos Diagnostics.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1500"
+   LastUpgradeVersion = "1510"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Nos.xcodeproj/xcshareddata/xcschemes/Nos Localization.xcscheme
+++ b/Nos.xcodeproj/xcshareddata/xcschemes/Nos Localization.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1500"
+   LastUpgradeVersion = "1510"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Nos.xcodeproj/xcshareddata/xcschemes/Nos Performance Tests.xcscheme
+++ b/Nos.xcodeproj/xcshareddata/xcschemes/Nos Performance Tests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1500"
+   LastUpgradeVersion = "1510"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Nos.xcodeproj/xcshareddata/xcschemes/Nos.xcscheme
+++ b/Nos.xcodeproj/xcshareddata/xcschemes/Nos.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1500"
+   LastUpgradeVersion = "1510"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Nos.xcodeproj/xcshareddata/xcschemes/NosTests.xcscheme
+++ b/Nos.xcodeproj/xcshareddata/xcschemes/NosTests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1500"
+   LastUpgradeVersion = "1510"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Nos.xcodeproj/xcshareddata/xcschemes/NosUITests.xcscheme
+++ b/Nos.xcodeproj/xcshareddata/xcschemes/NosUITests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1500"
+   LastUpgradeVersion = "1510"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Nos/Views/NoteButton.swift
+++ b/Nos/Views/NoteButton.swift
@@ -66,7 +66,6 @@ struct NoteButton: View {
     var body: some View {
         VStack {
             if note.kind == EventKind.repost.rawValue, let author = note.author {
-                let repost = note
                 Button(action: { 
                     router.push(author)
                 }, label: { 

--- a/NosTests/EventTests.swift
+++ b/NosTests/EventTests.swift
@@ -117,7 +117,6 @@ final class EventTests: XCTestCase {
         let sampleEventID = "f41e430f632b1e747da7efbb0ce11616876851e2fa3bbac440101c1b8a091152"
         let repostedEventID = "f82507f7c770a39d0eabf276ced34fbd6a172be869bd3a3231c9c0272f405008"
         let repostedEventContents = "#kraftwerk https://v.nostr.build/lx7e.mp4 "
-        let testContext = persistenceController.container.viewContext
         
         // Act
         let events = try EventProcessor.parse(jsonData: sampleData, from: nil, in: persistenceController)


### PR DESCRIPTION
Fixes #771. I found that some of the warnings are false alarms, so those can't actually be fixed. Specifically, these are not real warnings:

`No calls to throwing functions occur within 'try' expression`

The other warnings are fixed.