### PR TITLE
Potential fix for edit profile issue on Mac

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - Discover tab now features authors in a variety of categories.
+- Fixed an issue on Mac where the Edit Profile screen did not appear in some cases.
 - Fixed an issue where registering a NIP-05 username field could fail silently.
 - Fixed an issue where users named with valid urls were unable to be mentioned correctly.
 - Fixed an issue where pasting an npub while composing a note created an invalid mention.

--- a/Nos/Service/CurrentUser.swift
+++ b/Nos/Service/CurrentUser.swift
@@ -86,8 +86,6 @@ enum CurrentUserError: Error {
     
     var subscriptions = SubscriptionCancellables()
 
-    var editing = false
-
     var onboardingRelays: [Relay] = []
 
     // TODO: prevent this from being accessed from contexts other than the view context. Or maybe just get rid of it.

--- a/Nos/Views/Discover/DiscoverTab.swift
+++ b/Nos/Views/Discover/DiscoverTab.swift
@@ -86,6 +86,9 @@ struct DiscoverTab: View {
             .navigationDestination(for: Author.self) { author in
                 ProfileView(author: author)
             }
+            .navigationDestination(for: EditProfileDestination.self) { destination in
+                ProfileEditView(author: destination.profile)
+            }
             .navigationBarTitle(String(localized: .localizable.discover), displayMode: .inline)
             .toolbarBackground(.visible, for: .navigationBar)
             .toolbarBackground(Color.cardBgBottom, for: .navigationBar)

--- a/Nos/Views/Home/HomeTab.swift
+++ b/Nos/Views/Home/HomeTab.swift
@@ -15,15 +15,10 @@ struct HomeTab: View {
                     RepliesView(note: note)
                 }
                 .navigationDestination(for: Author.self) { author in
-                    if router.currentPath.wrappedValue.count == 1 {
-                        ProfileView(author: author)
-                    } else {
-                        if author == currentUser.author, currentUser.editing {
-                            ProfileEditView(author: author)
-                        } else {
-                            ProfileView(author: author)
-                        }
-                    }
+                    ProfileView(author: author)
+                }
+                .navigationDestination(for: EditProfileDestination.self) { destination in
+                    ProfileEditView(author: destination.profile)
                 }
                 .navigationDestination(for: ReplyToNavigationDestination.self) { destination in
                     RepliesView(note: destination.note, showKeyboard: true)

--- a/Nos/Views/NotificationsView.swift
+++ b/Nos/Views/NotificationsView.swift
@@ -100,6 +100,9 @@ struct NotificationsView: View {
             .navigationDestination(for: Author.self) { author in
                 ProfileView(author: author)
             }
+            .navigationDestination(for: EditProfileDestination.self) { destination in
+                ProfileEditView(author: destination.profile)
+            }
             .refreshable {
                 await subscribeToNewEvents()
             }

--- a/Nos/Views/Profile/ProfileTab.swift
+++ b/Nos/Views/Profile/ProfileTab.swift
@@ -14,11 +14,10 @@ struct ProfileTab: View {
             ProfileView(author: author, addDoubleTapToPop: true)
                 .navigationBarItems(leading: SideMenuButton())
                 .navigationDestination(for: Author.self) { profile in
-                    if profile == currentUser.author, currentUser.editing {
-                        ProfileEditView(author: author)
-                    } else {
-                        ProfileView(author: profile)
-                    }
+                    ProfileView(author: profile)
+                }
+                .navigationDestination(for: EditProfileDestination.self) { destination in
+                    ProfileEditView(author: destination.profile)
                 }
         }
     }

--- a/Nos/Views/Profile/ProfileView.swift
+++ b/Nos/Views/Profile/ProfileView.swift
@@ -111,6 +111,9 @@ struct ProfileView: View {
         .navigationDestination(for: RelaysDestination.self) { destination in
             RelayView(author: destination.author, editable: false)
         }
+        .navigationDestination(for: EditProfileDestination.self) { destination in
+            ProfileEditView(author: destination.profile)
+        }
         .navigationBarItems(
             trailing:
                 HStack {
@@ -132,8 +135,7 @@ struct ProfileView: View {
                         if isShowingLoggedInUser {
                             Button(
                                 action: {
-                                    currentUser.editing = true
-                                    router.push(author)
+                                    router.push(EditProfileDestination(profile: author))
                                 },
                                 label: {
                                     Text(.localizable.editProfile)

--- a/Nos/Views/ProfileEdit/ProfileEditView.swift
+++ b/Nos/Views/ProfileEdit/ProfileEditView.swift
@@ -2,6 +2,10 @@ import Dependencies
 import Logger
 import SwiftUI
 
+struct EditProfileDestination: Hashable {
+    let profile: Author
+}
+
 struct ProfileEditView: View {
     
     @EnvironmentObject private var router: Router
@@ -161,9 +165,6 @@ struct ProfileEditView: View {
         .id(author)
         .task {
             populateTextFields()
-        }
-        .onDisappear {
-            currentUser.editing = false
         }
     }
 

--- a/Nos/Views/SideMenuContent.swift
+++ b/Nos/Views/SideMenuContent.swift
@@ -24,8 +24,7 @@ struct SideMenuContent: View {
                     buttonImage: .editProfile
                 ) {
                     if let author = currentUser.author {
-                        currentUser.editing = true
-                        router.push(author)
+                        router.push(EditProfileDestination(profile: author))
                     }
                 }
                 .padding(.horizontal, 20)
@@ -111,11 +110,10 @@ struct SideMenuContent: View {
                 }
             }
             .navigationDestination(for: Author.self) { profile in
-                if profile == currentUser.author, currentUser.editing {
-                    ProfileEditView(author: profile)
-                } else {
-                    ProfileView(author: profile)
-                }
+                ProfileView(author: profile)
+            }
+            .navigationDestination(for: EditProfileDestination.self) { destination in
+                ProfileEditView(author: destination.profile)
             }
         }
     }


### PR DESCRIPTION
## Issues covered
#1096

## Description
This issue is intermittent, so a potential fix is the best we can do for now. I'm not able to reproduce it. However, I've made a change as suggested by @mplorentz to give Edit Profile its own navigation destination rather than doing conditional logic inside the Author destination. This should improve reliability since we don't have to worry about a race condition with `currentUser.editing`.

## How to test
First, make sure to **do this on a Mac** which is where the issue was discovered.

1. Navigate to Side Menu
2. Click Your Profile
3. Click 3-dot button in upper right of Profile view
4. Click Edit Profile
5. Observe that Edit Profile view is displayed
6. Navigate to Discover tab
7. Search for yourself
8. Click on your profile
9. Click 3-dot button in upper right of Profile view
10. Click Edit Profile
11. Observe that Edit Profile view is displayed
12. Navigate to Profile tab
13. Click 3-dot button in upper right of Profile view
14. Click Edit Profile
15. Observe that Edit Profile view is displayed

## Screenshots/Video
https://github.com/planetary-social/nos/assets/59564/b4d787a8-b3ed-4ff4-96a2-ec89a180afeb