### PR TITLE
#776: Add 10 second timer to show message if we can’t find results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Show a message when we’re not finding search results.
 - Optimized loading of the Notifications tab
 - Updated suggested users for discovery tab.
 - Show the profile view when a search matches a valid User ID (npub).

--- a/Nos/Assets/Localization/Localizable.xcstrings
+++ b/Nos/Assets/Localization/Localizable.xcstrings
@@ -7523,6 +7523,17 @@
         }
       }
     },
+    "notFindingResults" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "We are not finding results in our immediate network for your search. You can continue waiting or try another search term."
+          }
+        }
+      }
+    },
     "notifications" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/Nos/Assets/Localization/Localizable.xcstrings
+++ b/Nos/Assets/Localization/Localizable.xcstrings
@@ -7529,7 +7529,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "We are not finding results in our immediate network for your search. You can continue waiting or try another search term."
+            "value" : "We are not finding results on your relays. You can continue waiting or try another search term."
           }
         }
       }

--- a/Nos/Controller/SearchController.swift
+++ b/Nos/Controller/SearchController.swift
@@ -125,8 +125,6 @@ class SearchController: ObservableObject {
     func clear() {
         query = ""
         authorResults = []
-        isNotFindingResults = false
-        timer?.invalidate()
     }
     
     func note(fromPublicKey publicKeyString: String) -> Event? {

--- a/Nos/Controller/SearchController.swift
+++ b/Nos/Controller/SearchController.swift
@@ -181,10 +181,8 @@ class SearchController: ObservableObject {
         timer = Timer.scheduledTimer(withTimeInterval: 1, repeats: false) { _ in
             if !self.query.isEmpty && self.authorResults.isEmpty {
                 self.isNotFindingResults = true
-//                self.timerCancellables.removeAll()
             }
         }
-
 
 //        Timer.publish(every: 10, on: .main, in: .common)
 //            .autoconnect()

--- a/Nos/Controller/SearchController.swift
+++ b/Nos/Controller/SearchController.swift
@@ -33,7 +33,8 @@ class SearchController: ObservableObject {
     
     private var cancellables = [AnyCancellable]()
     private var searchSubscriptions = SubscriptionCancellables()
-//    private var timerCancellables = [AnyCancellable]()
+
+    /// The timer for showing the "not finding results" view. Resets any time the query is changed.
     private var timer: Timer?
 
     private lazy var context: NSManagedObjectContext = {
@@ -82,7 +83,6 @@ class SearchController: ObservableObject {
                 if query.isEmpty {
                     self.isNotFindingResults = false
                     self.timer?.invalidate()
-//                    self.timerCancellables.removeAll()
                 } else {
                     self.startSearchTimer()
                 }
@@ -126,7 +126,6 @@ class SearchController: ObservableObject {
         query = ""
         authorResults = []
         isNotFindingResults = false
-//        timerCancellables.removeAll()
         timer?.invalidate()
     }
     
@@ -175,24 +174,13 @@ class SearchController: ObservableObject {
 
     func startSearchTimer() {
         isNotFindingResults = false
-//        timerCancellables.removeAll()
         timer?.invalidate()
 
-        timer = Timer.scheduledTimer(withTimeInterval: 1, repeats: false) { _ in
+        timer = Timer.scheduledTimer(withTimeInterval: 10, repeats: false) { _ in
             if !self.query.isEmpty && self.authorResults.isEmpty {
                 self.isNotFindingResults = true
             }
         }
-
-//        Timer.publish(every: 10, on: .main, in: .common)
-//            .autoconnect()
-//            .sink { _ in
-//                if !self.query.isEmpty && self.authorResults.isEmpty {
-//                    self.isNotFindingResults = true
-//                    self.timerCancellables.removeAll()
-//                }
-//            }
-//            .store(in: &timerCancellables)
     }
 
     func submitSearch() { // rename to seeIfThisIsSomeSortOfIdentifier (or maybe put this all into .map)

--- a/Nos/Views/DiscoverGrid.swift
+++ b/Nos/Views/DiscoverGrid.swift
@@ -54,7 +54,11 @@ struct DiscoverGrid: View {
                     } else {
                         // Search results
                         if searchController.authorResults.isEmpty {
-                            FullscreenProgressView(isPresented: .constant(true))
+                            FullscreenProgressView(
+                                isPresented: .constant(true),
+                                text: searchController.isNotFindingResults ?
+                                    String(localized: .localizable.notFindingResults) : nil
+                            )
                         } else {
                             ScrollView {
                                 LazyVStack {

--- a/Nos/Views/DiscoverView.swift
+++ b/Nos/Views/DiscoverView.swift
@@ -110,7 +110,6 @@ struct DiscoverView: View {
                     }
                 }
             }
-            .overlay(searchController.isNotFindingResults ? notFindingResultsView : nil)
             .searchable(
                 text: $searchController.query, 
                 placement: .toolbar, 
@@ -197,17 +196,6 @@ struct DiscoverView: View {
             .toolbarBackground(Color.cardBgBottom, for: .navigationBar)
             .navigationBarItems(leading: SideMenuButton())
         }
-    }
-
-    var notFindingResultsView: some View {
-        VStack(alignment: .center) {
-            Spacer()
-            Text(.localizable.notFindingResults)
-            Spacer()
-        }
-        .font(.body)
-        .foregroundColor(.primaryTxt)
-        .padding(.horizontal, 25)
     }
 }
 

--- a/Nos/Views/DiscoverView.swift
+++ b/Nos/Views/DiscoverView.swift
@@ -110,8 +110,6 @@ struct DiscoverView: View {
                     }
                 }
             }
-            .blur(radius: searchController.isNotFindingResults ? 6 : 0)
-            .opacity(searchController.isNotFindingResults ? 0.3 : 1)
             .overlay(searchController.isNotFindingResults ? notFindingResultsView : nil)
             .searchable(
                 text: $searchController.query, 

--- a/Nos/Views/DiscoverView.swift
+++ b/Nos/Views/DiscoverView.swift
@@ -110,6 +110,9 @@ struct DiscoverView: View {
                     }
                 }
             }
+            .blur(radius: searchController.isNotFindingResults ? 6 : 0)
+            .opacity(searchController.isNotFindingResults ? 0.3 : 1)
+            .overlay(searchController.isNotFindingResults ? notFindingResultsView : nil)
             .searchable(
                 text: $searchController.query, 
                 placement: .toolbar, 
@@ -196,6 +199,17 @@ struct DiscoverView: View {
             .toolbarBackground(Color.cardBgBottom, for: .navigationBar)
             .navigationBarItems(leading: SideMenuButton())
         }
+    }
+
+    var notFindingResultsView: some View {
+        VStack(alignment: .center) {
+            Spacer()
+            Text(.localizable.notFindingResults)
+            Spacer()
+        }
+        .font(.body)
+        .foregroundColor(.primaryTxt)
+        .padding(.horizontal, 25)
     }
 }
 

--- a/Nos/Views/FullscreenProgressView.swift
+++ b/Nos/Views/FullscreenProgressView.swift
@@ -24,7 +24,6 @@ struct FullscreenProgressView: View {
                 Text(text)
                     .padding(.vertical, 10)
                     .padding(.horizontal, 25)
-                    .font(.body)
                     .foregroundColor(.primaryTxt)
             }
             Spacer()
@@ -52,5 +51,6 @@ struct FullscreenProgressView: View {
 #Preview("Long text") {
     FullscreenProgressView(
         isPresented: .constant(true),
-        text: String(localized: .localizable.notFindingResults))
+        text: String(localized: .localizable.notFindingResults)
+    )
 }

--- a/Nos/Views/FullscreenProgressView.swift
+++ b/Nos/Views/FullscreenProgressView.swift
@@ -21,7 +21,11 @@ struct FullscreenProgressView: View {
             ProgressView()
                 .foregroundColor(.primaryTxt)
             if let text {
-                Text(text).padding(10)
+                Text(text)
+                    .padding(.vertical, 10)
+                    .padding(.horizontal, 25)
+                    .font(.body)
+                    .foregroundColor(.primaryTxt)
             }
             Spacer()
         }
@@ -37,9 +41,16 @@ struct FullscreenProgressView: View {
     }
 }
 
-struct FullscreenProgressView_Previews: PreviewProvider {
-    static var previews: some View {
-        FullscreenProgressView(isPresented: .constant(true))
-        FullscreenProgressView(isPresented: .constant(true), text: "Lorem ipsum...")
-    }
+#Preview("No text") {
+    FullscreenProgressView(isPresented: .constant(true))
+}
+
+#Preview("Short text") {
+    FullscreenProgressView(isPresented: .constant(true), text: "Lorem ipsum...")
+}
+
+#Preview("Long text") {
+    FullscreenProgressView(
+        isPresented: .constant(true),
+        text: String(localized: .localizable.notFindingResults))
 }


### PR DESCRIPTION
This implements the last part of #776 where we show a message if we can't find search results after 10 seconds.

Here's what it looks like:

https://github.com/planetary-social/nos/assets/59564/72eb2814-00cf-4b06-a1b3-07e5b70e2c10
