### PR TITLE
#849: Add CLA Assistant Lite to support merge queue

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,43 @@
+name: "CLA Assistant"
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened,closed,synchronize]
+
+# explicitly configure permissions, in case your GITHUB_TOKEN workflow permissions are set to read-only in repository settings
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
+  statuses: write
+
+jobs:
+  CLAAssistant:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "CLA Assistant"
+        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
+        uses: contributor-assistant/github-action@v2.3.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # the below token should have repo scope and must be manually added by you in the repository's secret
+          # This token is required only if you have configured to store the signatures in a remote repository/organization
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+        with:
+          path-to-signatures: 'signatures/version1/cla.json'
+          path-to-document: 'https://github.com/cla-assistant/github-action/blob/master/SAPCLA.md' # e.g. a CLA or a DCO document
+          # branch should not be protected
+          branch: 'main'
+          allowlist: user1,bot*
+
+         # the followings are the optional inputs - If the optional inputs are not given, then default values will be taken
+          #remote-organization-name: enter the remote organization name where the signatures should be stored (Default is storing the signatures in the same repository)
+          #remote-repository-name: enter the  remote repository name where the signatures should be stored (Default is storing the signatures in the same repository)
+          #create-file-commit-message: 'For example: Creating file for storing CLA Signatures'
+          #signed-commit-message: 'For example: $contributorName has signed the CLA in $owner/$repo#$pullRequestNo'
+          #custom-notsigned-prcomment: 'pull request comment with Introductory message to ask new contributors to sign'
+          #custom-pr-sign-comment: 'The signature to be committed in order to sign the CLA'
+          #custom-allsigned-prcomment: 'pull request comment when all contributors has signed, defaults to **CLA Assistant Lite bot** All Contributors have signed the CLA.'
+          #lock-pullrequest-aftermerge: false - if you don't want this bot to automatically lock the pull request after merging (default - true)
+          #use-dco-flag: true - If you are using DCO instead of CLA

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,3 +1,4 @@
+# via https://github.com/marketplace/actions/cla-assistant-lite
 name: "CLA Assistant"
 on:
   issue_comment:
@@ -26,10 +27,10 @@ jobs:
           PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
         with:
           path-to-signatures: 'signatures/version1/cla.json'
-          path-to-document: 'https://github.com/cla-assistant/github-action/blob/master/SAPCLA.md' # e.g. a CLA or a DCO document
+          path-to-document: 'https://github.com/planetary-social/nos/blob/main/CLA.md' # e.g. a CLA or a DCO document
           # branch should not be protected
           branch: 'main'
-          allowlist: user1,bot*
+          #allowlist: user1,bot*
 
          # the followings are the optional inputs - If the optional inputs are not given, then default values will be taken
           #remote-organization-name: enter the remote organization name where the signatures should be stored (Default is storing the signatures in the same repository)

--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,33 @@
+# Planetary Contributor Agreement
+
+This Planetary Contributor Agreement (this **"Agreement"**) applies to any Contribution you make to any Work.
+
+This is a binding legal agreement on you and any organization you represent. If you are signing this Agreement on behalf of your employer or other organization, you represent and warrant that you have the authority to agree to this Agreement on behalf of the organization.
+
+## 1. Definitions.
+
+**"Contribution"** means any original work, including any modification of or addition to an existing work, that you submit to Planetary in any manner for inclusion of any Work.
+
+**"Planetary," "we"** and **"us"** means Verse Communications, Inc.
+
+**"Work"** means any project, work or materials owned or managed by Planetary.
+
+**"You"** and **"your"** means you and any organization on who's behalf you are entering this Agreement.
+
+## 2. Copyright Assignment, License and Waiver.
+
+**(a) Assignment.** By Submitting a Contribution, you assign to Planetary all right, title and interest in any copyright you have in the Contribution, and you waive any rights, including any moral rights, database rights, etc., that may affect our ownership of the copyright in the Contribution.
+
+**(b) License to Planetary.** If your assignment in Section 2(a) is ineffective for any reason, you grant to us and to any recipient of any Work distributed by us, a perpetual, worldwide, transferable, non-exclusive, no-charge, royalty-free, irrevocable, and sub-licensable license to use, reproduce, prepare derivative works of, publicly display, publicly perform, sublicense, and distribute Contributions and any derivative work created based on a Contribution. If your license grant is ineffective for any reason, you irrevocably waive and covenant to not assert any claim you may have against us, our successors in interest, and any of our direct or indirect licensees and customers, arising out of our, our successors in interest's, or any of our direct or indirect licensees' or customers' use, reproduction, preparation of derivative works, public display, public performance, sublicense, and distribution of a Contribution. You also agree that we may publicly use your name and the name of any organization on whose behalf you're entering in to this Agreement in connection with publicizing the Work.
+
+**(c) License to You.** We grant to you a perpetual, worldwide, transferable, non-exclusive, no-charge, royalty-free, irrevocable, and sub-licensable license to use, reproduce, prepare derivative works of, publicly display, publicly perform, sublicense, and distribute a Contribution and any derivative works you create based on a Contribution.
+
+**3\. Patent License.** You grant to us and to any recipient of any Work distributed by us, a perpetual, worldwide, transferable, non-exclusive, no-charge, royalty-free, irrevocable, and subs licensable patent license to make, have made, use, sell, offers to sell, import, and otherwise transfer the Contribution in whole or in part, alone or included in any Work under any patent you own, or license from a third party, that is necessarily infringed by the Contribution or by combination of the Contribution with any Work.
+
+**4\. Your Representations and Warranties.** By submitting a Contribution, you represent and parent that: (a) each Contribution you submit is an original work and you legally grant the rights set out in tis Agreement; (b) the Contribution does not, and any exercise of the rights granted by you will not, infringe any third party's intellectual property or other right; and (c) you are not aware of any claims, suits, or actions pertaining to the Contribution. You will notify us immediately if you become aware or have reason to believe that any of you representations and warranties is or becomes inaccurate.
+
+**5\. Intellectual Property.** Except for the assignment and licenses set forth in this Agreement, this Agreement does not transfer any right, title or interest in any intellectual property right of either party to the other. If you choose to provide us with suggestions, ideas for improvement, recommendations or other feedback, on any Work we may use your feedback without any restriction or payment.
+
+**6\. Miscellaneous.** Oregon Law governs this Agreement, excluding any applicable conflict of laws rules or principals, and the parties agree to exclusive jurisdiction of the courts of Portland, Oregon. This Agreement does not create a partnership, agency relationship, or join venture between the parties. We ma assign this Agreement without notice or restriction. If any provision of this Agreement is unenforceable, that provision will be modified to render it enforceable to the extend possible to the effect the parties' intention and the rating provisions will not be affected. The parties may amend this Agreement only in a written amendment signed by both parties. This Agreement comprises the parties' entire agreement relating to the subject matter of this Agreement.
+
+**Agreed and accepted on my behalf and on behalf of my organization:**


### PR DESCRIPTION
Further support for #849.

Our current approach to checking the CLA doesn't seem to be compatible with GitHub merge queue, so @mplorentz found an alternative approach called [CLA Assistant Lite](https://github.com/marketplace/actions/cla-assistant-lite). This PR adds it so we can have a GitHub action that runs to check the CLA and store signatures here in this repo (in the default location: `signatures/version1/cla.json`).

I'm hopeful that this will work. However, their docs also say that the branch should not be protected; that's a problem since the merge queue is implemented by GitHub via branch protection. We'll see how it goes.

I copied the CLA from here:
https://cla-assistant.io/planetary-social/nos