### PR TITLE
Remove limit from home feed fetch request

### DIFF
--- a/Nos/Models/CoreData/Event+CoreDataClass.swift
+++ b/Nos/Models/CoreData/Event+CoreDataClass.swift
@@ -390,8 +390,6 @@ public class Event: NosManagedObject {
         let fetchRequest = NSFetchRequest<Event>(entityName: "Event")
         fetchRequest.sortDescriptors = [NSSortDescriptor(keyPath: \Event.createdAt, ascending: false)]
         fetchRequest.predicate = homeFeedPredicate(for: user, before: before)
-        fetchRequest.includesPendingChanges = false
-        fetchRequest.fetchLimit = 1000
         return fetchRequest
     }
     


### PR DESCRIPTION
This fixes a little bug I noticed on #767. I think this limit was added for performance but we don't need it anymore now that the home feed is paginated. Skipping changelog since the paginated home feed hasn't been deployed to production.