### PR TITLE
Fix opensocket bug

### DIFF
--- a/Nos/Service/Relay/RelayService.swift
+++ b/Nos/Service/Relay/RelayService.swift
@@ -464,6 +464,7 @@ extension RelayService {
         // Make sure the socket doesn't stay open too long
         let task = Task(timeout: 10) { socket.disconnect() }
         return await withCheckedContinuation({ continuation in
+        
             var done = false
             socket.onEvent = { (event: WebSocketEvent) in
                 if done {
@@ -484,9 +485,10 @@ extension RelayService {
                     return
                 }
                 
+
+                done = true
                 task.cancel()
                 socket.disconnect()
-                done = true
                 continuation.resume()
             }
 


### PR DESCRIPTION
There was a bug in which for publication to single relays, the async continuation would not be called when the message received a cancellation message. This PR does this:

* Handles cancellation messages and closes the connection and continues
* Adds a flag to ensure we don't do this more than once because more messages could be coming. I saw in an [example](https://github.com/daltoniam/Starscream/blob/master/examples/AutobahnTest/Autobahn/ViewController.swift) that this type of flags are ok and don't need concurrency primitives. 
* While being there I just added a change to close the timeout task.
* Centralized this code for clarity (I think).
* I didn't add tests because I still not sure if this is easily testable but it seems to be working fine. I can spend some thing rethinking that

Related to #1048 