### PR TITLE
Bugfix: Two display mentions fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Fixed an issue where users named with valid urls were unable to be mentioned correctly.
+- Fixed an issue where pasting an npub while composing a note created an invalid mention.
 - Fixed the tint color on the Profile screen.
 - Added option to connect your existing NIP-05 username.
 - Fixed a crash that often occurred after opening the app.

--- a/Nos/Models/EditableNoteText.swift
+++ b/Nos/Models/EditableNoteText.swift
@@ -98,8 +98,14 @@ struct EditableNoteText: Equatable {
             )
         )
         mention.append(AttributedString(stringLiteral: " "))
-
-        attributedString.replaceSubrange(range, with: mention)
+        var rangeToReplace = range
+        if range.lowerBound > attributedString.startIndex {
+            let offsetedBound = attributedString.index(range.lowerBound, offsetByCharacters: -1)
+            if let char = attributedString[offsetedBound ..< range.lowerBound].characters.first, char == "@" {
+                rangeToReplace = offsetedBound ..< range.upperBound
+            }
+        }
+        attributedString.replaceSubrange(rangeToReplace, with: mention)
     }
 
     /// Inserts the mention of an author as a link at the given index of the string. The `index` should be the index

--- a/NosTests/NoteParserTests.swift
+++ b/NosTests/NoteParserTests.swift
@@ -5,18 +5,23 @@ import Dependencies
 final class NoteNoteParserTests: CoreDataTestCase {
 
     func testMentionPrecededByAt() throws {
+        // Arrange
         let name = "nos"
         let npub = "npub1pu3vqm4vzqpxsnhuc684dp2qaq6z69sf65yte4p39spcucv5lzmqswtfch"
         let hex = "0f22c06eac1002684efcc68f568540e8342d1609d508bcd4312c038e6194f8b6"
 
-        let content = "Ping @nostr:\(npub)" // The @ symbol before should not break the parsing
-        let expectedContent = "Ping @\(name)"
+        // The @ symbol before nostr: should not break the parsing
+        let content = "Ping @nostr:\(npub)"
+        let expected = "Ping @\(name)"
+
         let tags = [
             ["p", hex],
             ["p", "8c430bdaadc1a202e4dd11c86c82546bb108d755e374b7918181f533b94e312e"],
             ["e", "a9788ca56a90bb5b856e89f16f5f3b0da93c28ea625e845c9925a41377152a13", "", "root"],
             ["e", "3d9503a2d4ad024749b138c041e99934474e2822e2a1c697792dab5b24acc285", "", "reply"]
         ]
+
+        // Act
         let context = try XCTUnwrap(testContext)
         let author = try Author.findOrCreate(by: hex, context: context)
         author.displayName = name
@@ -26,8 +31,10 @@ final class NoteNoteParserTests: CoreDataTestCase {
             tags: tags,
             context: context
         )
+
+        // Assert
         let parsedContent = String(attributedContent.characters)
-        XCTAssertEqual(parsedContent, expectedContent)
+        XCTAssertEqual(parsedContent, expected)
         let links = attributedContent.links
         XCTAssertEqual(links.count, 1)
         XCTAssertEqual(links.first?.key, "@\(name)")
@@ -35,20 +42,24 @@ final class NoteNoteParserTests: CoreDataTestCase {
     }
 
     func testMentionToProfileWithURLInName() throws {
+        // Arrange
         let name = "nos.social" // This should not break the parsing
         let npub = "npub1pu3vqm4vzqpxsnhuc684dp2qaq6z69sf65yte4p39spcucv5lzmqswtfch"
         let hex = "0f22c06eac1002684efcc68f568540e8342d1609d508bcd4312c038e6194f8b6"
         
         let content = "Yep. Something like that. I, of course could implement it " +
             "in nostr:\(npub) but haven’t yet."
-        let expectedContent = "Yep. Something like that. I, of course could implement it " +
+        let expected = "Yep. Something like that. I, of course could implement it " +
             "in @\(name) but haven’t yet."
+
         let tags = [
             ["p", hex],
             ["p", "8c430bdaadc1a202e4dd11c86c82546bb108d755e374b7918181f533b94e312e"],
             ["e", "a9788ca56a90bb5b856e89f16f5f3b0da93c28ea625e845c9925a41377152a13", "", "root"],
             ["e", "3d9503a2d4ad024749b138c041e99934474e2822e2a1c697792dab5b24acc285", "", "reply"]
         ]
+
+        // Act
         let context = try XCTUnwrap(testContext)
         let author = try Author.findOrCreate(by: hex, context: context)
         author.displayName = name
@@ -58,13 +69,16 @@ final class NoteNoteParserTests: CoreDataTestCase {
             tags: tags,
             context: context
         )
+
+        // Assert
         let parsedContent = String(attributedContent.characters)
-        XCTAssertEqual(parsedContent, expectedContent)
+        XCTAssertEqual(parsedContent, expected)
         let links = attributedContent.links
         XCTAssertEqual(links.count, 1)
         XCTAssertEqual(links.first?.key, "@\(name)")
         XCTAssertEqual(links.first?.value, URL(string: "@\(hex)"))
     }
+    
     /// Example taken from [NIP-27](https://github.com/nostr-protocol/nips/blob/master/27.md)
     func testMentionWithNPub() throws {
         let mention = "@mattn"


### PR DESCRIPTION
#962 and #1042 

I added details in those issues with steps to reproduce the errors. In order to solve them this PR:

1. When pasting an npub while composing a note, we now check if the preceding character is an `@` so that we don't insert an extra `@` at the beginning of the mention.
2. When parsing a note, if a mention is `@@nostr:npub` instead of the most common `@nostr:npub`, we still recognize the mention.
3. When parsing a note with mentions to users whose name was a valid url, like `nos.social`, the code that looked for urls in order to substitute them with a proper url like https://nos.social didn't take into account if the url was inside a markdown link, so `[nos.social](@npub)` was altered mistakenly. After trying for a long time to update the regex, I couldn't work it out, it would be too complex, so I just changed the order in which we do the parsing. First, we look for links, and then we replace mentions link #[1] or nostr:npub with markdown links. That produced the same effect.

I created some unit tests to explicitly describe the issue, and I'm attaching screenshots associated to the same screenshots I attached in those issues (#962 and #1042) but with the bugfix, you can check the steps there to reproduce the bug:

![simulator_screenshot_AFD104EF-984B-460D-981C-BB8CF2BAD897](https://github.com/planetary-social/nos/assets/1703242/433e0e59-3172-42ea-80df-e14abc402c4e)

![Simulator Screenshot - iPhone 15 - 2024-04-15 at 18 19 58](https://github.com/planetary-social/nos/assets/1703242/9f7bcc35-5de2-4861-b1ce-0f2b44e6ec7d)
