### PR TITLE
Fixed a bug where not much stories data was downloaded

### DIFF
--- a/Nos/Service/Relay/RelayService.swift
+++ b/Nos/Service/Relay/RelayService.swift
@@ -323,8 +323,6 @@ extension RelayService {
                     await subscriptions.forceCloseSubscriptionCount(for: subscription.id)
                     await sendCloseToAll(for: subscription.id)
                 }
-                
-                Log.debug("Subscription \(subscriptionID) has received \(subscription.receivedEventCount) events")
             }
         } catch {
             print("Error: parsing event from relay (\(socket.request.url?.absoluteString ?? "")): " +

--- a/Nos/Service/Relay/RelayService.swift
+++ b/Nos/Service/Relay/RelayService.swift
@@ -323,6 +323,8 @@ extension RelayService {
                     await subscriptions.forceCloseSubscriptionCount(for: subscription.id)
                     await sendCloseToAll(for: subscription.id)
                 }
+                
+                Log.debug("Subscription \(subscriptionID) has received \(subscription.receivedEventCount) events")
             }
         } catch {
             print("Error: parsing event from relay (\(socket.request.url?.absoluteString ?? "")): " +


### PR DESCRIPTION
When I added [pagination to the home feed](https://github.com/planetary-social/nos/pull/793) (with no PR review lol) I didn't think about the fact that the home feed was also downloading all the events for the stories interface. I did some testing but because I was opening the app frequently I was getting enough recent events to not notice [this bug](https://github.com/planetary-social/nos/issues/767#issuecomment-1893969798).

I was worried I would have to build a whole custom pagination scheme for the home feed, but it turns out just requesting all notes from all our followers from the past couple days isn't that many notes, even if you follow 700 people, so I think the performance on this is good enough, but give it a try and let me know.