### PR TITLE
Update text and card bg top and bottom colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - Added a new UI for replying to messages that allows attaching images and setting an expiration date.
+- Updated dark theme colors for card backgrounds, primary text, and secondary text.
 
 ## [0.1.7] - 2024-03-21Z
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Added a new UI for replying to messages that allows attaching images and setting an expiration date.
 - Updated dark theme colors for card backgrounds, primary text, and secondary text.
+- Added a new UI for replying to messages that allows attaching images and setting an expiration date.
 
 ## [0.1.7] - 2024-03-21Z
 

--- a/Nos/Assets/Assets.xcassets/Colors/card-bg-bottom.colorset/Contents.json
+++ b/Nos/Assets/Assets.xcassets/Colors/card-bg-bottom.colorset/Contents.json
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0x3A",
-          "green" : "0x17",
-          "red" : "0x23"
+          "blue" : "0x3D",
+          "green" : "0x18",
+          "red" : "0x25"
         }
       },
       "idiom" : "universal"

--- a/Nos/Assets/Assets.xcassets/Colors/card-bg-top.colorset/Contents.json
+++ b/Nos/Assets/Assets.xcassets/Colors/card-bg-top.colorset/Contents.json
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0x4C",
-          "green" : "0x1E",
-          "red" : "0x2F"
+          "blue" : "0x47",
+          "green" : "0x1C",
+          "red" : "0x2B"
         }
       },
       "idiom" : "universal"

--- a/Nos/Assets/Assets.xcassets/Colors/primary-txt.colorset/Contents.json
+++ b/Nos/Assets/Assets.xcassets/Colors/primary-txt.colorset/Contents.json
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "1.000",
-          "green" : "1.000",
-          "red" : "1.000"
+          "blue" : "0xFF",
+          "green" : "0xFF",
+          "red" : "0xFF"
         }
       },
       "idiom" : "universal"

--- a/Nos/Assets/Assets.xcassets/Colors/secondary-txt.colorset/Contents.json
+++ b/Nos/Assets/Assets.xcassets/Colors/secondary-txt.colorset/Contents.json
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0xBF",
-          "green" : "0x79",
-          "red" : "0x93"
+          "blue" : "0xD8",
+          "green" : "0x88",
+          "red" : "0xA5"
         }
       },
       "idiom" : "universal"


### PR DESCRIPTION
#938

Updated the secondary text and card bg top and bottom colors for dark appearance.

| Header | Header |
|--------|--------|
| ![Simulator Screenshot - iPhone 15 Pro - 2024-03-21 at 17 38 59](https://github.com/planetary-social/nos/assets/59564/543e2c70-ee0e-44b4-bcd8-87fda05be333) | ![Simulator Screenshot - iPhone 15 Pro - 2024-03-21 at 17 55 21](https://github.com/planetary-social/nos/assets/59564/99018c9b-c10a-4765-8c97-5632b8e5ada9) | 
