### PR TITLE
Fix unit tests in non english locale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Fixed a date localization issue.
 - Optimized loading of the Notifications tab
 - Updated suggested users for discovery tab.
 - Show the profile view when a search matches a valid User ID (npub).

--- a/Nos/Extensions/Date+Elapsed.swift
+++ b/Nos/Extensions/Date+Elapsed.swift
@@ -51,7 +51,11 @@ extension Date {
         if let week = components.weekOfMonth, week >= 1 {
             let dateFormatter = DateFormatter()
             dateFormatter.timeStyle = .none
-            dateFormatter.dateFormat = DateFormatter.dateFormat(fromTemplate: "MMMMd", options: 0, locale: calendar.locale)
+            dateFormatter.dateFormat = DateFormatter.dateFormat(
+                fromTemplate: "MMMMd",
+                options: 0,
+                locale: calendar.locale
+            )
             dateFormatter.calendar = calendar
             dateFormatter.locale = calendar.locale
             dateFormatter.timeZone = calendar.timeZone

--- a/Nos/Extensions/Date+Elapsed.swift
+++ b/Nos/Extensions/Date+Elapsed.swift
@@ -51,7 +51,7 @@ extension Date {
         if let week = components.weekOfMonth, week >= 1 {
             let dateFormatter = DateFormatter()
             dateFormatter.timeStyle = .none
-            dateFormatter.setLocalizedDateFormatFromTemplate("MMMMd")
+            dateFormatter.dateFormat = DateFormatter.dateFormat(fromTemplate: "MMMMd", options: 0, locale: calendar.locale)
             dateFormatter.calendar = calendar
             dateFormatter.locale = calendar.locale
             dateFormatter.timeZone = calendar.timeZone

--- a/NosTests/Extensions/Date+ElapsedTests.swift
+++ b/NosTests/Extensions/Date+ElapsedTests.swift
@@ -131,18 +131,18 @@ final class Date_ElapsedTests: XCTestCase {
         XCTAssertEqual(
             try XCTUnwrap(calendar.date(byAdding: .weekOfMonth, value: -1, to: date))
                 .distanceString(date, calendar: calendar),
-            "décembre 2"
+            "2 décembre"
         )
         XCTAssertEqual(
             try XCTUnwrap(calendar.date(byAdding: .month, value: -1, to: date))
                 .distanceString(date, calendar: calendar),
-            "novembre 9"
+            "9 novembre"
         )
         XCTAssertEqual(
             try XCTUnwrap(calendar.date(byAdding: .year, value: -1, to: date))
                 .addingTimeInterval(1)
                 .distanceString(date, calendar: calendar),
-            "décembre 9"
+            "9 décembre"
         )
         XCTAssertEqual(
             try XCTUnwrap(calendar.date(byAdding: .year, value: -1, to: date))


### PR DESCRIPTION
#743 

I copied the code it was executing to a swift playground:

```
let locale = Locale(identifier: "fr")
var calendar = locale.calendar

let date = DateComponents(
    calendar: calendar,
    year: 2023,
    month: 12,
    day: 9,
    hour: 3,
    minute: 8,
    second: 23
).date

let dateFormatter = DateFormatter()
dateFormatter.timeStyle = .none
dateFormatter.calendar = calendar
dateFormatter.locale = calendar.locale
dateFormatter.timeZone = calendar.timeZone
dateFormatter.dateFormat = DateFormatter.dateFormat(
    fromTemplate: "MMMMd",
    options: 0,
    locale: calendar.locale
)

 dateFormatter.string(
    from: calendar.date(
        byAdding: .year,
        value: -1,
        to: date!
    )!.addingTimeInterval(1)
 )
```

And the result of running that in the playground was different to what I got in the unit tests. The playground was ok, while the unit tests was some weird mix of french and spanish (9 de novembre). This led me to think that it was a interaction with the simulator (which is where the unit tests are actually executed).

The documentation of [setLocalizedDateFormatFromTemplate](https://developer.apple.com/documentation/foundation/dateformatter/1417087-setlocalizeddateformatfromtempla) says that

> Calling this method is equivalent to, but not necessarily implemented as, setting the [dateFormat](https://developer.apple.com/documentation/foundation/dateformatter/1413514-dateformat) property to the result of calling the [dateFormat(fromTemplate:options:locale:)](https://developer.apple.com/documentation/foundation/dateformatter/1408112-dateformat) method, passing no options and the [locale](https://developer.apple.com/documentation/foundation/dateformatter/1411973-locale) property value.

Using that equivalent code gave me the expected value, just french. So I guess setLocalizedDateFormatFromTemplate has an issue when the locale is fixed (as in the unit tests).

I had to update the expected value anyway because it was wrong, in french the day is before the month (https://fr.wikipedia.org/wiki/9_novembre). This leads me to think that what we had there (9 novembre, that succeeded for you) was actually a mix of french and english. This enforces the theory that setLocalizedDateFormatFromTemplate mixes the locale of the simulator with the fixed locale (french).
