### PR TITLE
Ignore the .git folder for SwiftLint

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -81,6 +81,7 @@ excluded: # paths to ignore during linting. Takes precedence over `included`.
   - Architecture/
   - StarscreamOld/
   - "**/.build"
+  - .git
 analyzer_rules: # Rules run by `swiftlint analyze` (experimental)
   - explicit_self
   - unused_import


### PR DESCRIPTION
Fixes the failures we're having in SwiftLint. It's scanning files in the .git folder which is not helpful.

For example: https://github.com/planetary-social/nos/actions/runs/8743328674/job/23993641412?pr=1059#step:4:233

This is causing at least some PRs to fail checks.