### PR TITLE
Fix p tags on Reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Fixed an issue where reports for notes were treated as reports for profiles.
 - Added option to connect your existing NIP-05 username.
 - Fixed a crash that often occurred after opening the app.
 - In an effort to prioritize critical functionality, we are dropping support for light mode in the near term. If you have concerns about the remaining theme please reach out to us at support@nos.social

--- a/Nos/Models/CoreData/Author+CoreDataClass.swift
+++ b/Nos/Models/CoreData/Author+CoreDataClass.swift
@@ -308,7 +308,7 @@ import Logger
         let fetchRequest = NSFetchRequest<Event>(entityName: "Event")
         fetchRequest.sortDescriptors = [NSSortDescriptor(keyPath: \Event.createdAt, ascending: false)]
         fetchRequest.predicate = NSPredicate(
-            format: "(kind = %i) AND ANY authorReferences.pubkey = %@", 
+            format: "(kind = %i) AND ANY authorReferences.pubkey = %@ AND eventReferences.@count = 0",
             EventKind.report.rawValue,
             hexadecimalPublicKey
         )

--- a/Nos/Models/ReportTarget.swift
+++ b/Nos/Models/ReportTarget.swift
@@ -25,19 +25,24 @@ enum ReportTarget {
         }
     }
     
-    /// Creates a tag referencing this target that can be attached to a report event.
-    var tag: [String] {
+    /// Creates tags referencing this target that can be attached to a report event.
+    ///  - Parameter reportType: the NIP-56 report_type (spam, illegal, etc.) 
+    func tags(for reportType: String) -> [[String]] {
+        var tags = [[String]]()
         switch self {
         case .author(let author):
             if let pubKey = author.hexadecimalPublicKey {
-                return ["p", pubKey]
+                tags.append(["p", pubKey, reportType])
             }
         case .note(let note):
             if let eventID = note.identifier {
-                return ["e", eventID]
+                tags.append(["e", eventID, reportType])
+            }
+            if let pubKey = note.author?.hexadecimalPublicKey {
+                tags.append(["p", pubKey])
             }
         }
         
-        return []
+        return tags
     }
 }

--- a/Nos/Views/ReportMenu.swift
+++ b/Nos/Views/ReportMenu.swift
@@ -143,9 +143,8 @@ struct ReportMenuModifier: ViewModifier {
             content: String(localized: .localizable.reportEventContent(selectedCategory.displayName))
         )
         
-        var targetTag = reportedObject.tag
-        targetTag.append(selectedCategory.nip56Code.rawValue)
-        event.tags.append(targetTag)
+        let nip56Reason = selectedCategory.nip56Code.rawValue
+        event.tags += reportedObject.tags(for: nip56Reason)
         
         Task {
             do {


### PR DESCRIPTION
`Fixes` #997. [NIP-56](https://github.com/nostr-protocol/nips/blob/master/56.md) tells us to append an `e` and a `p` tag when reporting an event, but we were only adding the `e` tag. Also when we saw an event with both an `e` and `p` tag we were treating it as a report for the author, when it's really a report for the event. This fixes both those issues.