### PR TITLE
#849: Support GitHub merge queue in test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,8 @@ on:
     # This is needed to allow skipping enforcement of the changelog in PRs with specific labels,
     # as defined in the (optional) "skipLabels" property.
     types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
+  merge_group:
+    types: [checks_requested]
   push:
     branches: main
 env:


### PR DESCRIPTION
As we've accepted [the proposal to enable GitHub merge queue](https://github.com/planetary-social/nos/pull/836), this PR adds support for it in our test workflow. After this is working, we'll still need to enable it [in the project settings](https://github.com/planetary-social/nos/settings/branches), but this is needed first so our checks can run on PRs in the merge queue.

This is the first step of #849.

Further reading:

https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#triggering-merge-group-checks-with-github-actions

https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#merge_group

https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/merging-a-pull-request-with-a-merge-queue