### PR TITLE
#582: Move colors from SetUpUNSBanner to Assets

### DIFF
--- a/Nos/Assets/Assets.xcassets/Colors/uns-background.colorset/Contents.json
+++ b/Nos/Assets/Assets.xcassets/Colors/uns-background.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x2C",
+          "green" : "0x3C",
+          "red" : "0x92"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Nos/Assets/Assets.xcassets/Colors/uns-button-effect.colorset/Contents.json
+++ b/Nos/Assets/Assets.xcassets/Colors/uns-button-effect.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xB6",
+          "green" : "0xD4",
+          "red" : "0xF8"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Nos/Assets/Assets.xcassets/Colors/uns-button-gradient-leading.colorset/Contents.json
+++ b/Nos/Assets/Assets.xcassets/Colors/uns-button-gradient-leading.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xF7",
+          "green" : "0xF8",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Nos/Assets/Assets.xcassets/Colors/uns-button-gradient-trailing.colorset/Contents.json
+++ b/Nos/Assets/Assets.xcassets/Colors/uns-button-gradient-trailing.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xF5",
+          "green" : "0xF6",
+          "red" : "0xFD"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Nos/Assets/Assets.xcassets/Colors/uns-button-text.colorset/Contents.json
+++ b/Nos/Assets/Assets.xcassets/Colors/uns-button-text.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x41",
+          "green" : "0x61",
+          "red" : "0xF2"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Nos/Assets/Assets.xcassets/Colors/uns-checkmark.colorset/Contents.json
+++ b/Nos/Assets/Assets.xcassets/Colors/uns-checkmark.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x95",
+          "green" : "0x57",
+          "red" : "0xF9"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Nos/Assets/Assets.xcassets/Colors/uns-gradient-leading.colorset/Contents.json
+++ b/Nos/Assets/Assets.xcassets/Colors/uns-gradient-leading.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x08",
+          "green" : "0x85",
+          "red" : "0xF0"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Nos/Assets/Assets.xcassets/Colors/uns-gradient-trailing.colorset/Contents.json
+++ b/Nos/Assets/Assets.xcassets/Colors/uns-gradient-trailing.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x75",
+          "green" : "0x3F",
+          "red" : "0xF4"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Nos/Views/UNS/SetUpUNSBanner.swift
+++ b/Nos/Views/UNS/SetUpUNSBanner.swift
@@ -13,7 +13,7 @@ struct SetUpUNSBanner: View {
     
     private var backgroundGradient: LinearGradient {
         LinearGradient(
-            colors: [Color(hex: "#F08508"), Color(hex: "#F43F75")],
+            colors: [.unsGradientLeading, .unsGradientTrailing],
             startPoint: .leading,
             endPoint: .trailing
         )
@@ -21,7 +21,7 @@ struct SetUpUNSBanner: View {
     
     var body: some View {
         ZStack {
-            Color(hex: "#923c2c")
+            Color.unsBackground
                 .cornerRadius(21)
                 .offset(y: 2)
             VStack {
@@ -39,10 +39,10 @@ struct SetUpUNSBanner: View {
                 HStack {
                     ActionButton(
                         title: .localizable.manageUniversalName,
-                        textColor: Color(hex: "#f26141"),
-                        depthEffectColor: Color(hex: "#f8d4b6"),
+                        textColor: .unsButtonText,
+                        depthEffectColor: .unsButtonEffect,
                         backgroundGradient: LinearGradient(
-                            colors: [Color(hex: "#FFF8F7"), Color(hex: "#FDF6F5")],
+                            colors: [.unsButtonGradientLeading, .unsButtonGradientTrailing],
                             startPoint: .leading,
                             endPoint: .trailing
                         ),
@@ -62,7 +62,7 @@ struct SetUpUNSBanner: View {
                     Image(systemName: "checkmark.seal.fill")
                         .resizable()
                         .aspectRatio(1, contentMode: .fit)
-                        .foregroundColor(Color(hex: "#F95795"))
+                        .foregroundColor(.unsCheckmark)
                 }
                     .offset(x: 28)
             )


### PR DESCRIPTION
Just like it says: colors that used to be in SetUpUNSBanner are no more; they're in Assets now!

| Before | After |
|--------|--------|
| <img width="468" alt="Screenshot 2024-01-23 at 5 20 14 PM" src="https://github.com/planetary-social/nos/assets/59564/29cd0b8b-bf02-4560-b7dd-00904abe56d9"> | <img width="489" alt="Screenshot 2024-01-23 at 5 30 12 PM" src="https://github.com/planetary-social/nos/assets/59564/823e5662-eb60-4afd-b6ac-9b5cde0d2efd"> |