### PR TITLE
Allow team members to register reserved usernames

### DIFF
--- a/Nos/Service/NamesAPI.swift
+++ b/Nos/Service/NamesAPI.swift
@@ -60,16 +60,22 @@ class NamesAPI {
         throw Error.unexpected
     }
 
-    func verify(username: String) async throws -> Bool {
+    func verify(username: String, keyPair: KeyPair) async throws -> Bool {
         let request = URLRequest(
             url: verificationURL.appending(queryItems: [URLQueryItem(name: "name", value: username)])
         )
-        let (_, response) = try await URLSession.shared.data(for: request)
+        let (data, response) = try await URLSession.shared.data(for: request)
         if let response = response as? HTTPURLResponse {
-            return response.statusCode == 404
-        } else {
-            return false
+            let statusCode = response.statusCode
+            if statusCode == 404 {
+                return true
+            } else if statusCode == 200, let json = try JSONSerialization.jsonObject(with: data) as? [String: Any] {
+                let names = json["names"] as? [String: String]
+                let npub = names?[username]
+                return npub == keyPair.publicKeyHex
+            }
         }
+        return false
     }
 
     func register(username: String, keyPair: KeyPair) async throws {

--- a/Nos/Views/CreateUsernameSheet.swift
+++ b/Nos/Views/CreateUsernameSheet.swift
@@ -85,6 +85,7 @@ fileprivate struct PickYourUsernamePage: View {
     @State private var verified: Bool?
     @State private var isVerifying = false
     @FocusState private var usernameFieldIsFocused: Bool
+    @Dependency(\.currentUser) var currentUser
     @Dependency(\.namesAPI) var namesAPI
 
     var body: some View {
@@ -203,7 +204,7 @@ fileprivate struct PickYourUsernamePage: View {
     private func verify(_ username: String) async {
         verified = nil
 
-        guard !username.isEmpty else {
+        guard !username.isEmpty, let keyPair = currentUser.keyPair else {
             return
         }
 
@@ -214,7 +215,7 @@ fileprivate struct PickYourUsernamePage: View {
         }
 
         do {
-            verified = try await namesAPI.verify(username: username)
+            verified = try await namesAPI.verify(username: username, keyPair: keyPair)
         } catch {
             Log.error(error.localizedDescription)
         }


### PR DESCRIPTION
#904 

Adding this as a separate PR to ease review.

When verifying that a username is available, if it wasn't, we weren't checking that the npub that registered that username wasn't the user verifying. Besides catching an edge case, we were also not allowing nos team members to register reserved usernames. This PR checks the npub that registered a username when verifying availability and compares it to the logged in user.