### PR TITLE
#724: Fix margins of root notes on Mac and iPad

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Fix a bug where the margins of root notes appeared incorrectly on Mac and iPad.
 - Optimized loading of the Notifications tab
 - Updated suggested users for discovery tab.
 - Show the profile view when a search matches a valid User ID (npub).
@@ -16,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed a bug that prevented notes that failed to be published to be re-published again.
 - Added pagination to the home feed.
 - Fixed a bug that prevented reposted notes from loading sometimes.
-- Fixed a bug that prevented profile photoes and names from being downloaded.
+- Fixed a bug that prevented profile photos and names from being downloaded.
 
 ## [0.1.2 (153)] - 2024-01-11Z
 

--- a/Nos/Views/ThreadRootView.swift
+++ b/Nos/Views/ThreadRootView.swift
@@ -26,6 +26,7 @@ struct ThreadRootView<Reply: View>: View {
         ZStack(alignment: .top) {
             NoteButton(note: root, showFullMessage: false, hideOutOfNetwork: false, tapAction: tapAction)
                 .padding(EdgeInsets(top: 0, leading: 20, bottom: 0, trailing: 20))
+                .readabilityPadding()
                 .opacity(0.7)
                 .frame(height: 100, alignment: .top)
                 .clipped()
@@ -48,7 +49,12 @@ struct ThreadRootView_Previews: PreviewProvider {
                 ThreadRootView(
                     root: previewData.longNote, 
                     tapAction: { _ in },
-                    reply: { EmptyView() } 
+                    reply: {
+                        NoteButton(
+                            note: previewData.reply,
+                            hideOutOfNetwork: false
+                        )
+                    }
                 )
             }
         }


### PR DESCRIPTION
#724

Adds readabilityPadding to the note so it appears correctly on Mac and iPad.