### PR TITLE
Fix crash after tapping Done while editing profile

### DIFF
--- a/Nos/Router.swift
+++ b/Nos/Router.swift
@@ -52,6 +52,7 @@ import Dependencies
     }
 
     func pop() {
+        guard !currentPath.wrappedValue.isEmpty else { return }
         currentPath.wrappedValue.removeLast()
     }
 


### PR DESCRIPTION
## Issue
#816

## Description
This fixes the crash that happens when you tap the Done button on the Edit Profile screen. The crash happens intermittently, and seems to happen only when you tap the Done button more than once (perhaps accidentally). I was able to force crashes _sometimes_ with the following steps:

## Steps to Reproduce
1. Tap the Profile tab
2. Tap the three-dot button in the upper right
3. Tap Edit Profile
4. Tap Done as many times as possible as quickly as possible

Expected: The Done action happens once and pops the user back to the Profile view.
Actual: The app crashes (sometimes)

## Additional Info
Ideally, we'd prevent the Done button from being activated more than once. It's an `ActionButton` which already has a `disabled` state that _should_ prevent the double activation from happening. What _should_ happen is that the user taps the button, we disable it immediately, perform the action, then reenable it. If this were happening as expected for the Done button on Edit Profile, this is how it would work:

1. user taps Done
2. disable the button
3. save the profile
4. pop to the previous screen
5. reenable the Done button
6. the Done button should be gone since we popped

That's obviously not working, or maybe the Done button is still tappable while the Edit screen is being popped and the user can tap it as it slides away. I tried a few approaches to ensuring `ActionButton` is actually disabled before running the action, but nothing seemed to work. Perhaps we should spend more time on that, but I've run out of ideas at this point.