### PR TITLE
Append a space after inserting a mention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- While composing a note, a space is now automatically inserted after any mention of a user or note to ensure it’s formatted correctly.
 - Fixed an issue where tapping the Feed tab did not scroll to the top of the Feed.
 - Fixed an issue where tapping the Profile tab did not scroll to the top of the Profile.
 - Search now starts automatically after entering three characters instead of one.

--- a/Nos/Models/EditableNoteText.swift
+++ b/Nos/Models/EditableNoteText.swift
@@ -84,37 +84,42 @@ struct EditableNoteText: Equatable {
             return
         }
         
-        let mention = AttributedString(
+        var mention = AttributedString(
             "@\(author.safeName)",
             attributes: defaultAttributes.merging(
                 AttributeContainer([NSAttributedString.Key.link: url.absoluteString])
             )
         )
-        
+        mention.append(AttributedString(stringLiteral: " "))
+
         attributedString.replaceSubrange((attributedString.index(beforeCharacter: index))..<index, with: mention)
     }
 
     /// Inserts the mention of an author as a link at the given index of the string. The `index` should be the index
     /// after a `@` character, which this function will replace.
     mutating func insertMention(npub: String, at range: Range<AttributedString.Index>) {
-        let mention = AttributedString(
+        var mention = AttributedString(
             "@\(npub.prefix(10).appending("..."))",
             attributes: defaultAttributes.merging(
                 AttributeContainer([NSAttributedString.Key.link: "nostr:\(npub)"])
             )
         )
+        mention.append(AttributedString(stringLiteral: " "))
+
         attributedString.replaceSubrange(range, with: mention)
     }
 
     /// Inserts the mention of an author as a link at the given index of the string. The `index` should be the index
     /// after a `@` character, which this function will replace.
     mutating func insertMention(note: String, at range: Range<AttributedString.Index>) {
-        let mention = AttributedString(
+        var mention = AttributedString(
             "@\(note.prefix(10).appending("..."))",
             attributes: defaultAttributes.merging(
                 AttributeContainer([NSAttributedString.Key.link: "nostr:\(note)"])
             )
         )
+        mention.append(AttributedString(stringLiteral: " "))
+
         attributedString.replaceSubrange(range, with: mention)
     }
     


### PR DESCRIPTION
Addresses #535 by inserting a space after a mention. Handles `@username` mentions, npub mentions, and note mentions.

This works for `@username` even if you delete the space that's inserted, as I did in this one:
https://njump.me/note166nvr920z4nppxds0r4t58dxf3ngfqla5g7ex8hhy9ueaertvyts2z2h0d

To test:

1. select the + Post button
2. type '@' and select a username
3. continue typing and select Post
4. select the + Post button
5. type or paste an npub
6. continue typing and select Post
7. select the + Post button
8. type or paste a note id
9. continue typing and select Post

Observe all the beautiful, properly-formatted links.