### PR TITLE
Remove debug logs from PagedNoteDataSource

### DIFF
--- a/Nos/Controller/PagedNoteDataSource.swift
+++ b/Nos/Controller/PagedNoteDataSource.swift
@@ -194,7 +194,6 @@ class PagedNoteDataSource<Header: View, EmptyPlaceholder: View>: NSObject, UICol
             insertedIndexes = [IndexPath]()
             deletedIndexes = [IndexPath]()
             movedIndexes = [(IndexPath, IndexPath)]()
-        }, completion: { (success) in
         })
     }
     


### PR DESCRIPTION
## Issues covered
none

## Description
This removes the debug logs I added to help diagnose https://github.com/planetary-social/nos/pull/996. I left them in in case the crash was not really fixed, but it's been three weeks now and I'm confident it's gone.