### PR TITLE
Fix URL detection of raw domain names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Fixed URL detection of raw domain names, such as “nos.social” (without the “http” prefix).
 - Fixed the sort order of gallery media to match the order in the note.
 - Fixed an issue where tapping the Feed tab did not scroll to the top of the Feed.
 - Fixed an issue where tapping the Profile tab did not scroll to the top of the Profile.

--- a/Nos.xcodeproj/xcshareddata/xcschemes/Nos.xcscheme
+++ b/Nos.xcodeproj/xcshareddata/xcschemes/Nos.xcscheme
@@ -73,6 +73,9 @@
                <Test
                   Identifier = "SocialGraphTests/testFollow()">
                </Test>
+               <Test
+                  Identifier = "SocialGraphTests/testTwoFollows()">
+               </Test>
             </SkippedTests>
          </TestableReference>
          <TestableReference

--- a/Nos/Extensions/String+Markdown.swift
+++ b/Nos/Extensions/String+Markdown.swift
@@ -43,19 +43,19 @@ extension String {
         let regexPattern = "(\\s*)((https?://)?([a-zA-Z0-9][-a-zA-Z0-9]{0,62}\\.){1,127}[a-z]{2,63}[^\\s]*)"
 
         do {
-            let regex = try NSRegularExpression(pattern: regexPattern, options: [])
+            let regex = try NSRegularExpression(pattern: regexPattern)
             let range = NSRange(location: 0, length: mutableString.length)
             
-            let matches = regex.matches(in: self, options: [], range: range).reversed()
+            let matches = regex.matches(in: self, range: range).reversed()
             
             for match in matches {
                 if let range = Range(match.range(at: 2), in: self), let url = URL(string: String(self[range])) {
-                    urls.insert(url, at: 0) // maintain original order of links (we're looping in reverse)
+                    // maintain original order of links by inserting at index 0 (we're looping in reverse)
+                    urls.insert(url.addingSchemeIfNeeded(), at: 0)
                     let prettyURL = url.truncatedMarkdownLink
                     regex.replaceMatches(
                         in: mutableString, 
-                        options: [], 
-                        range: match.range, 
+                        range: match.range,
                         withTemplate: "$1\(prettyURL)"
                     )
                 }

--- a/Nos/Extensions/String+Markdown.swift
+++ b/Nos/Extensions/String+Markdown.swift
@@ -38,8 +38,10 @@ extension String {
     func extractURLs() -> (String, [URL]) {
         var urls: [URL] = []
         let mutableString = NSMutableString(string: self)
-        let regexPattern = "(\\s*)(https?://[^\\s]*)"
-        
+        // The following pattern uses rules from the Domain Name System page on Wikipedia:
+        // https://en.wikipedia.org/wiki/Domain_Name_System#Domain_name_syntax,_internationalization
+        let regexPattern = "(\\s*)((https?://)?([a-zA-Z0-9][-a-zA-Z0-9]{0,61}[a-zA-Z0-9]\\.){1,127}[a-z]{2,63}[^\\s]*)"
+
         do {
             let regex = try NSRegularExpression(pattern: regexPattern, options: [])
             let range = NSRange(location: 0, length: mutableString.length)

--- a/Nos/Extensions/String+Markdown.swift
+++ b/Nos/Extensions/String+Markdown.swift
@@ -40,7 +40,7 @@ extension String {
         let mutableString = NSMutableString(string: self)
         // The following pattern uses rules from the Domain Name System page on Wikipedia:
         // https://en.wikipedia.org/wiki/Domain_Name_System#Domain_name_syntax,_internationalization
-        let regexPattern = "(\\s*)((https?://)?([a-zA-Z0-9][-a-zA-Z0-9]{0,61}[a-zA-Z0-9]\\.){1,127}[a-z]{2,63}[^\\s]*)"
+        let regexPattern = "(\\s*)((https?://)?([a-zA-Z0-9][-a-zA-Z0-9]{0,62}\\.){1,127}[a-z]{2,63}[^\\s]*)"
 
         do {
             let regex = try NSRegularExpression(pattern: regexPattern, options: [])

--- a/Nos/Extensions/URL+Extensions.swift
+++ b/Nos/Extensions/URL+Extensions.swift
@@ -23,6 +23,22 @@ extension URL {
     }
     
     var truncatedMarkdownLink: String {
+        // if there's no scheme, it may be a URL like "www.nostr.com", which we still want to truncate
+        guard scheme != nil else {
+            let truncated: String
+            if absoluteString.hasPrefix("www.") {
+                truncated = String(absoluteString.dropFirst(4))
+            } else {
+                truncated = absoluteString
+            }
+            if truncated.contains(/\//) {
+                let host = truncated.replacing(/\/.*/, with: "")
+                return "[\(host)...](\(absoluteString))"
+            } else {
+                return "[\(truncated)](\(absoluteString))"
+            }
+        }
+
         guard var host = host() else {
             return "[\(absoluteString)](\(absoluteString))"
         }

--- a/Nos/Extensions/URL+Extensions.swift
+++ b/Nos/Extensions/URL+Extensions.swift
@@ -8,7 +8,18 @@
 import Foundation
 
 extension URL {
-    
+
+    /// Returns the URL with the scheme "https" if the URL doesn't have a scheme; othewise, returns self.
+    /// Using a URL with a scheme fixes an issue with opening link previews when there's no scheme.
+    /// - Returns: The URL with the scheme "https" if the URL doesn't have a scheme; otherwise, returns self.
+    func addingSchemeIfNeeded() -> URL {
+        guard scheme == nil else {
+            return self
+        }
+
+        return URL(string: "https://\(absoluteString)") ?? self
+    }
+
     var isImage: Bool {
         let imageExtensions = ["png", "jpg", "jpeg", "gif"]
         return imageExtensions.contains(pathExtension)
@@ -23,34 +34,20 @@ extension URL {
     }
     
     var truncatedMarkdownLink: String {
-        // if there's no scheme, it may be a URL like "www.nostr.com", which we still want to truncate
-        guard scheme != nil else {
-            let truncated: String
-            if absoluteString.hasPrefix("www.") {
-                truncated = String(absoluteString.dropFirst(4))
-            } else {
-                truncated = absoluteString
-            }
-            if truncated.contains(/\//) {
-                let host = truncated.replacing(/\/.*/, with: "")
-                return "[\(host)...](\(absoluteString))"
-            } else {
-                return "[\(truncated)](\(absoluteString))"
-            }
-        }
+        let url = self.addingSchemeIfNeeded()
 
-        guard var host = host() else {
-            return "[\(absoluteString)](\(absoluteString))"
+        guard var host = url.host() else {
+            return "[\(url.absoluteString)](\(url.absoluteString))"
         }
         
         if host.hasPrefix("www.") {
             host = String(host.dropFirst(4))
         }
         
-        if path().isEmpty {
-            return "[\(host)](\(absoluteString))"
+        if url.path().isEmpty {
+            return "[\(host)](\(url.absoluteString))"
         } else {
-            return "[\(host)...](\(absoluteString))"
+            return "[\(host)...](\(url.absoluteString))"
         }
     }
 }

--- a/Nos/Models/NoteParser.swift
+++ b/Nos/Models/NoteParser.swift
@@ -33,7 +33,7 @@ enum NoteParser {
         }
     }
 
-    /// Parses the content and tags stored in a note and returns an attributed text and list of URLs that can be used 
+    /// Parses the content and tags stored in a note and returns an attributed string and list of URLs that can be used 
     /// to display the note in the UI.
     static func parse(content: String, tags: [[String]], context: NSManagedObjectContext) -> (AttributedString, [URL]) {
         var result = replaceTaggedNostrEntities(in: content, tags: tags, context: context)

--- a/NosTests/Extensions/String+MarkdownTests.swift
+++ b/NosTests/Extensions/String+MarkdownTests.swift
@@ -8,7 +8,21 @@
 import XCTest
 
 class String_MarkdownTests: XCTestCase {
-    func testExtractURLsFromNote() throws {
+    /// Test this function that's not used anwhere.
+    /// Consider removing it after extracting all value from it. (that regex in it looks great)
+    func testFindAndReplaceUnformattedLinksWithNoURLScheme() throws {
+        // Arrange
+        let string = "One: https://nos.social and two: nostr1.com"
+        let expected = "One: [https://nos.social](https://nos.social) and two: [nostr1.com](https://nostr1.com)"
+
+        // Act
+        let result = try string.findAndReplaceUnformattedLinks(in: string)
+
+        // Assert
+        XCTAssertEqual(result, expected)
+    }
+
+    func testExtractURLs() throws {
         // swiftlint:disable line_length
         let string = "Classifieds incoming... 👀\n\nhttps://nostr.build/i/2170fa01a69bca5ad0334430ccb993e41bb47eb15a4b4dbdfbee45585f63d503.jpg"
         let expectedString = "Classifieds incoming... 👀\n\n[nostr.build...](https://nostr.build/i/2170fa01a69bca5ad0334430ccb993e41bb47eb15a4b4dbdfbee45585f63d503.jpg)"
@@ -23,14 +37,26 @@ class String_MarkdownTests: XCTestCase {
         XCTAssertEqual(actualURLs, expectedURLs)
     }
 
-    func testExtractURLsFromNoteWithMultipleURLs() throws {
-        // swiftlint:disable line_length
-        let string = "Classifieds incoming... 👀\n\nhttps://nostr.build/i/2170fa01a69bca5ad0334430ccb993e41bb47eb15a4b4dbdfbee45585f63d503.jpg\n\nhttps://cdn.ymaws.com/nacfm.com/resource/resmgr/images/blog_photos/footprints.jpg"
-        let expectedString = "Classifieds incoming... 👀\n\n[nostr.build...](https://nostr.build/i/2170fa01a69bca5ad0334430ccb993e41bb47eb15a4b4dbdfbee45585f63d503.jpg)\n\n[cdn.ymaws.com...](https://cdn.ymaws.com/nacfm.com/resource/resmgr/images/blog_photos/footprints.jpg)"
-        // swiftlint:enable line_length
+    func testExtractURLsWithMultipleURLs() throws {
+        let string = """
+        A few links...
+
+        https://nostr.build/i/2170fa01a69bca5ad0334430ccb993e41bb47eb15a4b4dbdfbee45585f63d503.jpg
+        nos.social
+        www.nostr.com/get-started
+        """
+        let expectedString = """
+        A few links...
+
+        [nostr.build...](https://nostr.build/i/2170fa01a69bca5ad0334430ccb993e41bb47eb15a4b4dbdfbee45585f63d503.jpg)
+        [nos.social](nos.social)
+        [nostr.com...](www.nostr.com/get-started)
+        """
+
         let expectedURLs = [
             URL(string: "https://nostr.build/i/2170fa01a69bca5ad0334430ccb993e41bb47eb15a4b4dbdfbee45585f63d503.jpg")!,
-            URL(string: "https://cdn.ymaws.com/nacfm.com/resource/resmgr/images/blog_photos/footprints.jpg")!
+            URL(string: "nos.social")!,
+            URL(string: "www.nostr.com/get-started")
         ]
 
         // Act
@@ -39,7 +65,19 @@ class String_MarkdownTests: XCTestCase {
         XCTAssertEqual(actualURLs, expectedURLs)
     }
 
-    func testExtractURLsFromImageNote() throws {
+    func testExtractURLsDoesNotInterpretAllDotsAsURLs() throws {
+        // Arrange
+        let string = "No links...and just some tricks for the extractor..to try to trip it up. ...Ready for It?"
+
+        // Act
+        let (actualString, actualURLs) = string.extractURLs()
+
+        // Assert
+        XCTAssertEqual(actualString, string)
+        XCTAssertTrue(actualURLs.isEmpty)
+    }
+
+    func testExtractURLsWithImage() throws {
         let string = "Hello, world!https://cdn.ymaws.com/footprints.jpg"
         let expectedString = "Hello, world![cdn.ymaws.com...](https://cdn.ymaws.com/footprints.jpg)"
         let expectedURLs = [
@@ -52,7 +90,7 @@ class String_MarkdownTests: XCTestCase {
         XCTAssertEqual(actualURLs, expectedURLs)
     }
 
-    func testExtractURLsFromImageNoteWithExtraNewlines() throws {
+    func testExtractURLsWithImageWithExtraNewlines() throws {
         let string = "https://cdn.ymaws.com/footprints.jpg\n\nHello, world!"
         let expectedString = "[cdn.ymaws.com...](https://cdn.ymaws.com/footprints.jpg)\n\nHello, world!"
         let expectedURLs = [

--- a/NosTests/Extensions/String+MarkdownTests.swift
+++ b/NosTests/Extensions/String+MarkdownTests.swift
@@ -49,14 +49,14 @@ class String_MarkdownTests: XCTestCase {
         A few links...
 
         [nostr.build...](https://nostr.build/i/2170fa01a69bca5ad0334430ccb993e41bb47eb15a4b4dbdfbee45585f63d503.jpg)
-        [nos.social](nos.social)
-        [nostr.com...](www.nostr.com/get-started)
+        [nos.social](https://nos.social)
+        [nostr.com...](https://www.nostr.com/get-started)
         """
 
         let expectedURLs = [
             URL(string: "https://nostr.build/i/2170fa01a69bca5ad0334430ccb993e41bb47eb15a4b4dbdfbee45585f63d503.jpg")!,
-            URL(string: "nos.social")!,
-            URL(string: "www.nostr.com/get-started")
+            URL(string: "https://nos.social")!,
+            URL(string: "https://www.nostr.com/get-started")
         ]
 
         // Act

--- a/NosTests/Fixtures/URLExtensionTests.swift
+++ b/NosTests/Fixtures/URLExtensionTests.swift
@@ -28,6 +28,16 @@ final class URLExtensionTests: XCTestCase {
         let url = URL(string: "https://www.example.com")!
         XCTAssertEqual(url.truncatedMarkdownLink, "[example.com](https://www.example.com)")
     }
+
+    func testTruncatedMarkdownLink_noScheme_withWWW_removesWWW() {
+        let url = URL(string: "www.nostr.com/get-started")!
+        XCTAssertEqual(url.truncatedMarkdownLink, "[nostr.com...](www.nostr.com/get-started)")
+    }
+    
+    func testTruncatedMarkdownLink_noScheme_withWWW_noPath_doesNotIncludeEllipsis() {
+        let url = URL(string: "www.nos.social")!
+        XCTAssertEqual(url.truncatedMarkdownLink, "[nos.social](www.nos.social)")
+    }
     
     func testTruncatedMarkdownLink_withShortPath() {
         let url = URL(string: "https://nips.be/1")!

--- a/NosTests/Fixtures/URLExtensionTests.swift
+++ b/NosTests/Fixtures/URLExtensionTests.swift
@@ -9,6 +9,39 @@ import XCTest
 
 final class URLExtensionTests: XCTestCase {
 
+    func test_addingSchemeIfNeeded_adds_scheme_when_there_is_no_scheme() {
+        let subject = URL(string: "nos.social")!
+        let expected = URL(string: "https://nos.social")!
+        let result = subject.addingSchemeIfNeeded()
+        XCTAssertEqual(result, expected)
+    }
+
+    func test_addingSchemeIfNeeded_adds_scheme_when_url_has_path() {
+        let subject = URL(string: "nos.social/about")!
+        let expected = URL(string: "https://nos.social/about")!
+        let result = subject.addingSchemeIfNeeded()
+        XCTAssertEqual(result, expected)
+    }
+
+    func test_addingSchemeIfNeeded_adds_scheme_when_url_has_subdomain() {
+        let subject = URL(string: "www.nos.social")!
+        let expected = URL(string: "https://www.nos.social")!
+        let result = subject.addingSchemeIfNeeded()
+        XCTAssertEqual(result, expected)
+    }
+
+    func test_addingSchemeIfNeeded_does_not_add_scheme_when_http_scheme_already_exists() {
+        let subject = URL(string: "http://nos.social")!
+        let result = subject.addingSchemeIfNeeded()
+        XCTAssertEqual(result, subject)
+    }
+
+    func test_addingSchemeIfNeeded_does_not_add_scheme_when_nostr_scheme_already_exists() {
+        let subject = URL(string: "nostr:npub1234")!
+        let result = subject.addingSchemeIfNeeded()
+        XCTAssertEqual(result, subject)
+    }
+
     func testTruncatedMarkdownLink_withEmptyPathExtension() {
         let url = URL(string: "https://subdomain.example.com")!
         XCTAssertEqual(url.truncatedMarkdownLink, "[subdomain.example.com](https://subdomain.example.com)")
@@ -31,12 +64,12 @@ final class URLExtensionTests: XCTestCase {
 
     func testTruncatedMarkdownLink_noScheme_withWWW_removesWWW() {
         let url = URL(string: "www.nostr.com/get-started")!
-        XCTAssertEqual(url.truncatedMarkdownLink, "[nostr.com...](www.nostr.com/get-started)")
+        XCTAssertEqual(url.truncatedMarkdownLink, "[nostr.com...](https://www.nostr.com/get-started)")
     }
     
     func testTruncatedMarkdownLink_noScheme_withWWW_noPath_doesNotIncludeEllipsis() {
         let url = URL(string: "www.nos.social")!
-        XCTAssertEqual(url.truncatedMarkdownLink, "[nos.social](www.nos.social)")
+        XCTAssertEqual(url.truncatedMarkdownLink, "[nos.social](https://www.nos.social)")
     }
     
     func testTruncatedMarkdownLink_withShortPath() {


### PR DESCRIPTION
Fixes URL detection of raw domain names (like nos.social, or www.nos.social, or anything without `http` or `https`). #448

Steps to test:

1. Create a new note with a URL that doesn't have `http` at the beginning
2. Post it
3. Observe that the link is formatted properly
4. Tap on the inline link to ensure it opens the website
5. Tap on the link preview to ensure it opens the website