### PR TITLE
Remove "love AI" from discover tab

### DIFF
--- a/Nos/Models/CoreData/Event+CoreDataClass.swift
+++ b/Nos/Models/CoreData/Event+CoreDataClass.swift
@@ -194,8 +194,7 @@ public class Event: NosManagedObject {
         "npub1zyfv44hl4kezcn2st6de75ejypfwqk5rfq3vlymgm365e2au0w5spdg837": ["Dr. Monali Desai"],
         "npub1r9lucu40595a3qlycc7whv0524664dm6hp7qmah80psvt7zznyzq9vkmz0": ["lynnrose"],
         "npub1qk003dm7f6tqe3ydykawvqrmnze5n444dwql88qxd6hzxczzgv3syh87jz": ["bettyrose"],
-        "npub13mh45wl4u9ur26sxxwcklywgyt640s2dqkn6mvsu55302nwvqymq6xae0f": ["Katrin Theresa"],
-        "npub1curnt7jtq8mhl9fcswnwvuvc9ccm6lvsdv4kzydx75v92kldrvdqh7sq09": ["loveai"]
+        "npub13mh45wl4u9ur26sxxwcklywgyt640s2dqkn6mvsu55302nwvqymq6xae0f": ["Katrin Theresa"]
     ]
     
     // MARK: - Fetching


### PR DESCRIPTION
I'm not loving "love AI" in the discover tab, as it frequently sends notes that start with "Prompt: null". To me, this makes our discover tab look broken, even if the images add some interest and color.

![Simulator Screenshot - iPhone 15 Pro - 2024-02-06 at 17 35 37](https://github.com/planetary-social/nos/assets/59564/ce72dd65-ab0b-4da3-84a4-0917d12745d9)