### PR TITLE
Fix profile tab crashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Fixed a crash that sometimes occured when opening the profile view.
+- Fixed a crash that sometimes occured when viewing a note.
 - Migrate to Apple-native string catalog and codegen LocalizedStringResources with xcstrings-tool-plugin.
 - Discover screen can now search notes by id.
 - Added pagination to Profile screens.

--- a/Nos/Assets/Localization/Localizable.xcstrings
+++ b/Nos/Assets/Localization/Localizable.xcstrings
@@ -4126,13 +4126,13 @@
               "one" : {
                 "stringUnit" : {
                   "state" : "new",
-                  "value" : "Followed by **%@** and **%lld other**"
+                  "value" : "Followed by **%1@** and **%2ld other**"
                 }
               },
               "other" : {
                 "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "Gefolgt von **%@** und **%lld anderen**"
+                  "state" : "needs_review",
+                  "value" : "Gefolgt von **%1@** und **%2ld anderen**"
                 }
               }
             }
@@ -4144,13 +4144,13 @@
               "one" : {
                 "stringUnit" : {
                   "state" : "translated",
-                  "value" : "Followed by **%@** and **%lld other**"
+                  "value" : "Followed by **%1@** and **%2ld other**"
                 }
               },
               "other" : {
                 "stringUnit" : {
                   "state" : "translated",
-                  "value" : "Followed by **%@** and **%lld others**"
+                  "value" : "Followed by **%1@** and **%2ld others**"
                 }
               }
             }
@@ -4167,7 +4167,7 @@
               },
               "other" : {
                 "stringUnit" : {
-                  "state" : "translated",
+                  "state" : "needs_review",
                   "value" : "دنبال شده توسط **%@** و **%lld** نفر دیگر"
                 }
               }
@@ -4185,7 +4185,7 @@
               },
               "other" : {
                 "stringUnit" : {
-                  "state" : "translated",
+                  "state" : "needs_review",
                   "value" : "Följs av **%@** och **%lld andra**"
                 }
               }
@@ -4197,7 +4197,7 @@
             "plural" : {
               "other" : {
                 "stringUnit" : {
-                  "state" : "translated",
+                  "state" : "needs_review",
                   "value" : "被**%@**和**%lld个其他用户**关注"
                 }
               }
@@ -4209,7 +4209,7 @@
             "plural" : {
               "other" : {
                 "stringUnit" : {
-                  "state" : "translated",
+                  "state" : "needs_review",
                   "value" : "被**%@**和**%lld個其他用戶**關注"
                 }
               }

--- a/Nos/Models/Event+CoreDataClass.swift
+++ b/Nos/Models/Event+CoreDataClass.swift
@@ -1013,13 +1013,15 @@ public class Event: NosManagedObject {
 
     /// This function formats an Event's content for display in the UI. It does things like replacing raw npub links
     /// with the author's name, and extracting any URLs so that previews can be displayed for them.
+    ///
+    /// The given note should be initialized in a main queue NSManagedObjectContext (probably viewContext).
     /// 
     /// - Parameter note: the note whose content should be processed.
     /// - Parameter context: the context to use for database queries - this does not need to be the same context that
     ///     `note` is in.
     /// - Returns: A tuple where the first object is the note content formatted for display, and the second is a list
     ///     of HTTP links found in the note's context.  
-    class func attributedContentAndURLs(
+    @MainActor class func attributedContentAndURLs(
         note: Event, 
         context: NSManagedObjectContext
     ) async -> (AttributedString, [URL])? {

--- a/Nos/Service/Relay/RelayService.swift
+++ b/Nos/Service/Relay/RelayService.swift
@@ -119,7 +119,6 @@ extension RelayService {
             let request: [Any] = ["CLOSE", subscription]
             let requestData = try JSONSerialization.data(withJSONObject: request)
             let requestString = String(data: requestData, encoding: .utf8)!
-            Log.debug("\(requestString) sent to \(client.host)")
             client.write(string: requestString)
         } catch {
             Log.error("Error: Could not send close \(error.localizedDescription)")

--- a/Nos/Service/SocialGraphCache.swift
+++ b/Nos/Service/SocialGraphCache.swift
@@ -128,7 +128,7 @@ actor SocialGraphCache: NSObject, NSFetchedResultsControllerDelegate {
         followedKeys.insert(userKey)
         
         do {
-            try await context.perform {
+            try await context.perform { [self] in
                 let authorRequest = Author.request(by: userKey) 
                 authorRequest.relationshipKeyPathsForPrefetching = ["follows.destination.hexadecimalPublicKey"]
                 self.userWatcher = NSFetchedResultsController(
@@ -145,14 +145,13 @@ actor SocialGraphCache: NSObject, NSFetchedResultsControllerDelegate {
                         cacheName: "SocialGraphCache.oneHopWatcher"
                     )
                 }
-            }
-            
-            userWatcher?.delegate = self
-            oneHopWatcher?.delegate = self
-            try self.userWatcher?.performFetch()
-            try self.oneHopWatcher?.performFetch()
-            if let author = self.userWatcher?.fetchedObjects?.first {
-                process(user: userKey, followed: Set(author.followedKeys))
+                self.userWatcher?.delegate = self
+                self.oneHopWatcher?.delegate = self
+                try self.userWatcher?.performFetch()
+                try self.oneHopWatcher?.performFetch()
+                if let author = self.userWatcher?.fetchedObjects?.first {
+                    process(user: userKey, followed: Set(author.followedKeys))
+                }
             }
         } catch {
             Log.error(error.localizedDescription)


### PR DESCRIPTION
This contains some fixes for #778. I fixed two crashes and a couple other issues I found along the way:
- Fixed a crash in localized string interpolation. This was really frustrating as this sort of thing should be caught at compile time. I looked for a way to check these at compile time and there doesn't seem to be an easy way :(
- Fixed a Core Data concurrency warning in `Event.attributedContentAndURLs`. This one has definitely caused crashes as I saw one in Sentry.
- Fixed a Core Data concurrency warning in SocialGraphCache.
- Fixed an issue where the app wouldn't send requests to any relays after logging in on a fresh install.
- I also added more logging to PagedNoteData source to try to understand why this [NSInternalConsistency](https://sentry.nos.social/organizations/verse/issues/752/?query=is%3Aunresolved+error.unhandled%3Atrue&referrer=issue-stream&sort=date&statsPeriod=14d&stream_index=5) crash is happening.