### PR TITLE
Create bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -25,7 +25,7 @@ If applicable, add screenshots or video to help explain your problem.
 
 **Technical info (please complete the following information):**
  - OS: [e.g. iOS, iPadOS, macOS]
- - App Version [e.g. 22]
+ - App Version: [e.g. 0.1.9 (239)]
 
 **Additional context**
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -13,8 +13,8 @@ A clear and concise description of what the bug is.
 **To Reproduce**
 Steps to reproduce the behavior:
 1. Go to '...'
-2. Click on '....'
-3. Scroll down to '....'
+2. Tap '...'
+3. Scroll down to '...'
 4. See error
 
 **Expected behavior**

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -26,6 +26,7 @@ If applicable, add screenshots or video to help explain your problem.
 **Technical info (please complete the following information):**
  - OS: [e.g. iOS, iPadOS, macOS]
  - App Version: [e.g. 0.1.9 (239)]
+ - Environment: [e.g. Dev, Staging, Production]
 
 **Additional context**
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -24,7 +24,7 @@ A clear and concise description of what you expected to happen.
 If applicable, add screenshots or video to help explain your problem.
 
 **Technical info (please complete the following information):**
- - OS: [e.g. iOS, iPadOS macOS]
+ - OS: [e.g. iOS, iPadOS, macOS]
  - App Version [e.g. 22]
 
 **Additional context**

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,31 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots or Video**
+If applicable, add screenshots or video to help explain your problem.
+
+**Technical info (please complete the following information):**
+ - OS: [e.g. iOS, iPadOS macOS]
+ - App Version [e.g. 22]
+
+**Additional context**
+Add any other context about the problem here.


### PR DESCRIPTION
Often when we get a bug report, I request more information -- especially steps to reproduce. This template should eliminate that need and help us to get the information we need before we start working on a ticket.

Further reading: [Creating issue templates](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#creating-issue-templates)

**Update:** I just discovered that we can create a form instead, which may be a better option. Investigating that now.

Results of investigation: [Creating issue forms](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#creating-issue-forms) is still in beta, so I'm going with this issue template instead for now.