### PR TITLE
Disable cell reuse in PagedNoteDataSource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update font styles on Edit Profile and Settings screens.
 - Fix issue with uploading photos on Mac.
 - Re-design the confirmation dialog that appears when you delete your NIP-05.
+- Fixed a bug where liking a note could cause other notes to appear liked.
 
 ## [0.1.6] - 2024-03-07Z
 

--- a/Nos/Controller/PagedNoteDataSource.swift
+++ b/Nos/Controller/PagedNoteDataSource.swift
@@ -18,9 +18,10 @@ class PagedNoteDataSource<Header: View, EmptyPlaceholder: View>: NSObject, UICol
     private var emptyPlaceholder: () -> EmptyPlaceholder
     let pageSize = 10
     
-    private var cellReuseID = "Cell"
-    private var headerReuseID = "Header"
-    private var footerReuseID = "Footer"
+    // We intentionally generate unique IDs for cell reuse to get around 
+    // [this issue](https://github.com/planetary-social/nos/issues/873)
+    lazy var headerReuseID = { "Header-\(self.description)" }()
+    lazy var footerReuseID = { "Footer-\(self.description)" }()
     
     init(
         databaseFilter: NSFetchRequest<Event>, 
@@ -42,7 +43,8 @@ class PagedNoteDataSource<Header: View, EmptyPlaceholder: View>: NSObject, UICol
         self.header = header
         self.emptyPlaceholder = emptyPlaceholder
         
-        collectionView.register(UICollectionViewCell.self, forCellWithReuseIdentifier: cellReuseID)
+        super.init()
+        
         collectionView.register(
             UICollectionViewCell.self, 
             forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader, 
@@ -53,8 +55,6 @@ class PagedNoteDataSource<Header: View, EmptyPlaceholder: View>: NSObject, UICol
             forSupplementaryViewOfKind: UICollectionView.elementKindSectionFooter, 
             withReuseIdentifier: footerReuseID
         )
-
-        super.init()
         
         self.fetchedResultsController.delegate = self
         
@@ -99,7 +99,13 @@ class PagedNoteDataSource<Header: View, EmptyPlaceholder: View>: NSObject, UICol
         }        
         
         let note = fetchedResultsController.object(at: indexPath) 
+        
+        // We intentionally generate unique IDs for cell reuse to get around 
+        // [this issue](https://github.com/planetary-social/nos/issues/873)
+        let cellReuseID = note.identifier ?? "error"
+        collectionView.register(UICollectionViewCell.self, forCellWithReuseIdentifier: cellReuseID)
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: cellReuseID, for: indexPath) 
+        
         cell.contentConfiguration = UIHostingConfiguration { 
             NoteButton(note: note, hideOutOfNetwork: false, displayRootMessage: true)
         }


### PR DESCRIPTION
This `fixes` #873. The problem is that UICollectionView was reusing SwiftUI Views which means their @State vars would be jumbled to whatever value the cell being reused had. One solution was to make a custom subclass of UICollectionViewCell that would pass the `prepareForReuse()` message down to the SwiftUI views and then they could each have a custom function to reset their state. I didn't want to go this route because it would involve adding this code to all views in `NoteButton` hierarchy, which is probably a couple dozen. It would also be very fragile in the future - if someone added a view or @State var and forgot about this weird quirk then we'd have another bug. Instead I essentially broke UICollectionView's cell reuse by using a unique identifier for every note. Obviously this negatively effects runtime performance but I could not tell the difference on my devices. I tried to get some empirical data with the performance tests, but I couldn't get them running (see [Slack](https://planetary-app.slack.com/archives/C04PLR5QFQQ/p1710530090802949)).