### PR TITLE
Update categories and authors on Discover tab

### DIFF
--- a/Nos.xcodeproj/project.pbxproj
+++ b/Nos.xcodeproj/project.pbxproj
@@ -7,8 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		030AE4292BE3D63C004DEE02 /* FeaturedAuthor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 030AE4282BE3D63C004DEE02 /* FeaturedAuthor.swift */; };
 		0378409D2BB4A2B600E5E901 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 0378409C2BB4A2B600E5E901 /* PrivacyInfo.xcprivacy */; };
-		03A053342BD8649600A9B4D7 /* FeaturedAuthorCategory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03A053332BD8649600A9B4D7 /* FeaturedAuthorCategory.swift */; };
 		2D06BB9D2AE249D70085F509 /* ThreadRootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D06BB9C2AE249D70085F509 /* ThreadRootView.swift */; };
 		2D4010A22AD87DF300F93AD4 /* KnownFollowersView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D4010A12AD87DF300F93AD4 /* KnownFollowersView.swift */; };
 		3A1C296F2B2A537C0020B753 /* Moderation.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = 3A1C296E2B2A537C0020B753 /* Moderation.xcstrings */; };
@@ -446,8 +446,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		030AE4282BE3D63C004DEE02 /* FeaturedAuthor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeaturedAuthor.swift; sourceTree = "<group>"; };
 		0378409C2BB4A2B600E5E901 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
-		03A053332BD8649600A9B4D7 /* FeaturedAuthorCategory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeaturedAuthorCategory.swift; sourceTree = "<group>"; };
 		2D06BB9C2AE249D70085F509 /* ThreadRootView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ThreadRootView.swift; sourceTree = "<group>"; };
 		2D4010A12AD87DF300F93AD4 /* KnownFollowersView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KnownFollowersView.swift; sourceTree = "<group>"; };
 		3A1C296E2B2A537C0020B753 /* Moderation.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Moderation.xcstrings; sourceTree = "<group>"; };
@@ -908,6 +908,7 @@
 			isa = PBXGroup;
 			children = (
 				65BD8DBE2BDAF2C300802039 /* DiscoverTab.swift */,
+				030AE4282BE3D63C004DEE02 /* FeaturedAuthor.swift */,
 				65BD8DBF2BDAF2C300802039 /* FeaturedAuthorCategory.swift */,
 				65BD8DC02BDAF2C300802039 /* FeaturedAuthorsView.swift */,
 			);
@@ -1142,7 +1143,6 @@
 				C9C9443A29F6E420002F2C7A /* Test Helpers */,
 				C9DEC0042989477A0078B43A /* Fixtures */,
 				C9DEBFE8298941020078B43A /* EventTests.swift */,
-				C96D391A2B61AFD500D3D0A1 /* RawNostrIDTests.swift */,
 				C9C45E152B23741E00F523DA /* EventObservationTests.swift */,
 				C9ADB132299287D60075E7F8 /* KeyPairTests.swift */,
 				5B6EB48F29EDBEC1006E750C /* NoteParserTests.swift */,
@@ -1150,8 +1150,6 @@
 				5B098DC82BDAF7CF00500A1B /* NoteParserTests+NIP27.swift */,
 				5BFBB2942BD9D7EB002E909F /* URLParserTests.swift */,
 				C96D391A2B61AFD500D3D0A1 /* RawNostrIDTests.swift */,
-				C94D59AD2AE7286E00295AE8 /* ReportTests.swift */,
-				5B88051B2A21046C00E21F06 /* SHA256KeyTests.swift */,
 				5B80BE9D29F9864000A363E4 /* Bech32Tests.swift */,
 				C9B678E329EED2DC00303F33 /* SocialGraphTests.swift */,
 				5B88051B2A21046C00E21F06 /* SHA256KeyTests.swift */,
@@ -1297,8 +1295,6 @@
 		C9F84C24298DC7C100C6714D /* Views */ = {
 			isa = PBXGroup;
 			children = (
-				65BD8DC12BDAF2C300802039 /* Discover */,
-				65BD8DB82BDAF28200802039 /* CircularFollowButton.swift */,
 				C9A0DADF29C697A100466635 /* AboutView.swift */,
 				C98DC9BA2A795CAD004E5F0F /* ActionBanner.swift */,
 				C987F81929BA4D0E00B44E7A /* ActionButton.swift */,
@@ -1314,9 +1310,9 @@
 				C95D68A0299E6D3E00429F86 /* BioView.swift */,
 				CD2CF38D299E67F900332116 /* CardButtonStyle.swift */,
 				C9DFA968299BEC33006929C1 /* CardStyle.swift */,
+				65BD8DB82BDAF28200802039 /* CircularFollowButton.swift */,
 				C9DFA96A299BEE2C006929C1 /* CompactNoteView.swift */,
 				5B0D99022A94090A0039F0C5 /* DoubleTapToPopModifier.swift */,
-				5B8C96B529DDD3B200B73AEC /* NoteTextViewRepresentable.swift */,
 				A303AF8229A9153A005DC8FC /* FollowButton.swift */,
 				A32B6C7729A6C99200653FF5 /* FollowCard.swift */,
 				A32B6C7229A6BE9B00653FF5 /* FollowsView.swift */,
@@ -1335,6 +1331,7 @@
 				C974652D2A3B86600031226F /* NoteCardHeader.swift */,
 				CD76864F29B6503500085358 /* NoteOptionsButton.swift */,
 				C9B708BA2A13BE41006C613A /* NoteTextEditor.swift */,
+				5B8C96B529DDD3B200B73AEC /* NoteTextViewRepresentable.swift */,
 				C98B8B3F29FBF83B009789C8 /* NotificationCard.swift */,
 				C94437E529B0DB83004D8C86 /* NotificationsView.swift */,
 				C986510F2B0BD49200597B68 /* PagedNoteListView.swift */,
@@ -1369,6 +1366,7 @@
 				C913DA0D2AEB3265003BDD6D /* WarningView.swift */,
 				C9CE5B132A0172CF008E198C /* WebView.swift */,
 				5B79F6402BA11618002DA9BE /* Components */,
+				65BD8DC12BDAF2C300802039 /* Discover */,
 				C92F01502AC4D67B00972489 /* Form */,
 				C96877B32B4EDCCF0051ED2F /* Home */,
 				C9CFF6D02AB241EB00D4B368 /* Modifiers */,
@@ -1812,6 +1810,7 @@
 				C93F045E2B9B7A7000AD5872 /* ReplyPreview.swift in Sources */,
 				C97465312A3B89140031226F /* AuthorLabel.swift in Sources */,
 				C9C547592A4F1D8C006B0741 /* NosNotification+CoreDataClass.swift in Sources */,
+				030AE4292BE3D63C004DEE02 /* FeaturedAuthor.swift in Sources */,
 				C9B678E729F01A8500303F33 /* FullscreenProgressView.swift in Sources */,
 				C9F0BB6929A5039D000547FC /* Int+Bool.swift in Sources */,
 				DC5F203F2A6AE24200F8D73F /* ImagePickerButton.swift in Sources */,

--- a/Nos/Assets/Localization/Localizable.xcstrings
+++ b/Nos/Assets/Localization/Localizable.xcstrings
@@ -4048,6 +4048,17 @@
         }
       }
     },
+    "featuredAuthorCategoryActivists" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Activists"
+          }
+        }
+      }
+    },
     "featuredAuthorCategoryAll" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -4081,6 +4092,17 @@
         }
       }
     },
+    "featuredAuthorCategoryGaming" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gaming"
+          }
+        }
+      }
+    },
     "featuredAuthorCategoryJournalists" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -4110,6 +4132,17 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "New"
+          }
+        }
+      }
+    },
+    "featuredAuthorCategoryNews" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "News"
           }
         }
       }

--- a/Nos/Views/Discover/FeaturedAuthor.swift
+++ b/Nos/Views/Discover/FeaturedAuthor.swift
@@ -1,0 +1,132 @@
+import Foundation
+
+/// An author that's featured on the Discover tab.
+/// - Note: This is not related to the `Author` Core Data model. This is simply a lightweight type used to
+///         specify which authors appear on the Discover tab.
+struct FeaturedAuthor {
+    /// A name, used for internal purposes, to make it easier to distinguish between featured authors.
+    /// Not used or displayed anywhere; this is purely to prevent bugs via code readability.
+    let name: String
+    /// The public key (npub) of the author.
+    let npub: String
+    /// The categories in which to show the author on the Discover tab.
+    /// No need to include the `.all` category; that's done automatically.
+    let categories: [FeaturedAuthorCategory]
+}
+
+extension FeaturedAuthor {
+    /// All featured authors that should appear on the Discover tab.
+    static let all = cohort0 + cohort1
+}
+
+extension FeaturedAuthor {
+    /// The seed cohort of authors to display on the Discover tab.
+    static let cohort0 = [
+        FeaturedAuthor(
+            name: "Teder",
+            npub: "npub1asuq0pxedwfagpqkdf4lrfmcyfaffgptmayel9947j8krad3x58srs20ap",
+            categories: [.music]
+        ),
+        FeaturedAuthor(
+            name: "Taylor Lorenz",
+            npub: "npub1d9nndmy3lx6f00cysrmn2v9t6hz280uwycw0kgcfdhvg99azry8sududfv",
+            categories: [.journalists, .tech]
+        ),
+        FeaturedAuthor(
+            name: "Mike Masnick",
+            npub: "npub1grz7afdguc67jkjly6fu0xmw0r386t8mtxafutu9u34dy207nt9ql335cv",
+            categories: [.journalists, .tech]
+        ),
+        FeaturedAuthor(
+            name: "Cory Doctorow",
+            npub: "npub1yxzkmtuyctjw2pffp6e9uvyrkp29hrqra2tm3xp3z9707z06muxsg75qvv",
+            categories: [.tech]
+        ),
+        FeaturedAuthor(
+            name: "Matt Blaze",
+            npub: "npub1d7ggne0xsy8e2999q8cyh9zxda688axm07cwncufjeku0nahvfgsyz6qzr",
+            categories: [.art]
+        ),
+        FeaturedAuthor(
+            name: "LotteZ",
+            npub: "npub17a49ajzjlwjv4znh85jcfgmk7qq5ck8m5advx66rudz8g0v034kss2hnk3",
+            categories: [.art]
+        ),
+        FeaturedAuthor(
+            name: "Karine Studio",
+            npub: "npub1l9kr6ajfwp6vfjp60vuzxwqwwlw884dff98a9cznujs520shsf9s35xfwh",
+            categories: [.art]
+        ),
+        FeaturedAuthor(
+            name: "Victor",
+            npub: "npub1uh8e4y97tvs5zhsq6srr43qy0u66zk8xfy08xcrhef2803sdfcrslq62el",
+            categories: [.environment]
+        ),
+        FeaturedAuthor(
+            name: "Premier League Scores",
+            npub: "npub1aylzctp5p20yc842qfpu2w9j8q0kpqcfx8q3p42ugnp3t8uxg3xq3k8nn0",
+            categories: [.sports]
+        ),
+    ]
+}
+
+extension FeaturedAuthor {
+    /// The first official cohort of authors to display on the Discover tab.
+    static let cohort1 = [
+        FeaturedAuthor(
+            name: "Mark Cubey",
+            npub: "npub1j9gcqjheu50kyzkjjmh3pq0msknh58sxu6ugsp33hxfwf5a78r3sfx59e7",
+            categories: [.news]
+        ),
+        FeaturedAuthor(
+            name: "Miguel Almodo",
+            npub: "npub1ajt9gp0prf4xrp4j07j9rghlcyukahncs0fw5ywr977jccued9nqrcc0cs",
+            categories: [.activists]
+        ),
+        FeaturedAuthor(
+            name: "The Conversation",
+            npub: "npub1uuxnz0sq60thc098xfxqst7wnw77l0sm3r8nn48yspuvz4ecprksxdahzv",
+            categories: [.news]
+        ),
+        FeaturedAuthor(
+            name: "Nela Biedermann",
+            npub: "npub1fv9u4drq4hdrr7k45vn0krqy7mkgy8ajf059m0wq8szvcrsjlsrs8tdz3p",
+            categories: [.art]
+        ),
+        FeaturedAuthor(
+            name: "Ainsley Costello",
+            npub: "npub13qrrw2h4z52m7jh0spefrwtysl4psfkfv6j4j672se5hkhvtyw7qu0almy",
+            categories: [.music]
+        ),
+        FeaturedAuthor(
+            name: "Chris Liss",
+            npub: "npub1dwhr8j9uy6ju2uu39t6tj6mw76gztr4rwdd6jr9qtkdh5crjwt5q2nqfxe",
+            categories: [.sports]
+        ),
+        FeaturedAuthor(
+            name: "Kimm Topping",
+            npub: "npub1kw97r9hkcd475cdsqemzh70pwk9vn7qq64ggu2gkgrfnz559kcvqygtr6m",
+            categories: [.activists]
+        ),
+        FeaturedAuthor(
+            name: "Alicia Stockman",
+            npub: "npub1l3y60kjywvrrln5ftse553h2ltg53sm3zy55grvlncd78x3k5uqsmw8dff",
+            categories: [.music]
+        ),
+        FeaturedAuthor(
+            name: "Judson McKinney and the Wanderers",
+            npub: "npub1jvt2hacqqzvwjkum30mlvmy52jer4p4crfh0veqstpk58rr9e7ms2fwh74",
+            categories: [.music]
+        ),
+        FeaturedAuthor(
+            name: "Lou",
+            npub: "npub1rr3678k7ajms2sht0cqqeawy86sdd5ahn6akfj8zex9ng82zuh0sz8nywd",
+            categories: [.gaming]
+        ),
+        FeaturedAuthor(
+            name: "Onigirl",
+            npub: "npub18jvyjwpmm65g8v9azmlvu8knd5m7xlxau08y8vt75n53jtkpz2ys6mqqu3",
+            categories: [.art]
+        ),
+    ]
+}

--- a/Nos/Views/Discover/FeaturedAuthorCategory.swift
+++ b/Nos/Views/Discover/FeaturedAuthorCategory.swift
@@ -1,8 +1,14 @@
 import Foundation
 
+/// Categories of featured authors on the Discover tab.
+/// The order of cases in this enum determines the order in which categories are displayed on the Discover tab.
 enum FeaturedAuthorCategory: CaseIterable {
+    /// A special type of category that includes all other categories.
     case all
     case new // swiftlint:disable:this identifier_name
+    case activists
+    case news
+    case gaming
     case journalists
     case tech
     case art // swiftlint:disable:this identifier_name
@@ -14,6 +20,9 @@ enum FeaturedAuthorCategory: CaseIterable {
         switch self {
         case .all: LocalizedStringResource.localizable.featuredAuthorCategoryAll
         case .new: LocalizedStringResource.localizable.featuredAuthorCategoryNew
+        case .activists: LocalizedStringResource.localizable.featuredAuthorCategoryActivists
+        case .news: LocalizedStringResource.localizable.featuredAuthorCategoryNews
+        case .gaming: LocalizedStringResource.localizable.featuredAuthorCategoryGaming
         case .journalists: LocalizedStringResource.localizable.featuredAuthorCategoryJournalists
         case .tech: LocalizedStringResource.localizable.featuredAuthorCategoryTech
         case .art: LocalizedStringResource.localizable.featuredAuthorCategoryArt
@@ -37,6 +46,16 @@ enum FeaturedAuthorCategory: CaseIterable {
     }
 
     static let npubsToCategories: [String: [FeaturedAuthorCategory]] = [
+        "npub1ajt9gp0prf4xrp4j07j9rghlcyukahncs0fw5ywr977jccued9nqrcc0cs": [.activists],
+        "npub1uuxnz0sq60thc098xfxqst7wnw77l0sm3r8nn48yspuvz4ecprksxdahzv": [.news],
+        "npub1fv9u4drq4hdrr7k45vn0krqy7mkgy8ajf059m0wq8szvcrsjlsrs8tdz3p": [.art],
+        "npub13qrrw2h4z52m7jh0spefrwtysl4psfkfv6j4j672se5hkhvtyw7qu0almy": [.music],
+        "npub1dwhr8j9uy6ju2uu39t6tj6mw76gztr4rwdd6jr9qtkdh5crjwt5q2nqfxe": [.sports],
+        "npub1kw97r9hkcd475cdsqemzh70pwk9vn7qq64ggu2gkgrfnz559kcvqygtr6m": [.activists],
+        "npub1l3y60kjywvrrln5ftse553h2ltg53sm3zy55grvlncd78x3k5uqsmw8dff": [.music],
+        "npub1jvt2hacqqzvwjkum30mlvmy52jer4p4crfh0veqstpk58rr9e7ms2fwh74": [.music],
+        "npub1rr3678k7ajms2sht0cqqeawy86sdd5ahn6akfj8zex9ng82zuh0sz8nywd": [.gaming],
+        "npub18jvyjwpmm65g8v9azmlvu8knd5m7xlxau08y8vt75n53jtkpz2ys6mqqu3": [.art],
         "npub1asuq0pxedwfagpqkdf4lrfmcyfaffgptmayel9947j8krad3x58srs20ap": [.new, .music],
         "npub1d9nndmy3lx6f00cysrmn2v9t6hz280uwycw0kgcfdhvg99azry8sududfv": [.journalists, .tech],
         "npub1grz7afdguc67jkjly6fu0xmw0r386t8mtxafutu9u34dy207nt9ql335cv": [.journalists, .tech],

--- a/Nos/Views/Discover/FeaturedAuthorCategory.swift
+++ b/Nos/Views/Discover/FeaturedAuthorCategory.swift
@@ -1,69 +1,48 @@
 import Foundation
 
 /// Categories of featured authors on the Discover tab.
-/// The order of cases in this enum determines the order in which categories are displayed on the Discover tab.
+/// - Note: The order of cases in this enum determines the order in which categories are displayed
+///         on the Discover tab.
 enum FeaturedAuthorCategory: CaseIterable {
     /// A special type of category that includes all other categories.
     case all
+    /// A special type of category that includes all authors from the latest cohort.
     case new // swiftlint:disable:this identifier_name
-    case activists
+    case music
     case news
+    case art // swiftlint:disable:this identifier_name
+    case activists
     case gaming
     case journalists
     case tech
-    case art // swiftlint:disable:this identifier_name
     case environment
     case sports
-    case music
 
     var text: LocalizedStringResource {
         switch self {
         case .all: LocalizedStringResource.localizable.featuredAuthorCategoryAll
         case .new: LocalizedStringResource.localizable.featuredAuthorCategoryNew
-        case .activists: LocalizedStringResource.localizable.featuredAuthorCategoryActivists
+        case .music: LocalizedStringResource.localizable.featuredAuthorCategoryMusic
         case .news: LocalizedStringResource.localizable.featuredAuthorCategoryNews
+        case .art: LocalizedStringResource.localizable.featuredAuthorCategoryArt
+        case .activists: LocalizedStringResource.localizable.featuredAuthorCategoryActivists
         case .gaming: LocalizedStringResource.localizable.featuredAuthorCategoryGaming
         case .journalists: LocalizedStringResource.localizable.featuredAuthorCategoryJournalists
         case .tech: LocalizedStringResource.localizable.featuredAuthorCategoryTech
-        case .art: LocalizedStringResource.localizable.featuredAuthorCategoryArt
         case .environment: LocalizedStringResource.localizable.featuredAuthorCategoryEnvironment
         case .sports: LocalizedStringResource.localizable.featuredAuthorCategorySports
-        case .music: LocalizedStringResource.localizable.featuredAuthorCategoryMusic
         }
     }
 
     var npubs: [String] {
         switch self {
         case .all:
-            Array(FeaturedAuthorCategory.npubsToCategories.keys)
+            FeaturedAuthor.all.map { $0.npub }
+        case .new:
+            FeaturedAuthor.cohort1.map { $0.npub }
         default:
-            FeaturedAuthorCategory.npubsToCategories
-                .filter { npubToCategories in
-                    npubToCategories.value.contains(self)
-                }
-                .map { $0.key }
+            FeaturedAuthor.all.filter { $0.categories.contains(self) }
+                .map { $0.npub }
         }
     }
-
-    static let npubsToCategories: [String: [FeaturedAuthorCategory]] = [
-        "npub1ajt9gp0prf4xrp4j07j9rghlcyukahncs0fw5ywr977jccued9nqrcc0cs": [.activists],
-        "npub1uuxnz0sq60thc098xfxqst7wnw77l0sm3r8nn48yspuvz4ecprksxdahzv": [.news],
-        "npub1fv9u4drq4hdrr7k45vn0krqy7mkgy8ajf059m0wq8szvcrsjlsrs8tdz3p": [.art],
-        "npub13qrrw2h4z52m7jh0spefrwtysl4psfkfv6j4j672se5hkhvtyw7qu0almy": [.music],
-        "npub1dwhr8j9uy6ju2uu39t6tj6mw76gztr4rwdd6jr9qtkdh5crjwt5q2nqfxe": [.sports],
-        "npub1kw97r9hkcd475cdsqemzh70pwk9vn7qq64ggu2gkgrfnz559kcvqygtr6m": [.activists],
-        "npub1l3y60kjywvrrln5ftse553h2ltg53sm3zy55grvlncd78x3k5uqsmw8dff": [.music],
-        "npub1jvt2hacqqzvwjkum30mlvmy52jer4p4crfh0veqstpk58rr9e7ms2fwh74": [.music],
-        "npub1rr3678k7ajms2sht0cqqeawy86sdd5ahn6akfj8zex9ng82zuh0sz8nywd": [.gaming],
-        "npub18jvyjwpmm65g8v9azmlvu8knd5m7xlxau08y8vt75n53jtkpz2ys6mqqu3": [.art],
-        "npub1asuq0pxedwfagpqkdf4lrfmcyfaffgptmayel9947j8krad3x58srs20ap": [.new, .music],
-        "npub1d9nndmy3lx6f00cysrmn2v9t6hz280uwycw0kgcfdhvg99azry8sududfv": [.journalists, .tech],
-        "npub1grz7afdguc67jkjly6fu0xmw0r386t8mtxafutu9u34dy207nt9ql335cv": [.journalists, .tech],
-        "npub1yxzkmtuyctjw2pffp6e9uvyrkp29hrqra2tm3xp3z9707z06muxsg75qvv": [.tech],
-        "npub1d7ggne0xsy8e2999q8cyh9zxda688axm07cwncufjeku0nahvfgsyz6qzr": [.art],
-        "npub17a49ajzjlwjv4znh85jcfgmk7qq5ck8m5advx66rudz8g0v034kss2hnk3": [.art],
-        "npub1l9kr6ajfwp6vfjp60vuzxwqwwlw884dff98a9cznujs520shsf9s35xfwh": [.art],
-        "npub1uh8e4y97tvs5zhsq6srr43qy0u66zk8xfy08xcrhef2803sdfcrslq62el": [.environment],
-        "npub1aylzctp5p20yc842qfpu2w9j8q0kpqcfx8q3p42ugnp3t8uxg3xq3k8nn0": [.sports],
-    ]
 }


### PR DESCRIPTION
## Issues covered
#1092

## Description
Adds new categories and authors to the Discover tab, as described in the Google Sheet.

## How to test
1. Navigate to Discover
2. Observe new authors

## Screenshots/Video
https://github.com/planetary-social/nos/assets/59564/36267098-ff43-4ba4-836e-16f66302011c
