### PR TITLE
Add merge queue support to CLA Assistant

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -5,6 +5,8 @@ on:
     types: [created]
   pull_request_target:
     types: [opened,closed,synchronize]
+  merge_group:
+    types: [checks_requested]
 
 # explicitly configure permissions, in case your GITHUB_TOKEN workflow permissions are set to read-only in repository settings
 permissions:


### PR DESCRIPTION
#849 

I missed adding the `merge_group` for CLA Assistant Lite in my last PR. This is needed so the CLA status is reported while a PR is in the merge queue.