### PR TITLE
Fix bad data in the contact list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Fixed an issue where bad data in the contact list could break the home feed.
 - Optimized loading of the Notifications tab
 - Updated suggested users for discovery tab.
 - Show the profile view when a search matches a valid User ID (npub).

--- a/Nos.xcodeproj/project.pbxproj
+++ b/Nos.xcodeproj/project.pbxproj
@@ -319,6 +319,7 @@
 		C9BAB09C2996FBA10003A84E /* EventProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9BAB09A2996FBA10003A84E /* EventProcessor.swift */; };
 		C9BCF1C12AC72020009BDE06 /* UNSWizardChooseNameView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9BCF1C02AC72020009BDE06 /* UNSWizardChooseNameView.swift */; };
 		C9BD91892B61BBEF00FDA083 /* bad_contact_list.json in Resources */ = {isa = PBXBuildFile; fileRef = C9BD91882B61BBEF00FDA083 /* bad_contact_list.json */; };
+		C9BD919B2B61C4FB00FDA083 /* RawNostrID+Random.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9BD919A2B61C4FB00FDA083 /* RawNostrID+Random.swift */; };
 		C9C2B77C29E072E400548B4A /* WebSocket+Nos.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9C2B77B29E072E400548B4A /* WebSocket+Nos.swift */; };
 		C9C2B77D29E072E400548B4A /* WebSocket+Nos.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9C2B77B29E072E400548B4A /* WebSocket+Nos.swift */; };
 		C9C2B77F29E0731600548B4A /* AsyncTimer.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9C2B77E29E0731600548B4A /* AsyncTimer.swift */; };
@@ -669,6 +670,7 @@
 		C9BAB09A2996FBA10003A84E /* EventProcessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventProcessor.swift; sourceTree = "<group>"; };
 		C9BCF1C02AC72020009BDE06 /* UNSWizardChooseNameView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UNSWizardChooseNameView.swift; sourceTree = "<group>"; };
 		C9BD91882B61BBEF00FDA083 /* bad_contact_list.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = bad_contact_list.json; sourceTree = "<group>"; };
+		C9BD919A2B61C4FB00FDA083 /* RawNostrID+Random.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RawNostrID+Random.swift"; sourceTree = "<group>"; };
 		C9C2B77B29E072E400548B4A /* WebSocket+Nos.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WebSocket+Nos.swift"; sourceTree = "<group>"; };
 		C9C2B77E29E0731600548B4A /* AsyncTimer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncTimer.swift; sourceTree = "<group>"; };
 		C9C2B78129E0735400548B4A /* RelaySubscriptionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelaySubscriptionManager.swift; sourceTree = "<group>"; };
@@ -1000,6 +1002,7 @@
 				C9FC1E622B61ACE300A3A6FB /* CoreDataTestCase.swift */,
 				C91400232B2A3894009B13B4 /* SQLiteStoreTestCase.swift */,
 				C9C9444129F6F0E2002F2C7A /* XCTest+Eventually.swift */,
+				C9BD919A2B61C4FB00FDA083 /* RawNostrID+Random.swift */,
 			);
 			path = "Test Helpers";
 			sourceTree = "<group>";
@@ -1999,6 +2002,7 @@
 				C9C547552A4F1CDB006B0741 /* SearchController.swift in Sources */,
 				DC08FF802A796997009F87D1 /* ImagePickerUIViewController.swift in Sources */,
 				3FFB1D9429A6BBCE002A755D /* EventReference+CoreDataClass.swift in Sources */,
+				C9BD919B2B61C4FB00FDA083 /* RawNostrID+Random.swift in Sources */,
 				5B6EB49029EDBEC1006E750C /* NoteParserTests.swift in Sources */,
 				C9A6C7452AD83FB0001F9500 /* NotificationViewModel.swift in Sources */,
 			);

--- a/Nos.xcodeproj/project.pbxproj
+++ b/Nos.xcodeproj/project.pbxproj
@@ -73,6 +73,7 @@
 		A3B943D5299D514800A15A08 /* Follow+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3B943D4299D514800A15A08 /* Follow+CoreDataClass.swift */; };
 		A3B943D7299D6DB700A15A08 /* Follow+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3B943D4299D514800A15A08 /* Follow+CoreDataClass.swift */; };
 		A3B943D8299D758F00A15A08 /* KeyChain.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3B943CE299AE00100A15A08 /* KeyChain.swift */; };
+		C900385F2B6195C60080CC4F /* FollowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C900385E2B6195C60080CC4F /* FollowTests.swift */; };
 		C905B0752A619367009B8A78 /* DequeModule in Frameworks */ = {isa = PBXBuildFile; productRef = C905B0742A619367009B8A78 /* DequeModule */; };
 		C905B0772A619E99009B8A78 /* LinkPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = C905B0762A619E99009B8A78 /* LinkPreview.swift */; };
 		C90862BE29E9804B00C35A71 /* NosPerformanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C90862BD29E9804B00C35A71 /* NosPerformanceTests.swift */; };
@@ -161,6 +162,10 @@
 		C96877B92B4EDD110051ED2F /* AuthorStoryCarousel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C96877B82B4EDD110051ED2F /* AuthorStoryCarousel.swift */; };
 		C96877BB2B4EDE510051ED2F /* StoryAvatarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C96877BA2B4EDE510051ED2F /* StoryAvatarView.swift */; };
 		C96CB98C2A6040C500498C4E /* DequeModule in Frameworks */ = {isa = PBXBuildFile; productRef = C96CB98B2A6040C500498C4E /* DequeModule */; };
+		C96D391B2B61AFD500D3D0A1 /* RawNostrIDTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C96D391A2B61AFD500D3D0A1 /* RawNostrIDTests.swift */; };
+		C96D39252B61B06200D3D0A1 /* AuthorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C96D39242B61B06200D3D0A1 /* AuthorTests.swift */; };
+		C96D39272B61B6D200D3D0A1 /* RawNostrID.swift in Sources */ = {isa = PBXBuildFile; fileRef = C96D39262B61B6D200D3D0A1 /* RawNostrID.swift */; };
+		C96D39282B61B6D200D3D0A1 /* RawNostrID.swift in Sources */ = {isa = PBXBuildFile; fileRef = C96D39262B61B6D200D3D0A1 /* RawNostrID.swift */; };
 		C97141EE2AE95F07001A5DD0 /* USBCAddress.swift in Sources */ = {isa = PBXBuildFile; fileRef = C97141ED2AE95F07001A5DD0 /* USBCAddress.swift */; };
 		C97141EF2AE95F07001A5DD0 /* USBCAddress.swift in Sources */ = {isa = PBXBuildFile; fileRef = C97141ED2AE95F07001A5DD0 /* USBCAddress.swift */; };
 		C973364F2A7968220012D8B8 /* SetUpUNSBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = C973364E2A7968220012D8B8 /* SetUpUNSBanner.swift */; };
@@ -313,6 +318,7 @@
 		C9BAB09B2996FBA10003A84E /* EventProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9BAB09A2996FBA10003A84E /* EventProcessor.swift */; };
 		C9BAB09C2996FBA10003A84E /* EventProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9BAB09A2996FBA10003A84E /* EventProcessor.swift */; };
 		C9BCF1C12AC72020009BDE06 /* UNSWizardChooseNameView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9BCF1C02AC72020009BDE06 /* UNSWizardChooseNameView.swift */; };
+		C9BD91892B61BBEF00FDA083 /* bad_contact_list.json in Resources */ = {isa = PBXBuildFile; fileRef = C9BD91882B61BBEF00FDA083 /* bad_contact_list.json */; };
 		C9C2B77C29E072E400548B4A /* WebSocket+Nos.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9C2B77B29E072E400548B4A /* WebSocket+Nos.swift */; };
 		C9C2B77D29E072E400548B4A /* WebSocket+Nos.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9C2B77B29E072E400548B4A /* WebSocket+Nos.swift */; };
 		C9C2B77F29E0731600548B4A /* AsyncTimer.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9C2B77E29E0731600548B4A /* AsyncTimer.swift */; };
@@ -400,6 +406,7 @@
 		C9F84C21298DC36800C6714D /* AppView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9F84C20298DC36800C6714D /* AppView.swift */; };
 		C9F84C23298DC7B900C6714D /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9F84C22298DC7B900C6714D /* SettingsView.swift */; };
 		C9F84C27298DC98800C6714D /* KeyPair.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9F84C26298DC98800C6714D /* KeyPair.swift */; };
+		C9FC1E632B61ACE300A3A6FB /* CoreDataTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9FC1E622B61ACE300A3A6FB /* CoreDataTestCase.swift */; };
 		CD09A74429A50F1D0063464F /* SideMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD09A74329A50F1D0063464F /* SideMenu.swift */; };
 		CD09A74629A50F750063464F /* SideMenuContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD09A74529A50F750063464F /* SideMenuContent.swift */; };
 		CD09A74829A51EFC0063464F /* Router.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD09A74729A51EFC0063464F /* Router.swift */; };
@@ -507,6 +514,7 @@
 		A351E1A129BA92240009B7F6 /* ProfileEditView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProfileEditView.swift; sourceTree = "<group>"; };
 		A3B943CE299AE00100A15A08 /* KeyChain.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyChain.swift; sourceTree = "<group>"; };
 		A3B943D4299D514800A15A08 /* Follow+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Follow+CoreDataClass.swift"; sourceTree = "<group>"; };
+		C900385E2B6195C60080CC4F /* FollowTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FollowTests.swift; sourceTree = "<group>"; };
 		C905B0762A619E99009B8A78 /* LinkPreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkPreview.swift; sourceTree = "<group>"; };
 		C905EA342A3360FE006F1E99 /* StagingSecrets.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = StagingSecrets.xcconfig; path = Nos/Assets/StagingSecrets.xcconfig; sourceTree = SOURCE_ROOT; };
 		C90862BB29E9804B00C35A71 /* NosPerformanceTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = NosPerformanceTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -572,6 +580,9 @@
 		C9680AD32ACDF57D006C8C93 /* UNSWizardNeedsPaymentView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UNSWizardNeedsPaymentView.swift; sourceTree = "<group>"; };
 		C96877B82B4EDD110051ED2F /* AuthorStoryCarousel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthorStoryCarousel.swift; sourceTree = "<group>"; };
 		C96877BA2B4EDE510051ED2F /* StoryAvatarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoryAvatarView.swift; sourceTree = "<group>"; };
+		C96D391A2B61AFD500D3D0A1 /* RawNostrIDTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RawNostrIDTests.swift; sourceTree = "<group>"; };
+		C96D39242B61B06200D3D0A1 /* AuthorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthorTests.swift; sourceTree = "<group>"; };
+		C96D39262B61B6D200D3D0A1 /* RawNostrID.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RawNostrID.swift; sourceTree = "<group>"; };
 		C97141ED2AE95F07001A5DD0 /* USBCAddress.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = USBCAddress.swift; sourceTree = "<group>"; };
 		C973364E2A7968220012D8B8 /* SetUpUNSBanner.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SetUpUNSBanner.swift; sourceTree = "<group>"; };
 		C973AB552A323167002AED16 /* Follow+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Follow+CoreDataProperties.swift"; sourceTree = "<group>"; };
@@ -657,6 +668,7 @@
 		C9B71DC12A9003670031ED9F /* CrashReporting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrashReporting.swift; sourceTree = "<group>"; };
 		C9BAB09A2996FBA10003A84E /* EventProcessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventProcessor.swift; sourceTree = "<group>"; };
 		C9BCF1C02AC72020009BDE06 /* UNSWizardChooseNameView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UNSWizardChooseNameView.swift; sourceTree = "<group>"; };
+		C9BD91882B61BBEF00FDA083 /* bad_contact_list.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = bad_contact_list.json; sourceTree = "<group>"; };
 		C9C2B77B29E072E400548B4A /* WebSocket+Nos.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WebSocket+Nos.swift"; sourceTree = "<group>"; };
 		C9C2B77E29E0731600548B4A /* AsyncTimer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncTimer.swift; sourceTree = "<group>"; };
 		C9C2B78129E0735400548B4A /* RelaySubscriptionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelaySubscriptionManager.swift; sourceTree = "<group>"; };
@@ -724,6 +736,7 @@
 		C9F84C20298DC36800C6714D /* AppView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppView.swift; sourceTree = "<group>"; };
 		C9F84C22298DC7B900C6714D /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		C9F84C26298DC98800C6714D /* KeyPair.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyPair.swift; sourceTree = "<group>"; };
+		C9FC1E622B61ACE300A3A6FB /* CoreDataTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataTestCase.swift; sourceTree = "<group>"; };
 		CD09A74329A50F1D0063464F /* SideMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SideMenu.swift; sourceTree = "<group>"; };
 		CD09A74529A50F750063464F /* SideMenuContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SideMenuContent.swift; sourceTree = "<group>"; };
 		CD09A74729A51EFC0063464F /* Router.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Router.swift; sourceTree = "<group>"; };
@@ -984,8 +997,9 @@
 		C9C9443A29F6E420002F2C7A /* Test Helpers */ = {
 			isa = PBXGroup;
 			children = (
-				C9C9444129F6F0E2002F2C7A /* XCTest+Eventually.swift */,
+				C9FC1E622B61ACE300A3A6FB /* CoreDataTestCase.swift */,
 				C91400232B2A3894009B13B4 /* SQLiteStoreTestCase.swift */,
+				C9C9444129F6F0E2002F2C7A /* XCTest+Eventually.swift */,
 			);
 			path = "Test Helpers";
 			sourceTree = "<group>";
@@ -1070,6 +1084,7 @@
 				C9C9443A29F6E420002F2C7A /* Test Helpers */,
 				C9DEC0042989477A0078B43A /* Fixtures */,
 				C9DEBFE8298941020078B43A /* EventTests.swift */,
+				C96D391A2B61AFD500D3D0A1 /* RawNostrIDTests.swift */,
 				C9C45E152B23741E00F523DA /* EventObservationTests.swift */,
 				C9ADB132299287D60075E7F8 /* KeyPairTests.swift */,
 				5B6EB48F29EDBEC1006E750C /* NoteParserTests.swift */,
@@ -1078,6 +1093,8 @@
 				5B88051B2A21046C00E21F06 /* SHA256KeyTests.swift */,
 				5B88051E2A21056E00E21F06 /* TLVTests.swift */,
 				C94D59AD2AE7286E00295AE8 /* ReportTests.swift */,
+				C900385E2B6195C60080CC4F /* FollowTests.swift */,
+				C96D39242B61B06200D3D0A1 /* AuthorTests.swift */,
 			);
 			path = NosTests;
 			sourceTree = "<group>";
@@ -1130,6 +1147,7 @@
 				C9DEC005298947900078B43A /* sample_data.json */,
 				C9ADB134299288230075E7F8 /* KeyFixture.swift */,
 				C90B16B72AFED96300CB4B85 /* URLExtensionTests.swift */,
+				C9BD91882B61BBEF00FDA083 /* bad_contact_list.json */,
 			);
 			path = Fixtures;
 			sourceTree = "<group>";
@@ -1160,6 +1178,7 @@
 				C9F204602ADEDB720029A858 /* Wei.swift */,
 				030742C32B4769F90073839D /* CoreData */,
 				C936B4572A4C7B7C00DF1EB9 /* Nos.xcdatamodeld */,
+				C96D39262B61B6D200D3D0A1 /* RawNostrID.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -1501,22 +1520,22 @@
 			);
 			mainGroup = C9DEBFC5298941000078B43A;
 			packageReferences = (
-				C9DEC066298965270078B43A /* XCRemoteSwiftPackageReference "Starscream.git" */,
-				C97797BA298AB1890046BD25 /* XCRemoteSwiftPackageReference "secp256k1.swift" */,
+				C9DEC066298965270078B43A /* XCRemoteSwiftPackageReference "Starscream" */,
+				C97797BA298AB1890046BD25 /* XCRemoteSwiftPackageReference "secp256k1" */,
 				C94D855D29914D2300749478 /* XCRemoteSwiftPackageReference "swiftui-navigation" */,
-				C9ADB139299299570075E7F8 /* XCRemoteSwiftPackageReference "bech32.git" */,
+				C9ADB139299299570075E7F8 /* XCRemoteSwiftPackageReference "bech32" */,
 				C9646E9829B79E04007239A4 /* XCRemoteSwiftPackageReference "logger-ios" */,
-				C9646EA229B7A24A007239A4 /* XCRemoteSwiftPackageReference "posthog-ios.git" */,
+				C9646EA229B7A24A007239A4 /* XCRemoteSwiftPackageReference "posthog-ios" */,
 				C9646EA529B7A3DD007239A4 /* XCRemoteSwiftPackageReference "swift-dependencies" */,
-				C96CB98A2A6040C500498C4E /* XCRemoteSwiftPackageReference "swift-collections.git" */,
-				C9B71DBC2A8E9BAD0031ED9F /* XCRemoteSwiftPackageReference "sentry-cocoa.git" */,
+				C96CB98A2A6040C500498C4E /* XCRemoteSwiftPackageReference "swift-collections" */,
+				C9B71DBC2A8E9BAD0031ED9F /* XCRemoteSwiftPackageReference "sentry-cocoa" */,
 				C99DBF7C2A9E81CF00F7068F /* XCRemoteSwiftPackageReference "SDWebImageSwiftUI" */,
 				C9B737702AB24D5F00398BE7 /* XCRemoteSwiftPackageReference "SwiftGenPlugin" */,
 				C95F0AC82ABA379700A0D9CE /* XCRemoteSwiftPackageReference "WalletConnectSwiftV2" */,
-				C9AA1BB82ABB62EB00E8BD6D /* XCRemoteSwiftPackageReference "Web3.swift" */,
+				C9AA1BB82ABB62EB00E8BD6D /* XCRemoteSwiftPackageReference "Web3" */,
 				C9332C642ADED0D700AD7B0E /* XCLocalSwiftPackageReference "StarscreamOld" */,
 				C91565BF2B2368FA0068EECA /* XCRemoteSwiftPackageReference "ViewInspector" */,
-				3AD3185B2B294E6200026B07 /* XCRemoteSwiftPackageReference "xcstrings-tool-plugin.git" */,
+				3AD3185B2B294E6200026B07 /* XCRemoteSwiftPackageReference "xcstrings-tool-plugin" */,
 			);
 			productRefGroup = C9DEBFCF298941000078B43A /* Products */;
 			projectDirPath = "";
@@ -1587,6 +1606,7 @@
 				C987F83D29BA951E00B44E7A /* ClarityCity-Bold.otf in Resources */,
 				C987F84529BA951E00B44E7A /* ClarityCity-ExtraBoldItalic.otf in Resources */,
 				C987F84329BA951E00B44E7A /* ClarityCity-Black.otf in Resources */,
+				C9BD91892B61BBEF00FDA083 /* bad_contact_list.json in Resources */,
 				C987F85329BA951E00B44E7A /* ClarityCity-Regular.otf in Resources */,
 				C987F84729BA951E00B44E7A /* ClarityCity-Light.otf in Resources */,
 				C987F83929BA951E00B44E7A /* ClarityCity-MediumItalic.otf in Resources */,
@@ -1753,6 +1773,7 @@
 				5B8C96B629DDD3B200B73AEC /* EditableText.swift in Sources */,
 				C93EC2F129C337EB0012EE2A /* RelayPicker.swift in Sources */,
 				C9F0BB6F29A50437000547FC /* NostrConstants.swift in Sources */,
+				C96D39272B61B6D200D3D0A1 /* RawNostrID.swift in Sources */,
 				5BFF66B12A573F6400AA79DD /* RelayDetailView.swift in Sources */,
 				C9F204632ADEDB910029A858 /* Web3Utils.swift in Sources */,
 				C9F75AD62A041FF7005BBE45 /* ExpirationTimePicker.swift in Sources */,
@@ -1888,10 +1909,12 @@
 				5B08A1E12A1FDFF700EB8F2E /* TLV.swift in Sources */,
 				C9C2B78329E0735400548B4A /* RelaySubscriptionManager.swift in Sources */,
 				C9C2B78029E0731600548B4A /* AsyncTimer.swift in Sources */,
+				C96D39282B61B6D200D3D0A1 /* RawNostrID.swift in Sources */,
 				5B88051C2A21046C00E21F06 /* SHA256KeyTests.swift in Sources */,
 				C9B678E229EEC41000303F33 /* SocialGraphCache.swift in Sources */,
 				3AAB61B52B24CD0000717A07 /* Date+ElapsedTests.swift in Sources */,
 				C936B45F2A4CAF2B00DF1EB9 /* AppDelegate.swift in Sources */,
+				C96D391B2B61AFD500D3D0A1 /* RawNostrIDTests.swift in Sources */,
 				C9C2B77D29E072E400548B4A /* WebSocket+Nos.swift in Sources */,
 				C973AB642A323167002AED16 /* Relay+CoreDataProperties.swift in Sources */,
 				C9EE3E642A053910008A7491 /* ExpirationTimeOption.swift in Sources */,
@@ -1909,6 +1932,7 @@
 				C936B45A2A4C7B7C00DF1EB9 /* Nos.xcdatamodeld in Sources */,
 				C98CA9082B14FD8600929141 /* PagedRelaySubscription.swift in Sources */,
 				C9F204812AE02D8C0029A858 /* AppDestination.swift in Sources */,
+				C9FC1E632B61ACE300A3A6FB /* CoreDataTestCase.swift in Sources */,
 				C9E37E162A1E8143003D4B0A /* Report.swift in Sources */,
 				C987F86229BABAF800B44E7A /* String+Markdown.swift in Sources */,
 				C94A5E192A72C84200B6EC5D /* ReportCategory.swift in Sources */,
@@ -1943,6 +1967,7 @@
 				C9A6C7422AD837AD001F9500 /* UNSWizardController.swift in Sources */,
 				C9B678DC29EEBF3B00303F33 /* DependencyInjection.swift in Sources */,
 				C9F0BB6D29A503D9000547FC /* Int+Bool.swift in Sources */,
+				C96D39252B61B06200D3D0A1 /* AuthorTests.swift in Sources */,
 				DC08FF812A7969C5009F87D1 /* UIDevice+Simulator.swift in Sources */,
 				C9C9444229F6F0E2002F2C7A /* XCTest+Eventually.swift in Sources */,
 				C9680AD22ACC5251006C8C93 /* Either.swift in Sources */,
@@ -1967,6 +1992,7 @@
 				C9BAB09C2996FBA10003A84E /* EventProcessor.swift in Sources */,
 				C992B32B2B3613CC00704A9C /* SubscriptionCancellable.swift in Sources */,
 				C973AB5C2A323167002AED16 /* Follow+CoreDataProperties.swift in Sources */,
+				C900385F2B6195C60080CC4F /* FollowTests.swift in Sources */,
 				C93005602A6AF8320098CA9E /* LoadingContent.swift in Sources */,
 				C97A1C8F29E58EC7009D9E8D /* NSManagedObjectContext+Nos.swift in Sources */,
 				C9ADB135299288230075E7F8 /* KeyFixture.swift in Sources */,
@@ -1992,11 +2018,11 @@
 /* Begin PBXTargetDependency section */
 		3AD3185D2B294E9000026B07 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			productRef = 3AD3185C2B294E9000026B07 /* plugin:XCStringsToolPlugin */;
+			productRef = 3AD3185C2B294E9000026B07 /* XCStringsToolPlugin */;
 		};
 		3AEABEF32B2BF806001BC933 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			productRef = 3AEABEF22B2BF806001BC933 /* plugin:XCStringsToolPlugin */;
+			productRef = 3AEABEF22B2BF806001BC933 /* XCStringsToolPlugin */;
 		};
 		C90862C229E9804B00C35A71 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -2005,11 +2031,11 @@
 		};
 		C9A6C7442AD83F7A001F9500 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			productRef = C9A6C7432AD83F7A001F9500 /* plugin:SwiftGenPlugin */;
+			productRef = C9A6C7432AD83F7A001F9500 /* SwiftGenPlugin */;
 		};
 		C9D573402AB24A3700E06BB4 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			productRef = C9D5733F2AB24A3700E06BB4 /* plugin:SwiftGenPlugin */;
+			productRef = C9D5733F2AB24A3700E06BB4 /* SwiftGenPlugin */;
 		};
 		C9DEBFE6298941020078B43A /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -2452,7 +2478,7 @@
 /* End XCLocalSwiftPackageReference section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		3AD3185B2B294E6200026B07 /* XCRemoteSwiftPackageReference "xcstrings-tool-plugin.git" */ = {
+		3AD3185B2B294E6200026B07 /* XCRemoteSwiftPackageReference "xcstrings-tool-plugin" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/liamnichols/xcstrings-tool-plugin.git";
 			requirement = {
@@ -2492,7 +2518,7 @@
 				minimumVersion = 1.1.0;
 			};
 		};
-		C9646EA229B7A24A007239A4 /* XCRemoteSwiftPackageReference "posthog-ios.git" */ = {
+		C9646EA229B7A24A007239A4 /* XCRemoteSwiftPackageReference "posthog-ios" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/PostHog/posthog-ios.git";
 			requirement = {
@@ -2508,7 +2534,7 @@
 				minimumVersion = 0.1.4;
 			};
 		};
-		C96CB98A2A6040C500498C4E /* XCRemoteSwiftPackageReference "swift-collections.git" */ = {
+		C96CB98A2A6040C500498C4E /* XCRemoteSwiftPackageReference "swift-collections" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/apple/swift-collections.git";
 			requirement = {
@@ -2516,7 +2542,7 @@
 				minimumVersion = 1.0.0;
 			};
 		};
-		C97797BA298AB1890046BD25 /* XCRemoteSwiftPackageReference "secp256k1.swift" */ = {
+		C97797BA298AB1890046BD25 /* XCRemoteSwiftPackageReference "secp256k1" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/GigaBitcoin/secp256k1.swift";
 			requirement = {
@@ -2532,7 +2558,7 @@
 				minimumVersion = 2.0.0;
 			};
 		};
-		C9AA1BB82ABB62EB00E8BD6D /* XCRemoteSwiftPackageReference "Web3.swift" */ = {
+		C9AA1BB82ABB62EB00E8BD6D /* XCRemoteSwiftPackageReference "Web3" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/Boilertalk/Web3.swift";
 			requirement = {
@@ -2540,7 +2566,7 @@
 				minimumVersion = 0.8.4;
 			};
 		};
-		C9ADB139299299570075E7F8 /* XCRemoteSwiftPackageReference "bech32.git" */ = {
+		C9ADB139299299570075E7F8 /* XCRemoteSwiftPackageReference "bech32" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/0xdeadp00l/bech32.git";
 			requirement = {
@@ -2548,7 +2574,7 @@
 				kind = branch;
 			};
 		};
-		C9B71DBC2A8E9BAD0031ED9F /* XCRemoteSwiftPackageReference "sentry-cocoa.git" */ = {
+		C9B71DBC2A8E9BAD0031ED9F /* XCRemoteSwiftPackageReference "sentry-cocoa" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/getsentry/sentry-cocoa.git";
 			requirement = {
@@ -2572,7 +2598,7 @@
 				minimumVersion = 6.6.2;
 			};
 		};
-		C9DEC066298965270078B43A /* XCRemoteSwiftPackageReference "Starscream.git" */ = {
+		C9DEC066298965270078B43A /* XCRemoteSwiftPackageReference "Starscream" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/daltoniam/Starscream.git";
 			requirement = {
@@ -2583,19 +2609,19 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		3AD3185C2B294E9000026B07 /* plugin:XCStringsToolPlugin */ = {
+		3AD3185C2B294E9000026B07 /* XCStringsToolPlugin */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 3AD3185B2B294E6200026B07 /* XCRemoteSwiftPackageReference "xcstrings-tool-plugin.git" */;
+			package = 3AD3185B2B294E6200026B07 /* XCRemoteSwiftPackageReference "xcstrings-tool-plugin" */;
 			productName = "plugin:XCStringsToolPlugin";
 		};
-		3AEABEF22B2BF806001BC933 /* plugin:XCStringsToolPlugin */ = {
+		3AEABEF22B2BF806001BC933 /* XCStringsToolPlugin */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 3AD3185B2B294E6200026B07 /* XCRemoteSwiftPackageReference "xcstrings-tool-plugin.git" */;
+			package = 3AD3185B2B294E6200026B07 /* XCRemoteSwiftPackageReference "xcstrings-tool-plugin" */;
 			productName = "plugin:XCStringsToolPlugin";
 		};
 		C905B0742A619367009B8A78 /* DequeModule */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = C96CB98A2A6040C500498C4E /* XCRemoteSwiftPackageReference "swift-collections.git" */;
+			package = C96CB98A2A6040C500498C4E /* XCRemoteSwiftPackageReference "swift-collections" */;
 			productName = DequeModule;
 		};
 		C91565C02B2368FA0068EECA /* ViewInspector */ = {
@@ -2618,7 +2644,7 @@
 		};
 		C94824492B32364900005B36 /* Web3 */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = C9AA1BB82ABB62EB00E8BD6D /* XCRemoteSwiftPackageReference "Web3.swift" */;
+			package = C9AA1BB82ABB62EB00E8BD6D /* XCRemoteSwiftPackageReference "Web3" */;
 			productName = Web3;
 		};
 		C94D855E29914D2300749478 /* SwiftUINavigation */ = {
@@ -2643,7 +2669,7 @@
 		};
 		C9646EA329B7A24A007239A4 /* PostHog */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = C9646EA229B7A24A007239A4 /* XCRemoteSwiftPackageReference "posthog-ios.git" */;
+			package = C9646EA229B7A24A007239A4 /* XCRemoteSwiftPackageReference "posthog-ios" */;
 			productName = PostHog;
 		};
 		C9646EA629B7A3DD007239A4 /* Dependencies */ = {
@@ -2653,7 +2679,7 @@
 		};
 		C9646EA829B7A4F2007239A4 /* PostHog */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = C9646EA229B7A24A007239A4 /* XCRemoteSwiftPackageReference "posthog-ios.git" */;
+			package = C9646EA229B7A24A007239A4 /* XCRemoteSwiftPackageReference "posthog-ios" */;
 			productName = PostHog;
 		};
 		C9646EAB29B7A520007239A4 /* Dependencies */ = {
@@ -2663,17 +2689,17 @@
 		};
 		C96CB98B2A6040C500498C4E /* DequeModule */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = C96CB98A2A6040C500498C4E /* XCRemoteSwiftPackageReference "swift-collections.git" */;
+			package = C96CB98A2A6040C500498C4E /* XCRemoteSwiftPackageReference "swift-collections" */;
 			productName = DequeModule;
 		};
 		C97797BB298AB1890046BD25 /* secp256k1 */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = C97797BA298AB1890046BD25 /* XCRemoteSwiftPackageReference "secp256k1.swift" */;
+			package = C97797BA298AB1890046BD25 /* XCRemoteSwiftPackageReference "secp256k1" */;
 			productName = secp256k1;
 		};
 		C97797BE298ABE060046BD25 /* secp256k1 */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = C97797BA298AB1890046BD25 /* XCRemoteSwiftPackageReference "secp256k1.swift" */;
+			package = C97797BA298AB1890046BD25 /* XCRemoteSwiftPackageReference "secp256k1" */;
 			productName = secp256k1;
 		};
 		C99DBF7D2A9E81CF00F7068F /* SDWebImageSwiftUI */ = {
@@ -2691,7 +2717,7 @@
 			package = C99DBF7C2A9E81CF00F7068F /* XCRemoteSwiftPackageReference "SDWebImageSwiftUI" */;
 			productName = SDWebImageSwiftUI;
 		};
-		C9A6C7432AD83F7A001F9500 /* plugin:SwiftGenPlugin */ = {
+		C9A6C7432AD83F7A001F9500 /* SwiftGenPlugin */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = C9B737702AB24D5F00398BE7 /* XCRemoteSwiftPackageReference "SwiftGenPlugin" */;
 			productName = "plugin:SwiftGenPlugin";
@@ -2703,7 +2729,7 @@
 		};
 		C9AA1BB92ABB62EB00E8BD6D /* Web3 */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = C9AA1BB82ABB62EB00E8BD6D /* XCRemoteSwiftPackageReference "Web3.swift" */;
+			package = C9AA1BB82ABB62EB00E8BD6D /* XCRemoteSwiftPackageReference "Web3" */;
 			productName = Web3;
 		};
 		C9AA1BBB2ABB6E8900E8BD6D /* WalletConnectModal */ = {
@@ -2713,17 +2739,17 @@
 		};
 		C9B71DBD2A8E9BAD0031ED9F /* Sentry */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = C9B71DBC2A8E9BAD0031ED9F /* XCRemoteSwiftPackageReference "sentry-cocoa.git" */;
+			package = C9B71DBC2A8E9BAD0031ED9F /* XCRemoteSwiftPackageReference "sentry-cocoa" */;
 			productName = Sentry;
 		};
 		C9B71DBF2A8E9BAD0031ED9F /* SentrySwiftUI */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = C9B71DBC2A8E9BAD0031ED9F /* XCRemoteSwiftPackageReference "sentry-cocoa.git" */;
+			package = C9B71DBC2A8E9BAD0031ED9F /* XCRemoteSwiftPackageReference "sentry-cocoa" */;
 			productName = SentrySwiftUI;
 		};
 		C9B71DC42A9008300031ED9F /* Sentry */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = C9B71DBC2A8E9BAD0031ED9F /* XCRemoteSwiftPackageReference "sentry-cocoa.git" */;
+			package = C9B71DBC2A8E9BAD0031ED9F /* XCRemoteSwiftPackageReference "sentry-cocoa" */;
 			productName = Sentry;
 		};
 		C9BA85902B23628300AFC2C3 /* Logger */ = {
@@ -2743,12 +2769,12 @@
 		};
 		C9BA85962B23638700AFC2C3 /* Starscream */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = C9DEC066298965270078B43A /* XCRemoteSwiftPackageReference "Starscream.git" */;
+			package = C9DEC066298965270078B43A /* XCRemoteSwiftPackageReference "Starscream" */;
 			productName = Starscream;
 		};
 		C9BA85982B23638700AFC2C3 /* secp256k1 */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = C97797BA298AB1890046BD25 /* XCRemoteSwiftPackageReference "secp256k1.swift" */;
+			package = C97797BA298AB1890046BD25 /* XCRemoteSwiftPackageReference "secp256k1" */;
 			productName = secp256k1;
 		};
 		C9BA859A2B23638700AFC2C3 /* SwiftUINavigation */ = {
@@ -2758,17 +2784,17 @@
 		};
 		C9BA859C2B23638700AFC2C3 /* PostHog */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = C9646EA229B7A24A007239A4 /* XCRemoteSwiftPackageReference "posthog-ios.git" */;
+			package = C9646EA229B7A24A007239A4 /* XCRemoteSwiftPackageReference "posthog-ios" */;
 			productName = PostHog;
 		};
 		C9BA859E2B23638700AFC2C3 /* DequeModule */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = C96CB98A2A6040C500498C4E /* XCRemoteSwiftPackageReference "swift-collections.git" */;
+			package = C96CB98A2A6040C500498C4E /* XCRemoteSwiftPackageReference "swift-collections" */;
 			productName = DequeModule;
 		};
 		C9BA85A02B23638700AFC2C3 /* SentrySwiftUI */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = C9B71DBC2A8E9BAD0031ED9F /* XCRemoteSwiftPackageReference "sentry-cocoa.git" */;
+			package = C9B71DBC2A8E9BAD0031ED9F /* XCRemoteSwiftPackageReference "sentry-cocoa" */;
 			productName = SentrySwiftUI;
 		};
 		C9BA85A22B23638700AFC2C3 /* WalletConnect */ = {
@@ -2778,7 +2804,7 @@
 		};
 		C9BA85A42B23638700AFC2C3 /* Web3 */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = C9AA1BB82ABB62EB00E8BD6D /* XCRemoteSwiftPackageReference "Web3.swift" */;
+			package = C9AA1BB82ABB62EB00E8BD6D /* XCRemoteSwiftPackageReference "Web3" */;
 			productName = Web3;
 		};
 		C9BA85A62B23638700AFC2C3 /* StarscreamOld */ = {
@@ -2793,22 +2819,22 @@
 		};
 		C9BA85AA2B2363CA00AFC2C3 /* Sentry */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = C9B71DBC2A8E9BAD0031ED9F /* XCRemoteSwiftPackageReference "sentry-cocoa.git" */;
+			package = C9B71DBC2A8E9BAD0031ED9F /* XCRemoteSwiftPackageReference "sentry-cocoa" */;
 			productName = Sentry;
 		};
-		C9D5733F2AB24A3700E06BB4 /* plugin:SwiftGenPlugin */ = {
+		C9D5733F2AB24A3700E06BB4 /* SwiftGenPlugin */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = C9C8450C2AB249DB00654BC1 /* XCRemoteSwiftPackageReference "SwiftGenPlugin" */;
 			productName = "plugin:SwiftGenPlugin";
 		};
 		C9DEC067298965270078B43A /* Starscream */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = C9DEC066298965270078B43A /* XCRemoteSwiftPackageReference "Starscream.git" */;
+			package = C9DEC066298965270078B43A /* XCRemoteSwiftPackageReference "Starscream" */;
 			productName = Starscream;
 		};
 		CDDA1F7A29A527650047ACD8 /* Starscream */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = C9DEC066298965270078B43A /* XCRemoteSwiftPackageReference "Starscream.git" */;
+			package = C9DEC066298965270078B43A /* XCRemoteSwiftPackageReference "Starscream" */;
 			productName = Starscream;
 		};
 		CDDA1F7C29A527650047ACD8 /* SwiftUINavigation */ = {

--- a/Nos/Controller/UNSWizardController.swift
+++ b/Nos/Controller/UNSWizardController.swift
@@ -37,7 +37,7 @@ class UNSWizardController: ObservableObject {
     }
     
     @Published var state: FlowState
-    @Published var authorKey: HexadecimalString?
+    @Published var authorKey: RawAuthorID?
     @Published var textField: String 
     @Published var phoneNumber: String?
     @Published var nameRecord: UNSNameRecord?
@@ -52,7 +52,7 @@ class UNSWizardController: ObservableObject {
     
     internal init(
         state: UNSWizardController.FlowState = .intro, 
-        authorKey: HexadecimalString? = nil, 
+        authorKey: RawAuthorID? = nil, 
         textField: String = "", 
         phoneNumber: String? = nil, 
         nameRecord: UNSNameRecord? = nil, 

--- a/Nos/Extensions/Data+Encoding.swift
+++ b/Nos/Extensions/Data+Encoding.swift
@@ -7,8 +7,6 @@
 
 import Foundation
 
-typealias HexadecimalString = String
-
 enum DataError: Error {
     case generic
 }

--- a/Nos/Extensions/String+Hex.swift
+++ b/Nos/Extensions/String+Hex.swift
@@ -27,4 +27,9 @@ extension String {
         }
         return data
     }
+    
+    var isValidHexadecimal: Bool {
+        let regex = "^[0-9a-fA-F]+$"
+        return range(of: regex, options: .regularExpression) != nil
+    }
 }

--- a/Nos/Models/CoreData/Author+CoreDataClass.swift
+++ b/Nos/Models/CoreData/Author+CoreDataClass.swift
@@ -87,7 +87,7 @@ enum AuthorError: Error {
         return nil
     }
     
-    var followedKeys: [HexadecimalString] {
+    var followedKeys: [RawAuthorID] {
         follows.compactMap({ $0.destination?.hexadecimalPublicKey }) 
     }
 
@@ -95,7 +95,7 @@ enum AuthorError: Error {
         name?.isEmpty == false || displayName?.isEmpty == false
     }
     
-    class func request(by pubKey: HexadecimalString) -> NSFetchRequest<Author> {
+    class func request(by pubKey: RawAuthorID) -> NSFetchRequest<Author> {
         let fetchRequest = NSFetchRequest<Author>(entityName: String(describing: Author.self))
         fetchRequest.predicate = NSPredicate(format: "hexadecimalPublicKey = %@", pubKey)
         fetchRequest.fetchLimit = 1
@@ -103,7 +103,7 @@ enum AuthorError: Error {
         return fetchRequest
     }
     
-    class func find(by pubKey: HexadecimalString, context: NSManagedObjectContext) throws -> Author? {
+    class func find(by pubKey: RawAuthorID, context: NSManagedObjectContext) throws -> Author? {
         let fetchRequest = request(by: pubKey)
         if let author = try context.fetch(fetchRequest).first {
             return author
@@ -122,7 +122,7 @@ enum AuthorError: Error {
     }
     
     @discardableResult
-    class func findOrCreate(by pubKey: HexadecimalString, context: NSManagedObjectContext) throws -> Author {
+    class func findOrCreate(by pubKey: RawAuthorID, context: NSManagedObjectContext) throws -> Author {
         if let author = try? Author.find(by: pubKey, context: context) {
             return author
         } else {

--- a/Nos/Models/CoreData/Author+CoreDataClass.swift
+++ b/Nos/Models/CoreData/Author+CoreDataClass.swift
@@ -88,7 +88,9 @@ enum AuthorError: Error {
     }
     
     var followedKeys: [RawAuthorID] {
-        follows.compactMap({ $0.destination?.hexadecimalPublicKey }) 
+        follows
+            .compactMap({ $0.destination?.hexadecimalPublicKey }) 
+            .filter { $0.isValid }
     }
 
     var hasHumanFriendlyName: Bool {

--- a/Nos/Models/CoreData/Author+CoreDataProperties.swift
+++ b/Nos/Models/CoreData/Author+CoreDataProperties.swift
@@ -17,7 +17,7 @@ extension Author {
 
     @NSManaged public var about: String?
     @NSManaged public var displayName: String?
-    @NSManaged public var hexadecimalPublicKey: String?
+    @NSManaged public var hexadecimalPublicKey: RawAuthorID?
     @NSManaged public var lastUpdatedContactList: Date?
     @NSManaged public var lastUpdatedMetadata: Date?
     @NSManaged public var muted: Bool

--- a/Nos/Models/CoreData/Event+CoreDataClass.swift
+++ b/Nos/Models/CoreData/Event+CoreDataClass.swift
@@ -669,12 +669,8 @@ public class Event: NosManagedObject {
         
         var newFollows = Set<Follow>()
         for jsonTag in jsonEvent.tags {
-            guard let followedKey = jsonTag[safe: 1],
-                followedKey.isValid else {
-                continue
-            }
-            
-            if let existingFollow = originalFollows[followedKey] {
+            if let followedKey = jsonTag[safe: 1], 
+                let existingFollow = originalFollows[followedKey] {
                 // We already have a Core Data Follow model for this user
                 newFollows.insert(existingFollow)
             } else {

--- a/Nos/Models/CoreData/Event+CoreDataClass.swift
+++ b/Nos/Models/CoreData/Event+CoreDataClass.swift
@@ -669,8 +669,12 @@ public class Event: NosManagedObject {
         
         var newFollows = Set<Follow>()
         for jsonTag in jsonEvent.tags {
-            if let followedKey = jsonTag[safe: 1], 
-                let existingFollow = originalFollows[followedKey] {
+            guard let followedKey = jsonTag[safe: 1],
+                followedKey.isValid else {
+                continue
+            }
+            
+            if let existingFollow = originalFollows[followedKey] {
                 // We already have a Core Data Follow model for this user
                 newFollows.insert(existingFollow)
             } else {

--- a/Nos/Models/CoreData/Event+CoreDataProperties.swift
+++ b/Nos/Models/CoreData/Event+CoreDataProperties.swift
@@ -19,7 +19,7 @@ extension Event {
     @NSManaged public var content: String?
     @NSManaged public var createdAt: Date?
     @NSManaged public var expirationDate: Date?
-    @NSManaged public var identifier: String?
+    @NSManaged public var identifier: RawEventID?
     @NSManaged public var isVerified: Bool
     @NSManaged public var kind: Int64
     @NSManaged public var receivedAt: Date?

--- a/Nos/Models/CoreData/Follow+CoreDataClass.swift
+++ b/Nos/Models/CoreData/Follow+CoreDataClass.swift
@@ -61,6 +61,7 @@ struct FollowerComparator: SortComparator {
 @objc(Follow)
 public class Follow: NosManagedObject {
     
+    // swiftlint:disable:next function_body_length
     class func upsert(
         by author: Author,
         jsonTag: [String],
@@ -72,6 +73,15 @@ public class Follow: NosManagedObject {
                 DecodingError.Context(
                     codingPath: [],
                     debugDescription: "Encoded tags did not have a key at position 1"
+                )
+            )
+        }
+        guard followedKey.isValid else {
+            throw DecodingError.valueNotFound(
+                Follow.self,
+                DecodingError.Context(
+                    codingPath: [],
+                    debugDescription: "Tag \(followedKey) is not a valid hexadecimal public key"
                 )
             )
         }

--- a/Nos/Models/CoreData/NosNotification+CoreDataClass.swift
+++ b/Nos/Models/CoreData/NosNotification+CoreDataClass.swift
@@ -15,9 +15,9 @@ import CoreData
 public class NosNotification: NSManagedObject {
 
     static func createIfNecessary(
-        from eventID: HexadecimalString,
+        from eventID: RawEventID,
         date: Date,
-        authorKey: HexadecimalString,
+        authorKey: RawAuthorID,
         in context: NSManagedObjectContext
     ) throws -> NosNotification? {
         guard date > staleNotificationCutoff() else {
@@ -35,7 +35,7 @@ public class NosNotification: NSManagedObject {
         }
     }
     
-    static func find(by eventID: HexadecimalString, in context: NSManagedObjectContext) throws -> NosNotification? {
+    static func find(by eventID: RawEventID, in context: NSManagedObjectContext) throws -> NosNotification? {
         let fetchRequest = request(by: eventID)
         if let notification = try context.fetch(fetchRequest).first {
             return notification
@@ -44,7 +44,7 @@ public class NosNotification: NSManagedObject {
         return nil
     }
     
-    static func request(by eventID: HexadecimalString) -> NSFetchRequest<NosNotification> {
+    static func request(by eventID: RawEventID) -> NSFetchRequest<NosNotification> {
         let fetchRequest = NSFetchRequest<NosNotification>(entityName: String(describing: NosNotification.self))
         fetchRequest.predicate = NSPredicate(format: "eventID = %@", eventID)
         fetchRequest.fetchLimit = 1

--- a/Nos/Models/JSONEvent.swift
+++ b/Nos/Models/JSONEvent.swift
@@ -48,7 +48,7 @@ struct JSONEvent: Codable, Hashable {
     }
     
     internal init(
-        pubKey: HexadecimalString, 
+        pubKey: RawAuthorID, 
         createdAt: Date = .now, 
         kind: EventKind, 
         tags: [[String]], 

--- a/Nos/Models/NotificationViewModel.swift
+++ b/Nos/Models/NotificationViewModel.swift
@@ -16,13 +16,13 @@ import UIKit
 /// `loadContent()` to populate the `content` variable because it relies on some
 ///  database queries.
 class NotificationViewModel: ObservableObject, Identifiable {
-    let noteID: HexadecimalString
+    let noteID: RawEventID
     let authorProfilePhotoURL: URL?
     let actionText: AttributedString
     @Published var content: AttributedString?
     let date: Date
     
-    var id: HexadecimalString {
+    var id: RawEventID {
         noteID
     }
     

--- a/Nos/Models/PublicKey.swift
+++ b/Nos/Models/PublicKey.swift
@@ -23,7 +23,7 @@ enum KeyError: Error {
 /// A model for Ed25519 X-only public keys. In Nostr the public key identifies a single author (although one author
 /// may have multiple public keys) and is used to cryptographically prove that a given Event was signed by the author.
 struct PublicKey {
-    var hex: HexadecimalString
+    var hex: RawAuthorID
     let npub: String
      
     private let underlyingKey: secp256k1.Signing.XonlyKey

--- a/Nos/Models/RawNostrID.swift
+++ b/Nos/Models/RawNostrID.swift
@@ -1,0 +1,41 @@
+//
+//  RawNostrID.swift
+//  Nos
+//
+//  Created by Matthew Lorentz on 1/24/24.
+//
+
+import Foundation
+
+// swiftlint:disable line_length
+
+/// A unique ID for either a Nostr user or event. In the case of a user this is their hex-encoded public key. If it's
+/// an event it is the hex-encoded sha256 of the serialized event data. See [NIP-01](https://github.com/nostr-protocol/nips/blob/master/01.md)) 
+/// for details.
+///
+/// These IDs are widely used at the protocol level, but should never be displayed to users. When displaying IDs to 
+/// users they should be bech-32 formatted strings as described by [NIP-19](https://github.com/nostr-protocol/nips/blob/master/19.md)
+/// 
+/// For now we are modeling this as a String because it's easy and can be stored natively in Core Data but it could be 
+/// refactored to be its own type.
+public typealias RawNostrID = String
+// swiftlint:enable line_length
+
+/// An alias for a RawNostrID that we know is for an Event. See docs for `RawNostrID`.
+public typealias RawEventID = RawNostrID
+
+/// An alias for a RawNostrID that we know is for an Author. See docs for `RawNostrID`.
+public typealias RawAuthorID = RawNostrID
+
+extension RawNostrID {
+    
+    /// Verifies that this ID is the right length and is a hexadecimal string. It cannot check that this refers to a
+    /// real Nostr user or event.
+    var isValid: Bool {
+        if count != 64 {
+            return false
+        }
+        
+        return isValidHexadecimal
+    }
+}

--- a/Nos/Service/Analytics.swift
+++ b/Nos/Service/Analytics.swift
@@ -172,6 +172,16 @@ class Analytics {
         track("Rate Limited", properties: ["relay": socket.request.url?.absoluteString ?? "null"])
     }
     
+    func badRequest(from socket: WebSocket, message: String) {
+        track(
+            "Bad Request to Relay", 
+            properties: [
+                "relay": socket.request.url?.absoluteString ?? "null",
+                "details": message
+            ]
+        )
+    }
+    
     // MARK: - Notifications
     
     func receivedNotification() {

--- a/Nos/Service/PushNotificationService.swift
+++ b/Nos/Service/PushNotificationService.swift
@@ -189,7 +189,7 @@ import Combine
     
     /// Tells the system to display a notification for the given event if it's appropriate. This will create a 
     /// NosNotification record in the database.
-    @MainActor private func showNotificationIfNecessary(for eventID: HexadecimalString) async {
+    @MainActor private func showNotificationIfNecessary(for eventID: RawEventID) async {
         guard let authorKey = currentAuthor?.hexadecimalPublicKey else {
             return
         }

--- a/Nos/Service/Relay/Filter.swift
+++ b/Nos/Service/Relay/Filter.swift
@@ -11,11 +11,11 @@ import Foundation
 /// See [NIP-01](https://github.com/nostr-protocol/nips/blob/master/01.md#communication-between-clients-and-relays).
 struct Filter: Hashable, Identifiable {
     
-    let authorKeys: [HexadecimalString]
-    let eventIDs: [HexadecimalString]
+    let authorKeys: [RawAuthorID]
+    let eventIDs: [RawEventID]
     let kinds: [EventKind]
-    let eTags: [HexadecimalString]
-    let pTags: [HexadecimalString]
+    let eTags: [RawEventID]
+    let pTags: [RawAuthorID]
     let search: String?
     let inNetwork: Bool
     var limit: Int?
@@ -23,11 +23,11 @@ struct Filter: Hashable, Identifiable {
     var until: Date?
     
     init(
-        authorKeys: [HexadecimalString] = [],
-        eventIDs: [HexadecimalString] = [],
+        authorKeys: [RawAuthorID] = [],
+        eventIDs: [RawEventID] = [],
         kinds: [EventKind] = [],
-        eTags: [HexadecimalString] = [],
-        pTags: [HexadecimalString] = [],
+        eTags: [RawEventID] = [],
+        pTags: [RawAuthorID] = [],
         search: String? = nil,
         inNetwork: Bool = false,
         limit: Int? = nil,

--- a/Nos/Service/Relay/RelayService.swift
+++ b/Nos/Service/Relay/RelayService.swift
@@ -194,7 +194,7 @@ extension RelayService {
         )
     }
     
-    func requestMetadata(for authorKey: HexadecimalString?, since: Date?) async -> SubscriptionCancellable {
+    func requestMetadata(for authorKey: RawAuthorID?, since: Date?) async -> SubscriptionCancellable {
         guard let authorKey else {
             return SubscriptionCancellable.empty()
         }
@@ -208,7 +208,7 @@ extension RelayService {
         return await subscribeToEvents(matching: metaFilter)
     }
     
-    func requestContactList(for authorKey: HexadecimalString?, since: Date?) async -> SubscriptionCancellable {
+    func requestContactList(for authorKey: RawAuthorID?, since: Date?) async -> SubscriptionCancellable {
         guard let authorKey else {
             return SubscriptionCancellable.empty()
         }
@@ -223,7 +223,7 @@ extension RelayService {
     }
     
     func requestProfileData(
-        for authorKey: HexadecimalString?, 
+        for authorKey: RawAuthorID?, 
         lastUpdateMetadata: Date?, 
         lastUpdatedContactList: Date?
     ) async -> SubscriptionCancellable {
@@ -741,13 +741,13 @@ extension RelayService: WebSocketDelegate {
 // MARK: NIP-05 and UNS Support
 extension RelayService {
     
-    func verifyNIP05(identifier: String, userPublicKey: HexadecimalString) async -> Bool {
+    func verifyNIP05(identifier: String, userPublicKey: RawAuthorID) async -> Bool {
         let internetIdentifierPublicKey = await retrievePublicKeyFromUsername(identifier)
         return internetIdentifierPublicKey == userPublicKey
     }
 
     /// Takes a NIP-05 or Mastodon username and tries to fetch the associated Nostr public key.
-    func retrievePublicKeyFromUsername(_ userName: String) async -> HexadecimalString? {
+    func retrievePublicKeyFromUsername(_ userName: String) async -> RawAuthorID? {
         let count = userName.filter { $0 == "@" }.count
         
         switch count {
@@ -769,7 +769,7 @@ extension RelayService {
         return try await fetchPublicKey(from: urlString, username: localPart)
     }
 
-    func fetchPublicKeyFromMastodonUsername(_ mastodonUsername: String) async throws -> HexadecimalString? {
+    func fetchPublicKeyFromMastodonUsername(_ mastodonUsername: String) async throws -> RawAuthorID? {
         guard let mostrUsername = mostrUsername(from: mastodonUsername) else {
             return nil
         }

--- a/Nos/Service/SocialGraphCache.swift
+++ b/Nos/Service/SocialGraphCache.swift
@@ -17,9 +17,9 @@ actor SocialGraphCache: NSObject, NSFetchedResultsControllerDelegate {
     
     // MARK: Public interface 
     
-    private(set) var followedKeys = Set<HexadecimalString>()
+    private(set) var followedKeys = Set<RawAuthorID>()
     
-    func isInNetwork(_ key: HexadecimalString?) -> Bool {
+    func isInNetwork(_ key: RawAuthorID?) -> Bool {
         guard let key, let userKey else {
             return false
         }
@@ -64,7 +64,7 @@ actor SocialGraphCache: NSObject, NSFetchedResultsControllerDelegate {
         }
     }
     
-    func follows(_ key: HexadecimalString?) -> Bool {
+    func follows(_ key: RawAuthorID?) -> Bool {
         guard let key, let userKey else {
             return false
         }
@@ -74,17 +74,17 @@ actor SocialGraphCache: NSObject, NSFetchedResultsControllerDelegate {
     
     // MARK: - Private properties
     
-    private let userKey: HexadecimalString?
+    private let userKey: RawAuthorID?
     private let context: NSManagedObjectContext
     
     private var userWatcher: NSFetchedResultsController<Author>?
     private var oneHopWatcher: NSFetchedResultsController<Author>?
-    private var twoHopKeys = Set<HexadecimalString>()
-    private var outOfNetworkKeys = Set<HexadecimalString>()
+    private var twoHopKeys = Set<RawAuthorID>()
+    private var outOfNetworkKeys = Set<RawAuthorID>()
     
     // MARK: - Setup
     
-    init(userKey: HexadecimalString?, context: NSManagedObjectContext) {
+    init(userKey: RawAuthorID?, context: NSManagedObjectContext) {
         self.userKey = userKey
         self.context = context
         super.init()
@@ -168,8 +168,8 @@ actor SocialGraphCache: NSObject, NSFetchedResultsControllerDelegate {
     ///   - followedKey: the key of the author the user has followed
     ///   - follows: the keys of the authors `followedKey` has followed
     private func process(
-        user: HexadecimalString,
-        followed newFollowedKeys: Set<HexadecimalString>
+        user: RawAuthorID,
+        followed newFollowedKeys: Set<RawAuthorID>
     ) {
         let unfollowedKeys = followedKeys.subtracting(newFollowedKeys)
         if !unfollowedKeys.isEmpty {
@@ -181,8 +181,8 @@ actor SocialGraphCache: NSObject, NSFetchedResultsControllerDelegate {
     }
     
     private func process(
-        followedAuthor: HexadecimalString,
-        followed newFollowedKeys: Set<HexadecimalString>
+        followedAuthor: RawAuthorID,
+        followed newFollowedKeys: Set<RawAuthorID>
     ) async {
         outOfNetworkKeys.subtract(newFollowedKeys)
         twoHopKeys.formUnion(newFollowedKeys)

--- a/Nos/Service/UNSAPI.swift
+++ b/Nos/Service/UNSAPI.swift
@@ -16,7 +16,7 @@ typealias UNSNameID = String
 struct UNSNameRecord: Identifiable, Equatable {
     var name: UNSName
     var id: UNSNameID
-    var nostrPubKey: HexadecimalString?
+    var nostrPubKey: RawAuthorID?
 }
 
 enum UNSError: Error {
@@ -384,7 +384,7 @@ class UNSAPI {
         }
     }
     
-    func names(matching query: String) async throws -> [HexadecimalString] {
+    func names(matching query: String) async throws -> [RawAuthorID] {
         if let nameRecord = try await nameRecord(for: query) {
             let nostrPubKeys = try await nostrKeys(for: nameRecord)
             return nostrPubKeys
@@ -393,7 +393,7 @@ class UNSAPI {
         }
     }
     
-    private func nostrKeys(for nameRecord: UNSNameRecord) async throws -> [HexadecimalString] {
+    private func nostrKeys(for nameRecord: UNSNameRecord) async throws -> [RawAuthorID] {
         let accessToken = try await checkAccessToken()
         var url = connectionURL.appending(path: "/v1/resolver")
         url = url.appending(queryItems: [
@@ -417,7 +417,7 @@ class UNSAPI {
             throw UNSError.badResponse
         }
         
-        var nostrPubKeys = [HexadecimalString]()
+        var nostrPubKeys = [RawAuthorID]()
         for connection in dataArray {
             if let npub = connection["display_value"] as? String,
                 let pubKey = PublicKey(npub: npub) {

--- a/NosTests/AuthorTests.swift
+++ b/NosTests/AuthorTests.swift
@@ -1,0 +1,41 @@
+//
+//  AuthorTests.swift
+//  NosTests
+//
+//  Created by Matthew Lorentz on 1/24/24.
+//
+
+import XCTest
+
+/// Tests for the `Author` model.
+final class AuthorTests: CoreDataTestCase {
+    
+    /// Verifies that the `followedKeys` property returns the correct set of keys followed by the author.
+    /// Written for bug [#845](https://github.com/planetary-social/nos/issues/845).
+    func testFollowedKeys() throws {
+        let context = persistenceController.viewContext
+        let author = try Author.findOrCreate(by: "test", context: context)
+        var expectedFollowedKeys = [String]()
+        for i in 0..<700 {
+            let followee = try Author.findOrCreate(by: "\(i)", context: context)
+            let follow = Follow(context: context)
+            follow.source = author
+            follow.destination = followee
+            expectedFollowedKeys.append("\(i)")
+        }
+        XCTAssertEqual(author.follows.count, 700)
+        XCTAssertEqual(Set(author.followedKeys), Set(expectedFollowedKeys))
+    }
+    
+    func testFollowedKeysIgnoresInvalidKeys() throws {
+        // inject bad data into the database
+        let user = try Author.findOrCreate(by: "user", context: testContext)
+        let followee = try Author.findOrCreate(by: "followee", context: testContext)
+        let follow = Follow(context: testContext)
+        follow.source = user
+        follow.destination = followee
+        
+        let fetchedAuthor = try Author.find(by: "user", context: testContext)
+        XCTAssertEqual(fetchedAuthor?.followedKeys, [])
+    }
+}

--- a/NosTests/AuthorTests.swift
+++ b/NosTests/AuthorTests.swift
@@ -17,11 +17,12 @@ final class AuthorTests: CoreDataTestCase {
         let author = try Author.findOrCreate(by: "test", context: context)
         var expectedFollowedKeys = [String]()
         for i in 0..<700 {
-            let followee = try Author.findOrCreate(by: "\(i)", context: context)
+            let key = RawNostrID.random
+            let followee = try Author.findOrCreate(by: "\(key)", context: context)
             let follow = Follow(context: context)
             follow.source = author
             follow.destination = followee
-            expectedFollowedKeys.append("\(i)")
+            expectedFollowedKeys.append("\(key)")
         }
         XCTAssertEqual(author.follows.count, 700)
         XCTAssertEqual(Set(author.followedKeys), Set(expectedFollowedKeys))

--- a/NosTests/AuthorTests.swift
+++ b/NosTests/AuthorTests.swift
@@ -16,7 +16,7 @@ final class AuthorTests: CoreDataTestCase {
         let context = persistenceController.viewContext
         let author = try Author.findOrCreate(by: "test", context: context)
         var expectedFollowedKeys = [String]()
-        for i in 0..<700 {
+        for _ in 0..<700 {
             let key = RawNostrID.random
             let followee = try Author.findOrCreate(by: "\(key)", context: context)
             let follow = Follow(context: context)

--- a/NosTests/EventObservationTests.swift
+++ b/NosTests/EventObservationTests.swift
@@ -46,13 +46,7 @@ struct EventObservationTestView: View {
 }
 
 /// Testing that our SwiftUI Views can successfully observe Event changes from Core Data
-final class EventObservationTests: XCTestCase {
-    
-    @Dependency(\.persistenceController) private var persistenceController
-    
-    override func setUp() async throws {
-        persistenceController.resetForTesting()
-    }
+final class EventObservationTests: CoreDataTestCase {
     
     /// This tests that the same event created in two separate contexts will update correctly in the view when both
     /// contexts are saved. This test exhibits bug https://github.com/planetary-social/nos/issues/697.  

--- a/NosTests/Fixtures/bad_contact_list.json
+++ b/NosTests/Fixtures/bad_contact_list.json
@@ -1,0 +1,20 @@
+{
+          "kind": 3,
+          "content": "Testing nos #[0]",
+          "tags": [
+            [
+              "p",
+              "this is not a valid hex key",
+              "wss://nostr.lorentz.is/",
+              "Pet Name"
+            ],
+            [
+              "p",
+              "76c71aae3a491f1d9eec47cba17e229cda4113a0bbb6e6ae1776d7643e29cafa"
+            ]
+          ],
+          "created_at": 1675264762,
+          "pubkey": "0701639be7fe1ea6d7af650b915073ccb622d8a1a1daa70eec8a075802ef949e",
+          "id": "182766bdaf82f359da281483e6a518de714d91bb5ff3c95e3584cc479c1639fc",
+          "sig": "376721bf261b21a297e61eeea62c3e0a50a932f07887adb0b29637e6da082ae0d49eba0375008208f3245920a122f56391c8bb254da30e38eaf8b20459451d65"
+}

--- a/NosTests/FollowTests.swift
+++ b/NosTests/FollowTests.swift
@@ -1,0 +1,17 @@
+//
+//  FollowTests.swift
+//  NosTests
+//
+//  Created by Matthew Lorentz on 1/24/24.
+//
+
+import XCTest
+
+/// Tests for the `Follow` model.
+final class FollowTests: CoreDataTestCase {
+
+    func testFollowWithBadHexDoesNotSave() throws {
+        let author = try Author.findOrCreate(by: "test", context: testContext)
+        XCTAssertThrowsError(try Follow.upsert(by: author, jsonTag: ["p", "artstr"], context: testContext))
+    }
+}

--- a/NosTests/NoteParserTests.swift
+++ b/NosTests/NoteParserTests.swift
@@ -11,17 +11,8 @@ import Dependencies
 
 // swiftlint:disable type_body_length
 
-final class NoteNoteParserTests: XCTestCase {
+final class NoteNoteParserTests: CoreDataTestCase {
 
-    @Dependency(\.persistenceController) private var persistenceController
-    var context: NSManagedObjectContext?
-    var continuation: DependencyValues.Continuation?
-
-    override func setUp() async throws {
-        persistenceController.resetForTesting()
-        context = persistenceController.viewContext
-    }
-    
     /// Example taken from [NIP-27](https://github.com/nostr-protocol/nips/blob/master/27.md)
     func testMentionWithNPub() throws {
         let mention = "@mattn"
@@ -43,7 +34,7 @@ final class NoteNoteParserTests: XCTestCase {
         let hex = "2c7cc62a697ea3a7826521f3fd34f0cb273693cbe5e9310f35449f43622a5cdc"
         let expectedContent = "hello @\(name)"
         let tags = [["p", hex]]
-        let context = try XCTUnwrap(context)
+        let context = try XCTUnwrap(testContext)
         let author = try Author.findOrCreate(by: hex, context: context)
         author.displayName = name
         try context.save()
@@ -78,7 +69,7 @@ final class NoteNoteParserTests: XCTestCase {
         let hex = "2c7cc62a697ea3a7826521f3fd34f0cb273693cbe5e9310f35449f43622a5cdc"
         let expectedContent = "@\(displayName)"
         let tags = [["p", hex]]
-        let context = try XCTUnwrap(context)
+        let context = try XCTUnwrap(testContext)
         let (attributedContent, _) = NoteParser.parse(content: content, tags: tags, context: context)
         let parsedContent = String(attributedContent.characters)
         XCTAssertEqual(parsedContent, expectedContent)
@@ -94,7 +85,7 @@ final class NoteNoteParserTests: XCTestCase {
         let hex = "2c7cc62a697ea3a7826521f3fd34f0cb273693cbe5e9310f35449f43622a5cdc"
         let expectedContent = "Hello\n@\(displayName)"
         let tags = [["p", hex]]
-        let context = try XCTUnwrap(context)
+        let context = try XCTUnwrap(testContext)
         let (attributedContent, _) = NoteParser.parse(content: content, tags: tags, context: context)
         let parsedContent = String(attributedContent.characters)
         XCTAssertEqual(parsedContent, expectedContent)
@@ -109,7 +100,7 @@ final class NoteNoteParserTests: XCTestCase {
         let hex = "2c7cc62a697ea3a7826521f3fd34f0cb273693cbe5e9310f35449f43622a5cdc"
         let expectedContent = "hello#[0]"
         let tags = [["p", hex]]
-        let context = try XCTUnwrap(context)
+        let context = try XCTUnwrap(testContext)
         let (attributedContent, _) = NoteParser.parse(content: content, tags: tags, context: context)
         let parsedContent = String(attributedContent.characters)
         XCTAssertEqual(parsedContent, expectedContent)
@@ -123,7 +114,7 @@ final class NoteNoteParserTests: XCTestCase {
         let content = "hello nostr:npub1937vv2nf06360qn9y8el6d8sevnndy7tuh5nzre4gj05xc32tnwqauhaj6"
         let hex = "2c7cc62a697ea3a7826521f3fd34f0cb273693cbe5e9310f35449f43622a5cdc"
         let tags = [["p", hex]]
-        let context = try XCTUnwrap(context)
+        let context = try XCTUnwrap(testContext)
         let author = try Author.findOrCreate(by: hex, context: context)
         author.displayName = name
         try context.save()
@@ -140,7 +131,7 @@ final class NoteNoteParserTests: XCTestCase {
         let content = "hello nostr:npub1937vv2nf06360qn9y8el6d8sevnndy7tuh5nzre4gj05xc32tnwqauhaj6"
         let hex = "2c7cc62a697ea3a7826521f3fd34f0cb273693cbe5e9310f35449f43622a5cdc"
         let tags = [["p", hex]]
-        let context = try XCTUnwrap(context)
+        let context = try XCTUnwrap(testContext)
         let (attributedContent, _) = NoteParser.parse(content: content, tags: tags, context: context)
         let links = attributedContent.links
         XCTAssertEqual(links.count, 1)
@@ -154,7 +145,7 @@ final class NoteNoteParserTests: XCTestCase {
         let content = "hello nostr:nprofile1qqszclxx9f5haga8sfjjrulaxncvkfekj097t6f3pu65f86rvg49ehqj6f9dh"
         let hex = "2c7cc62a697ea3a7826521f3fd34f0cb273693cbe5e9310f35449f43622a5cdc"
         let tags = [["p", hex]]
-        let context = try XCTUnwrap(context)
+        let context = try XCTUnwrap(testContext)
         let author = try Author.findOrCreate(by: hex, context: context)
         author.displayName = name
         try context.save()
@@ -170,7 +161,7 @@ final class NoteNoteParserTests: XCTestCase {
         let content = "Hello nostr:npub1pu3vqm4vzqpxsnhuc684dp2qaq6z69sf65yte4p39spcucv5lzmqswtfch.\n\nBye"
         let hex = "0f22c06eac1002684efcc68f568540e8342d1609d508bcd4312c038e6194f8b6"
         let tags = [["p", hex]]
-        let context = try XCTUnwrap(context)
+        let context = try XCTUnwrap(testContext)
         let author = try Author.findOrCreate(by: hex, context: context)
         author.displayName = name
         try context.save()
@@ -188,7 +179,7 @@ final class NoteNoteParserTests: XCTestCase {
         let displayName2 = "npub180cvv..."
         let hex2 = "3bf0c63fcb93463407af97a5e5ee64fa883d107ef9e558472c4eb9aaaefa459d"
         let tags = [["p", hex1], ["p", hex2]]
-        let context = try XCTUnwrap(context)
+        let context = try XCTUnwrap(testContext)
         let (attributedContent, _) = NoteParser.parse(content: content, tags: tags, context: context)
         let links = attributedContent.links
         XCTAssertEqual(links.count, 2)
@@ -203,7 +194,7 @@ final class NoteNoteParserTests: XCTestCase {
         let npub = "npub1937vv2nf06360qn9y8el6d8sevnndy7tuh5nzre4gj05xc32tnwqauhaj6"
         let hex = "2c7cc62a697ea3a7826521f3fd34f0cb273693cbe5e9310f35449f43622a5cdc"
         let tags: [[String]] = [[]]
-        let context = try XCTUnwrap(context)
+        let context = try XCTUnwrap(testContext)
         let (attributedContent, _) = NoteParser.parse(content: content, tags: tags, context: context)
         let links = attributedContent.links
         XCTAssertEqual(links.count, 1)
@@ -215,7 +206,7 @@ final class NoteNoteParserTests: XCTestCase {
         let content = "Check this note1h2mmqfjqle48j8ytmdar22v42g5y9n942aumyxatgtxpqj29pjjsjecraw"
         let hex = "bab7b02640fe6a791c8bdb7a352995522842ccb55779b21bab42cc1049450ca5"
         let tags: [[String]] = [[]]
-        let context = try XCTUnwrap(context)
+        let context = try XCTUnwrap(testContext)
         let (attributedContent, _) = NoteParser.parse(content: content, tags: tags, context: context)
         let links = attributedContent.links
         XCTAssertEqual(links.count, 1)
@@ -227,7 +218,7 @@ final class NoteNoteParserTests: XCTestCase {
         let content = "Check this nostr:note1h2mmqfjqle48j8ytmdar22v42g5y9n942aumyxatgtxpqj29pjjsjecraw"
         let hex = "bab7b02640fe6a791c8bdb7a352995522842ccb55779b21bab42cc1049450ca5"
         let tags: [[String]] = [[]]
-        let context = try XCTUnwrap(context)
+        let context = try XCTUnwrap(testContext)
         let (attributedContent, _) = NoteParser.parse(content: content, tags: tags, context: context)
         let links = attributedContent.links
         XCTAssertEqual(links.count, 1)
@@ -243,7 +234,7 @@ final class NoteNoteParserTests: XCTestCase {
         let profileHex = "0f22c06eac1002684efcc68f568540e8342d1609d508bcd4312c038e6194f8b6"
         let noteHex = "bab7b02640fe6a791c8bdb7a352995522842ccb55779b21bab42cc1049450ca5"
         let tags: [[String]] = [["p", profileHex]]
-        let context = try XCTUnwrap(context)
+        let context = try XCTUnwrap(testContext)
         let (attributedContent, _) = NoteParser.parse(content: content, tags: tags, context: context)
         let links = attributedContent.links
         XCTAssertEqual(links.count, 2)
@@ -261,7 +252,7 @@ final class NoteNoteParserTests: XCTestCase {
         let tags: [[String]] = [[]]
         
         let expectedContent = content
-        let context = try XCTUnwrap(context)
+        let context = try XCTUnwrap(testContext)
         let (attributedContent, _) = NoteParser.parse(content: content, tags: tags, context: context)
 
         let parsedContent = String(attributedContent.characters)
@@ -284,7 +275,7 @@ final class NoteNoteParserTests: XCTestCase {
         let tags: [[String]] = [[]]
 
         let expectedContent = "check this 🔗 Link to note"
-        let context = try XCTUnwrap(context)
+        let context = try XCTUnwrap(testContext)
         let (attributedContent, _) = NoteParser.parse(content: content, tags: tags, context: context)
 
         let parsedContent = String(attributedContent.characters)
@@ -307,7 +298,7 @@ final class NoteNoteParserTests: XCTestCase {
         let tags: [[String]] = [[]]
 
         let expectedContent = "check this 🔗 Link to note. Bye!"
-        let context = try XCTUnwrap(context)
+        let context = try XCTUnwrap(testContext)
         let (attributedContent, _) = NoteParser.parse(content: content, tags: tags, context: context)
 
         let parsedContent = String(attributedContent.characters)
@@ -328,7 +319,7 @@ final class NoteNoteParserTests: XCTestCase {
         let tags: [[String]] = [[]]
 
         let expectedContent = content
-        let context = try XCTUnwrap(context)
+        let context = try XCTUnwrap(testContext)
         let (attributedContent, _) = NoteParser.parse(content: content, tags: tags, context: context)
 
         let parsedContent = String(attributedContent.characters)

--- a/NosTests/RawNostrIDTests.swift
+++ b/NosTests/RawNostrIDTests.swift
@@ -7,25 +7,25 @@
 
 import XCTest
 
-final class RawNostrIDTest: XCTestCase {
+final class RawNostrIDTests: XCTestCase {
 
     func testHexadecimalKeyIsValid() throws {
-        let testKey = RawNostrID("76c71aae3a491f1d9eec47cba17e229cda4113a0bbb6e6ae1776d7643e29cafa")
-        XCTAssertEqual(testKey.isValid, true)
+        let validKey = RawNostrID("76c71aae3a491f1d9eec47cba17e229cda4113a0bbb6e6ae1776d7643e29cafa")
+        XCTAssertEqual(validKey.isValid, true)
     }
     
     func testHexadecimalKeyWithInvalidCharactersIsNotValid() throws {
-        let testKey = RawNostrID("!6c71aae3a491f1d9eec47cba17e229cda4113a0bbb6e6ae1776d7643e29cafa")
-        XCTAssertEqual(testKey.isValid, false)
+        let invalidCharacterKey = RawNostrID("!6c71aae3a491f1d9eec47cba17e229cda4113a0bbb6e6ae1776d7643e29cafa")
+        XCTAssertEqual(invalidCharacterKey.isValid, false)
     }
     
     func testHexadecimalKeyTooShortIsNotValid() throws {
-        let testKey = RawNostrID("6c71aae3a491f1d9eec47cba17e229cda4113a0bbb6e6ae1776d7643e29cafa")
-        XCTAssertEqual(testKey.isValid, false)
+        let invalidShortKey = RawNostrID("6c71aae3a491f1d9eec47cba17e229cda4113a0bbb6e6ae1776d7643e29cafa")
+        XCTAssertEqual(invalidShortKey.isValid, false)
     }
 
     func testHexadecimalKeyTooLongIsNotValid() throws {
-        let testKey = RawNostrID("006c71aae3a491f1d9eec47cba17e229cda4113a0bbb6e6ae1776d7643e29cafa")
-        XCTAssertEqual(testKey.isValid, false)
+        let invalidLongKey = RawNostrID("006c71aae3a491f1d9eec47cba17e229cda4113a0bbb6e6ae1776d7643e29cafa")
+        XCTAssertEqual(invalidLongKey.isValid, false)
     }
 }

--- a/NosTests/RawNostrIDTests.swift
+++ b/NosTests/RawNostrIDTests.swift
@@ -1,0 +1,31 @@
+//
+//  RawNostrIDTests.swift
+//  NosTests
+//
+//  Created by Matthew Lorentz on 1/24/24.
+//
+
+import XCTest
+
+final class RawNostrIDTest: XCTestCase {
+
+    func testHexadecimalKeyIsValid() throws {
+        let testKey = RawNostrID("76c71aae3a491f1d9eec47cba17e229cda4113a0bbb6e6ae1776d7643e29cafa")
+        XCTAssertEqual(testKey.isValid, true)
+    }
+    
+    func testHexadecimalKeyWithInvalidCharactersIsNotValid() throws {
+        let testKey = RawNostrID("!6c71aae3a491f1d9eec47cba17e229cda4113a0bbb6e6ae1776d7643e29cafa")
+        XCTAssertEqual(testKey.isValid, false)
+    }
+    
+    func testHexadecimalKeyTooShortIsNotValid() throws {
+        let testKey = RawNostrID("6c71aae3a491f1d9eec47cba17e229cda4113a0bbb6e6ae1776d7643e29cafa")
+        XCTAssertEqual(testKey.isValid, false)
+    }
+
+    func testHexadecimalKeyTooLongIsNotValid() throws {
+        let testKey = RawNostrID("006c71aae3a491f1d9eec47cba17e229cda4113a0bbb6e6ae1776d7643e29cafa")
+        XCTAssertEqual(testKey.isValid, false)
+    }
+}

--- a/NosTests/SocialGraphTests.swift
+++ b/NosTests/SocialGraphTests.swift
@@ -9,22 +9,8 @@ import XCTest
 import CoreData
 import Dependencies
 
-// swiftlint:disable implicitly_unwrapped_optional
-
-final class SocialGraphTests: XCTestCase {
+final class SocialGraphTests: CoreDataTestCase {
     
-    var testContext: NSManagedObjectContext!
-    
-    override func invokeTest() {
-        withDependencies { dependencies in
-            let persistenceController = PersistenceController(containerName: "NosTests", inMemory: true)
-            testContext = persistenceController.viewContext
-            dependencies.persistenceController = persistenceController
-        } operation: {
-            super.invokeTest()
-        }
-    }
-
     func testEmpty() async throws {
         // Arrange
         _ = try Author.findOrCreate(by: KeyFixture.alice.publicKeyHex, context: testContext)
@@ -182,4 +168,3 @@ final class SocialGraphTests: XCTestCase {
         XCTAssertFalse(isInNetwwork)
     }
 }
-// swiftlint:enable implicitly_unwrapped_optional

--- a/NosTests/Test Helpers/CoreDataTestCase.swift
+++ b/NosTests/Test Helpers/CoreDataTestCase.swift
@@ -1,0 +1,26 @@
+//
+//  DatabaseTestCase.swift
+//  NosTests
+//
+//  Created by Matthew Lorentz on 1/24/24.
+//
+
+import XCTest
+import CoreData
+import Foundation
+import Dependencies
+
+/// An `XCTestCase` that sets up an in-memory Core Data stack and resets it between test runs.
+class CoreDataTestCase: XCTestCase {
+    
+    @Dependency(\.persistenceController) var persistenceController
+    
+    // swiftlint:disable:next implicitly_unwrapped_optional
+    var testContext: NSManagedObjectContext!
+    
+    override func setUp() async throws {
+        try await super.setUp()
+        persistenceController.resetForTesting()
+        testContext = persistenceController.viewContext
+    }
+}

--- a/NosTests/Test Helpers/CoreDataTestCase.swift
+++ b/NosTests/Test Helpers/CoreDataTestCase.swift
@@ -1,5 +1,5 @@
 //
-//  DatabaseTestCase.swift
+//  CoreDataTestCase.swift
 //  NosTests
 //
 //  Created by Matthew Lorentz on 1/24/24.

--- a/NosTests/Test Helpers/RawNostrID+Random.swift
+++ b/NosTests/Test Helpers/RawNostrID+Random.swift
@@ -1,0 +1,18 @@
+//
+//  RawNostrID+Random.swift
+//  NosTests
+//
+//  Created by Matthew Lorentz on 1/24/24.
+//
+
+import Foundation
+
+extension RawNostrID {
+    static var random: RawNostrID {
+        var randomBytes = [UInt8](repeating: 0, count: 32)
+        _ = SecRandomCopyBytes(kSecRandomDefault, randomBytes.count, &randomBytes)
+        
+        let hexString = randomBytes.map { String(format: "%02x", $0) }.joined()
+        return hexString
+    }
+}


### PR DESCRIPTION
This should fix #845. A description of the bug is in the comments on the ticket. The fix was to validate that `Author` keys are valid hexadecimal public keys before sending them to relays. I also added validation before writing Follows to the database. 

Writing the validation logic led me down a path of refactoring. I started adding an `isValid` property to `HexadecimalString`, but I realized that we weren't just validating that the string was hexadecimal, but also of the length we expect for a Nostr identifier. So I renamed `HexadecimalString` to `RawNostrID`. Then just for fun I typealiased `RawNostrID` into `RawEventID` and `RawAuthorID`. These types aren't strict (you can instantiate an invalid one) but it does help us communicate in our APIs what type of ID we expect. They also play nicely with Core Data. Maybe someday we should refactor these into a stronger type but I didn't want/need to do it now. 

I also added an analytics event to log "bad req:" errors from relays. This sort of message isn't standard in the protocol but several relays were sending it and that's how I eventually found this bug. This will help us see if there are other bugs like this in the wild.