### PR TITLE
Show NIP-05 in Profile screen title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Display NIP-05 identifier in the Profile screen title bar.
 - Added option to register nos.social usernames.
 - Fixed intermittent crash when tapping Done after editing your profile.
 - Fixed URL detection of raw domain names, such as “nos.social” (without the “http” prefix).

--- a/Nos/Models/CoreData/Author+CoreDataClass.swift
+++ b/Nos/Models/CoreData/Author+CoreDataClass.swift
@@ -24,6 +24,15 @@ enum AuthorError: Error {
         publicKey?.npub
     }
     
+    /// Human-friendly identifier suitable for being displayed in the UI
+    var safeIdentifier: String {
+        if let nip05 {
+            return nip05
+        } else {
+            return npubString?.prefix(10).appending("...") ?? hexadecimalPublicKey ?? "error"
+        }
+    }
+
     var safeName: String {
         if let displayName, !displayName.isEmpty {
             return displayName

--- a/Nos/Views/ProfileView.swift
+++ b/Nos/Views/ProfileView.swift
@@ -42,7 +42,7 @@ struct ProfileView: View {
         self.author = author
         self.addDoubleTapToPop = addDoubleTapToPop
     }
-    
+
     func loadUSBCBalance() async {
         guard let unsName = author.uns, !unsName.isEmpty else {
             usbcAddress = nil
@@ -130,7 +130,7 @@ struct ProfileView: View {
             }
         }
         .background(Color.appBg)
-        .nosNavigationBar(title: .localizable.profileTitle)
+        .nosNavigationBar(title: LocalizedStringResource(stringLiteral: author.safeIdentifier))
         .navigationDestination(for: Event.self) { note in
             RepliesView(note: note)
         }                  

--- a/NosTests/AuthorTests.swift
+++ b/NosTests/AuthorTests.swift
@@ -39,4 +39,16 @@ final class AuthorTests: CoreDataTestCase {
         let fetchedAuthor = try Author.find(by: "user", context: testContext)
         XCTAssertEqual(fetchedAuthor?.followedKeys, [])
     }
+
+    func testSafeIdentifier() throws {
+        let context = persistenceController.viewContext
+        let key = RawNostrID.random
+        let publicKey = try XCTUnwrap(PublicKey(hex: key))
+        let truncatedKey = "\(publicKey.npub.prefix(10))..."
+        let nip05 = "me@nip05.com"
+        let author = try Author.findOrCreate(by: key, context: context)
+        XCTAssertEqual(author.safeIdentifier, truncatedKey)
+        author.nip05 = nip05
+        XCTAssertEqual(author.safeIdentifier, nip05)
+    }
 }


### PR DESCRIPTION
#823 

Just show either the NIP-05 identifier in the title bar when displaying a Profile or a truncated npub if the nip-05 is empty.