### PR TITLE
Publish relays when registering a NIP05 username

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- We are now publishing the relay list when registering a new NIP-05 username so
+that other users can find you more easily.
 - Fixed an issue where reports for notes were treated as reports for profiles.
 - Updated the Discover tab navigation bar to match new design.
 

--- a/Nos/Views/ProfileEdit/CreateUsernameWizard/ExcellentChoiceSheet.swift
+++ b/Nos/Views/ProfileEdit/CreateUsernameWizard/ExcellentChoiceSheet.swift
@@ -103,7 +103,14 @@ struct ExcellentChoiceSheet: View {
             claimState = .claiming
 
             do {
-                try await namesAPI.register(username: username, keyPair: keyPair)
+                let relays = currentUser.author?.relays.compactMap {
+                    $0.addressURL
+                }
+                try await namesAPI.register(
+                    username: username,
+                    keyPair: keyPair,
+                    relays: relays ?? []
+                )
                 currentUser.author?.nip05 = "\(username)@nos.social"
                 try currentUser.viewContext.saveIfNeeded()
                 await currentUser.publishMetaData()


### PR DESCRIPTION
#964 

When registering a new NIP05 username in nos.social, we are now sending the list of relays.

You can find how the final result looks in my test account at https://nos.social/.well-known/nostr.json?name=metest