### PR TITLE
Exclude relays that Relayable uses from event subscriptions

### DIFF
--- a/Nos.xcodeproj/project.pbxproj
+++ b/Nos.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		038985182B7AD6C0009C16CA /* String+MarkdownTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 038985172B7AD6BF009C16CA /* String+MarkdownTests.swift */; };
+		039196B52B992905004B38D3 /* RelayServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 039196B42B992905004B38D3 /* RelayServiceTests.swift */; };
 		2D06BB9D2AE249D70085F509 /* ThreadRootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D06BB9C2AE249D70085F509 /* ThreadRootView.swift */; };
 		2D4010A22AD87DF300F93AD4 /* KnownFollowersView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D4010A12AD87DF300F93AD4 /* KnownFollowersView.swift */; };
 		3A1C296F2B2A537C0020B753 /* Moderation.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = 3A1C296E2B2A537C0020B753 /* Moderation.xcstrings */; };
@@ -465,6 +466,7 @@
 
 /* Begin PBXFileReference section */
 		038985172B7AD6BF009C16CA /* String+MarkdownTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+MarkdownTests.swift"; sourceTree = "<group>"; };
+		039196B42B992905004B38D3 /* RelayServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelayServiceTests.swift; sourceTree = "<group>"; };
 		2D06BB9C2AE249D70085F509 /* ThreadRootView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ThreadRootView.swift; sourceTree = "<group>"; };
 		2D4010A12AD87DF300F93AD4 /* KnownFollowersView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KnownFollowersView.swift; sourceTree = "<group>"; };
 		3A1C296E2B2A537C0020B753 /* Moderation.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Moderation.xcstrings; sourceTree = "<group>"; };
@@ -859,6 +861,22 @@
 			path = CoreData;
 			sourceTree = "<group>";
 		};
+		039196B22B9928EE004B38D3 /* Service */ = {
+			isa = PBXGroup;
+			children = (
+				039196B32B9928F4004B38D3 /* Relay */,
+			);
+			path = Service;
+			sourceTree = "<group>";
+		};
+		039196B32B9928F4004B38D3 /* Relay */ = {
+			isa = PBXGroup;
+			children = (
+				039196B42B992905004B38D3 /* RelayServiceTests.swift */,
+			);
+			path = Relay;
+			sourceTree = "<group>";
+		};
 		3AAB61B12B24CC8A00717A07 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
@@ -1092,21 +1110,22 @@
 			isa = PBXGroup;
 			children = (
 				C98298312ADD7EDB0096C5B5 /* Info.plist */,
-				3AAB61B12B24CC8A00717A07 /* Extensions */,
-				C9C9443A29F6E420002F2C7A /* Test Helpers */,
-				C9DEC0042989477A0078B43A /* Fixtures */,
-				C9DEBFE8298941020078B43A /* EventTests.swift */,
-				C96D391A2B61AFD500D3D0A1 /* RawNostrIDTests.swift */,
+				C96D39242B61B06200D3D0A1 /* AuthorTests.swift */,
+				5B80BE9D29F9864000A363E4 /* Bech32Tests.swift */,
 				C9C45E152B23741E00F523DA /* EventObservationTests.swift */,
+				C9DEBFE8298941020078B43A /* EventTests.swift */,
+				C900385E2B6195C60080CC4F /* FollowTests.swift */,
 				C9ADB132299287D60075E7F8 /* KeyPairTests.swift */,
 				5B6EB48F29EDBEC1006E750C /* NoteParserTests.swift */,
-				5B80BE9D29F9864000A363E4 /* Bech32Tests.swift */,
-				C9B678E329EED2DC00303F33 /* SocialGraphTests.swift */,
-				5B88051B2A21046C00E21F06 /* SHA256KeyTests.swift */,
-				5B88051E2A21056E00E21F06 /* TLVTests.swift */,
+				C96D391A2B61AFD500D3D0A1 /* RawNostrIDTests.swift */,
 				C94D59AD2AE7286E00295AE8 /* ReportTests.swift */,
-				C900385E2B6195C60080CC4F /* FollowTests.swift */,
-				C96D39242B61B06200D3D0A1 /* AuthorTests.swift */,
+				5B88051B2A21046C00E21F06 /* SHA256KeyTests.swift */,
+				C9B678E329EED2DC00303F33 /* SocialGraphTests.swift */,
+				5B88051E2A21056E00E21F06 /* TLVTests.swift */,
+				3AAB61B12B24CC8A00717A07 /* Extensions */,
+				C9DEC0042989477A0078B43A /* Fixtures */,
+				039196B22B9928EE004B38D3 /* Service */,
+				C9C9443A29F6E420002F2C7A /* Test Helpers */,
 			);
 			path = NosTests;
 			sourceTree = "<group>";
@@ -1942,6 +1961,7 @@
 				5B88051D2A2104CC00E21F06 /* SHA256Key.swift in Sources */,
 				C9CF23182A38A58B00EBEC31 /* ParseQueue.swift in Sources */,
 				5B39E64429EDBF8100464830 /* NoteParser.swift in Sources */,
+				039196B52B992905004B38D3 /* RelayServiceTests.swift in Sources */,
 				C94A5E162A716A6D00B6EC5D /* EditableNoteText.swift in Sources */,
 				5BD08BB22A38E96F00BB926C /* JSONRelayMetadata.swift in Sources */,
 				C936B45A2A4C7B7C00DF1EB9 /* Nos.xcdatamodeld in Sources */,

--- a/Nos/Models/CoreData/Relay+CoreDataClass.swift
+++ b/Nos/Models/CoreData/Relay+CoreDataClass.swift
@@ -52,7 +52,26 @@ public class Relay: NosManagedObject {
         "wss://relay.causes.com",
         ]
     }
-    
+
+    /// The URL string for relayable.org. To be used for de-duplication since Relayable streams from other relays.
+    static var relayable: String {
+        "wss://relayable.org"
+    }
+
+    /// Known relays that relayable.org streams from. To be used for de-duplication.
+    static var streamedByRelayable: [String] {
+        [
+        "wss://relay.damus.io",
+        "wss://purplepag.es",
+        "wss://relay.snort.social",
+        "wss://nostr.wine",
+        "wss://nos.lol",
+        "wss://nostr21.com",
+        "wss://relay.wellorder.net",
+        "wss://nostr.mom",
+        ]
+    }
+
     @nonobjc public class func allRelaysRequest() -> NSFetchRequest<Relay> {
         let fetchRequest = NSFetchRequest<Relay>(entityName: "Relay")
         fetchRequest.sortDescriptors = [NSSortDescriptor(keyPath: \Relay.address, ascending: true)]

--- a/Nos/Service/Relay/RelayService.swift
+++ b/Nos/Service/Relay/RelayService.swift
@@ -170,7 +170,7 @@ extension RelayService {
             // Fall back to a large list of relays if we don't have any for this user (like on first login)
             relayAddresses = Relay.allKnown.compactMap { URL(string: $0) }
         }
-        relayAddresses = removeRelayableRelays(relayAddresses: relayAddresses)
+        relayAddresses = RelayService.removeRelayableRelays(relayAddresses: relayAddresses)
 
         var subscriptionIDs = [RelaySubscription.ID]()
         for relay in relayAddresses {
@@ -188,7 +188,7 @@ extension RelayService {
     /// The subscription will be cancelled when the returned subscription object is deallocated. 
     func subscribeToPagedEvents(matching filter: Filter) async -> PagedRelaySubscription {
         let userRelayAddresses = await self.relayAddresses(for: currentUser)
-        let relayAddresses = removeRelayableRelays(relayAddresses: userRelayAddresses)
+        let relayAddresses = RelayService.removeRelayableRelays(relayAddresses: userRelayAddresses)
 
         return PagedRelaySubscription(
             startDate: .now,
@@ -277,7 +277,7 @@ extension RelayService {
     /// If the Relayable relay is in the list, removes the relay addresses from the list that relayable streams from.
     /// Otherwise, returns `relayAddressses` as it was.
     /// This allows us to de-duplicate events to improve bandwidth use and performance.
-    private func removeRelayableRelays(relayAddresses: [URL]) -> [URL] {
+    static func removeRelayableRelays(relayAddresses: [URL]) -> [URL] {
         let result: [URL]
         if let relayableURL = URL(string: Relay.relayable),
             relayAddresses.contains(where: { $0 == relayableURL }) {

--- a/NosTests/Service/Relay/RelayServiceTests.swift
+++ b/NosTests/Service/Relay/RelayServiceTests.swift
@@ -1,0 +1,33 @@
+import XCTest
+
+class RelayServiceTests: XCTestCase {
+    func test_removeRelayableRelays_removes_relays_when_relayable_is_in_array() {
+        // Arrange
+        let relays = Relay.recommended.compactMap { URL(string: $0) }
+        let expected = [
+            "wss://relay.nostr.band",
+            "wss://e.nos.lol",
+            "wss://relay.current.fyi",
+            "wss://relay.nos.social",
+            "wss://relayable.org",
+            "wss://relay.causes.com",
+        ].compactMap { URL(string: $0) }
+
+        // Act
+        let result = RelayService.removeRelayableRelays(relayAddresses: relays)
+
+        // Assert
+        XCTAssertEqual(result, expected)
+    }
+
+    func test_removeRelayableRelays_does_not_remove_relays_when_relayable_is_not_in_array() {
+        // Arrange
+        let relays = Relay.streamedByRelayable.compactMap { URL(string: $0) }
+
+        // Act
+        let result = RelayService.removeRelayableRelays(relayAddresses: relays)
+
+        // Assert
+        XCTAssertEqual(result, relays)
+    }
+}


### PR DESCRIPTION
#903

This excludes the Relayable relays from event subscriptions when the user has the relayable.org in their relays.

I'm not sure if `subscribeToEvents` and `subscribeToPagedEvents` cover everything, so let me know if there's something I missed.

I know this needs a lot of testing and perhaps a side-by-side comparison with the existing app to see if any events are missing. Or search results. Or anything else that might be affected by this.

Update: After some side-by-side testing, I'm noticing that in this version (that excludes some relays), I'm not able to scroll down in my profile past my January 30 post. I wonder if relayable doesn't go back past a certain point or number of posts, or if I'm seeing a different bug. Either way, there seems to be no way for me to continue scrolling down, even though I can in a separate build of the app.

Update 2: I reproduced the profile scrolling issue on `main` so it doesn't appear to be related to this PR.