### PR TITLE
Remove build number from stamp_release lane

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -100,7 +100,7 @@ platform :ios do
     build_number = get_build_number(
       xcodeproj: "Nos.xcodeproj"
     )
-    stamp_changelog(section_identifier: "#{version_number} (#{build_number})")
+    stamp_changelog(section_identifier: "#{version_number}")
     git_commit(message: "Stamping beta deployment", path: "*")
     push_to_git_remote
   end


### PR DESCRIPTION
This fixes a little problem I found in the Fastfile when deploying 0.1.2. Our Github CI doesn't commit the latest build number to the repository when doing builds, so it was wrong in the changelog. I just removed the build number from the changelog since we are only stamping when the version number changes, not for each build anymore. I think this makes sense: now that we build on every PR merge it would result in one changelog entry per heading in the CHANGELOG if we stamped it after every time we incremented the build number.