### PR TITLE
Fix issue causing 'subscription id too long' messages

### DIFF
--- a/Nos/Models/RelaySubscription.swift
+++ b/Nos/Models/RelaySubscription.swift
@@ -42,6 +42,7 @@ struct RelaySubscription: Identifiable {
     ) {
         self.filter = filter
         self.relayAddress = relayAddress
+        // Compute a unique ID but predictable ID. The sha256 cuts the length down to an acceptable size.
         self.id = (filter.id + "-" + relayAddress.absoluteString).data(using: .utf8)?.sha256 ?? "error"
         self.subscriptionStartDate = subscriptionStartDate
         self.oldestEventCreationDate = oldestEventCreationDate

--- a/Nos/Models/RelaySubscription.swift
+++ b/Nos/Models/RelaySubscription.swift
@@ -42,7 +42,7 @@ struct RelaySubscription: Identifiable {
     ) {
         self.filter = filter
         self.relayAddress = relayAddress
-        self.id = filter.id + "-" + relayAddress.absoluteString
+        self.id = (filter.id + "-" + relayAddress.absoluteString).data(using: .utf8)?.sha256 ?? "error"
         self.subscriptionStartDate = subscriptionStartDate
         self.oldestEventCreationDate = oldestEventCreationDate
         self.referenceCount = referenceCount


### PR DESCRIPTION
I made this change [here](https://github.com/planetary-social/nos/pull/987#discussion_r1554111889) with the comment (and I quote) "I'm not sure why we are sha256ing this at all." It turns out that if you don't sha256 it the subscription IDs can become very long and relays will reject subscriptions with messages like:
```
Notice from relay.damus.io: [NOTICE, ERROR: bad close: subscription id too long]
```