### PR TITLE
Change “Report user” to “Flag this user”; make it non-destructive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed an issue where users named with valid urls were unable to be mentioned correctly.
 - Fixed an issue where pasting an npub while composing a note created an invalid mention.
 - Changed "Report note" button to "Flag this content"
+- Changed "Report user" button to "Flag this user"
 - We are now publishing the relay list when registering a new NIP-05 username so
 that other users can find you more easily.
 

--- a/Nos/Assets/Localization/Localizable.xcstrings
+++ b/Nos/Assets/Localization/Localizable.xcstrings
@@ -4231,6 +4231,59 @@
         }
       }
     },
+    "flagUser" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Benutzer melden"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Flag this user"
+          }
+        },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "گزارش کاربر"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "ユーザーを報告する"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Rapporteer gebruiker"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Rapportera användare"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "举报用户"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "舉報用戶"
+          }
+        }
+      }
+    },
     "follow" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -10092,59 +10145,6 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "標記此筆記"
-          }
-        }
-      }
-    },
-    "reportUser" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Benutzer melden"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Report user"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "گزارش کاربر"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ユーザーを報告する"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rapporteer gebruiker"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rapportera användare"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "举报用户"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "舉報用戶"
           }
         }
       }

--- a/Nos/Views/Profile/ProfileView.swift
+++ b/Nos/Views/Profile/ProfileView.swift
@@ -178,7 +178,7 @@ struct ProfileView: View {
                                 }
                             }
                             
-                            Button(String(localized: .localizable.reportUser), role: .destructive) {
+                            Button(String(localized: .localizable.flagUser)) {
                                 showingReportMenu = true
                             }
                         }


### PR DESCRIPTION
## Issues covered
#1081 

## Description
Changes the "Report user" text to "Flag this user" in the alert sheet.

## How to test
1. Navigate to a profile
2. Tap the three-dot button in the upper right
3. Observe last option in the alert sheet is now "Flag this user" and not red

## Screenshots/Video
| Before | After |
|--------|--------|
| ![Simulator Screenshot - iPhone 15 Pro Max - 2024-04-26 at 15 13 16](https://github.com/planetary-social/nos/assets/59564/156dead4-d4d3-4f46-a681-1a3a569deb26) | ![Simulator Screenshot - iPhone 15 Pro Max - 2024-04-26 at 14 59 24](https://github.com/planetary-social/nos/assets/59564/54e037a7-0673-47d6-ae7b-345003934a39) | 