### PR TITLE
Set Sentry environment in production

### DIFF
--- a/Nos/Service/CrashReporting.swift
+++ b/Nos/Service/CrashReporting.swift
@@ -26,6 +26,8 @@ class CrashReporting {
             options.environment = "staging"
             #elseif DEV
             options.environment = "debug"
+            #else
+            options.environment = "production"
             #endif
             options.enableTracing = true
             options.tracesSampleRate = 0.3 // tracing must be enabled for profiling


### PR DESCRIPTION
I noticed while doing the latest release that production builds aren't showing up under the "production" environment in [Sentry](https://sentry.nos.social/organizations/verse/releases/?environment=production&project=2&statsPeriod=24h).

hmm, now that I am looking in Sentry again I am seeing 0.1.10 in the production environment. Maybe it is just really slow and this PR isn't needed? 🤔 