### PR TITLE
Fix issue where Reply field is cut off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Show “Post a reply” field at the proper height initially, and allow it to expand as more text is entered.
 - Tap the Like button on a note you’ve already liked to remove the Like.
 - Display NIP-05 identifier in the Profile screen title bar.
 - Added option to register nos.social usernames.

--- a/Nos/Views/ExpandingTextFieldAndSubmitButton.swift
+++ b/Nos/Views/ExpandingTextFieldAndSubmitButton.swift
@@ -20,14 +20,21 @@ struct ExpandingTextFieldAndSubmitButton: View {
     @State private var showPostButton = false
     @State var disabled = false
 
-    @State private var calculatedHeight: CGFloat = 44
-    
+    /// The calculated height of the NoteTextEditor.
+    @State private var calculatedEditorHeight: CGFloat = 44
+
     var body: some View {
         HStack {
-            NoteTextEditor(text: $reply, placeholder: placeholder, focus: focus)
-                .frame(maxHeight: 270)
-                .background(Color.appBg)
-                .cornerRadius(17.5)
+            NoteTextEditor(
+                text: $reply,
+                placeholder: placeholder,
+                focus: focus,
+                calculatedHeight: $calculatedEditorHeight
+            )
+            .frame(minHeight: calculatedEditorHeight, maxHeight: 270)
+            .background(Color.appBg)
+            .cornerRadius(17.5)
+
             if showPostButton {
                 Button(
                     action: {

--- a/Nos/Views/New Note/NewNoteView.swift
+++ b/Nos/Views/New Note/NewNoteView.swift
@@ -21,7 +21,10 @@ struct NewNoteView: View {
 
     /// State holding the text the user is typing
     @State private var text = EditableNoteText()
-    
+
+    /// The calculated height of the NoteTextEditor.
+    @State private var calculatedEditorHeight: CGFloat = 44
+
     @State var expirationTime: TimeInterval?
     
     @State private var alert: AlertState<Never>?
@@ -46,7 +49,8 @@ struct NewNoteView: View {
                     NoteTextEditor(
                         text: $text, 
                         placeholder: .localizable.newNotePlaceholder,
-                        focus: $isTextEditorInFocus
+                        focus: $isTextEditorInFocus,
+                        calculatedHeight: $calculatedEditorHeight
                     )
                     .padding(10)
                     Spacer()

--- a/Nos/Views/NoteTextEditor.swift
+++ b/Nos/Views/NoteTextEditor.swift
@@ -13,8 +13,10 @@ struct NoteTextEditor: View {
     @Binding var text: EditableNoteText
     var placeholder: LocalizedStringResource
     var focus: FocusState<Bool>.Binding
-    
-    @State private var calculatedHeight: CGFloat = 44
+
+    /// The calculated height of this view.
+    @Binding var calculatedHeight: CGFloat
+
     @State private var guid = UUID()
     
     /// State containing the offset (index) of text when the user is mentioning someone
@@ -97,10 +99,16 @@ struct NoteTextEditor_Previews: PreviewProvider {
     @State static var text = EditableNoteText()
     static var placeholder: LocalizedStringResource = .localizable.newNotePlaceholder
     @FocusState static var isFocused: Bool
-    
+    @State static var calculatedHeight: CGFloat = 44
+
     static var previews: some View {
         VStack {
-            NoteTextEditor(text: $text, placeholder: placeholder, focus: $isFocused)
+            NoteTextEditor(
+                text: $text,
+                placeholder: placeholder, 
+                focus: $isFocused,
+                calculatedHeight: $calculatedHeight
+            )
             Spacer()
         }
     }


### PR DESCRIPTION
#924 

Fixes the issue described, where the reply field is too short initially. Also allows the reply field to expand as the user types more text, up to its max height of 270.

| Empty | Full |
|--------|--------|
| ![Simulator Screenshot - iPhone 15 Pro Max - 2024-03-04 at 17 21 03](https://github.com/planetary-social/nos/assets/59564/f3fa647a-861e-4407-b99c-90a7afa925be) | ![Simulator Screenshot - iPhone 15 Pro Max - 2024-03-04 at 17 20 54](https://github.com/planetary-social/nos/assets/59564/e01006ea-5996-418e-b581-7c7774858ba5) |