### PR TITLE
Don’t include trailing comma in detected URL

### DIFF
--- a/Nos/Extensions/String+Markdown.swift
+++ b/Nos/Extensions/String+Markdown.swift
@@ -11,9 +11,8 @@ import Logger
 extension String {
     /// Find all links in a given string and replaces them with markdown formatted links
     func findAndReplaceUnformattedLinks(in string: String) throws -> String {
-        // swiftlint:disable line_length
+        // swiftlint:disable:next line_length
         let regex = "(?:^|\\s)(?<link>((http|https)?:\\/\\/.)?(www\\.)?[-a-zA-Z0-9@:%._\\+~#=]{2,256}\\.[a-z]{2,6}\\b([-a-zA-Z0-9@:%_\\+.~#?&//=]*))"
-        // swiftlint:enable line_length
         let regularExpression = try NSRegularExpression(pattern: regex)
         let wholeRange = NSRange(location: 0, length: string.utf16.count)
         if let match = regularExpression.firstMatch(in: string, range: wholeRange) {
@@ -40,7 +39,8 @@ extension String {
         let mutableString = NSMutableString(string: self)
         // The following pattern uses rules from the Domain Name System page on Wikipedia:
         // https://en.wikipedia.org/wiki/Domain_Name_System#Domain_name_syntax,_internationalization
-        let regexPattern = "(\\s*)((https?://)?([a-zA-Z0-9][-a-zA-Z0-9]{0,62}\\.){1,127}[a-z]{2,63}[^\\s]*)"
+        // swiftlint:disable:next line_length
+        let regexPattern = "(\\s*)((https?://)?([a-zA-Z0-9][-a-zA-Z0-9]{0,62}\\.){1,127}[a-z]{2,63}\\b[-a-zA-Z0-9@:%_\\+.~#?&//=]*)"
 
         do {
             let regex = try NSRegularExpression(pattern: regexPattern)

--- a/Nos/Extensions/String+Markdown.swift
+++ b/Nos/Extensions/String+Markdown.swift
@@ -40,7 +40,7 @@ extension String {
         // The following pattern uses rules from the Domain Name System page on Wikipedia:
         // https://en.wikipedia.org/wiki/Domain_Name_System#Domain_name_syntax,_internationalization
         // swiftlint:disable:next line_length
-        let regexPattern = "(\\s*)((https?://)?([a-zA-Z0-9][-a-zA-Z0-9]{0,62}\\.){1,127}[a-z]{2,63}\\b[-a-zA-Z0-9@:%_\\+.~#?&//=]*)"
+        let regexPattern = "(\\s*)((https?://)?([a-zA-Z0-9][-a-zA-Z0-9]{0,62}\\.){1,127}[a-z]{2,63}\\b[-a-zA-Z0-9@:%_\\+.~#?&/=]*)"
 
         do {
             let regex = try NSRegularExpression(pattern: regexPattern)

--- a/NosTests/Extensions/String+MarkdownTests.swift
+++ b/NosTests/Extensions/String+MarkdownTests.swift
@@ -77,6 +77,22 @@ class String_MarkdownTests: XCTestCase {
         XCTAssertTrue(actualURLs.isEmpty)
     }
 
+    func testExtractURLsDoesNotIncludeCommasInURLs() throws {
+        // Arrange
+        let string = "Welcome to nos.social, a place for humans"
+        let expectedString = "Welcome to [nos.social](https://nos.social), a place for humans"
+        let expectedURLs = [
+            URL(string: "https://nos.social")!
+        ]
+
+        // Act
+        let (actualString, actualURLs) = string.extractURLs()
+
+        // Assert
+        XCTAssertEqual(actualString, expectedString)
+        XCTAssertEqual(actualURLs, expectedURLs)
+    }
+
     func testExtractURLsWithImage() throws {
         let string = "Hello, world!https://cdn.ymaws.com/footprints.jpg"
         let expectedString = "Hello, world![cdn.ymaws.com...](https://cdn.ymaws.com/footprints.jpg)"


### PR DESCRIPTION
#448 

When the URL is followed by a comma, do not include the comma in the URL. Here's what that looks like when it's broken:

<img width="627" alt="Screenshot 2024-02-27 at 11 15 11 AM" src="https://github.com/planetary-social/nos/assets/59564/022bafeb-4dd3-40a7-ace8-41b1817c0530">

Skipping changelog since this is part of #448 and that hasn't been released yet.