### PR TITLE
Center categories on iPad/Mac

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- On the Discover tab, center the category buttons.
+
 ## [0.1.12] - 2024-05-07Z
 
 - Open Profiles when tapping on a NIP-05 username reference in a note.

--- a/Nos/Views/Discover/FeaturedAuthorsView.swift
+++ b/Nos/Views/Discover/FeaturedAuthorsView.swift
@@ -104,35 +104,40 @@ struct FeaturedAuthorsView: View {
     }
 
     var categoryPicker: some View {
-        ScrollView(.horizontal) {
-            HStack(spacing: 2) {
-                ForEach(FeaturedAuthorCategory.allCases, id: \.self) { category in
-                    Button(action: {
-                        selectedCategory = category
-                    }, label: {
-                        Text(category.text)
-                            .font(.callout)
-                            .padding(.vertical, 4)
-                            .padding(.horizontal, 8)
-                            .background(
-                                selectedCategory == category ?
-                                Color.pickerBackgroundSelected :
-                                Color.clear
-                            )
-                            .foregroundColor(
-                                selectedCategory == category ?
-                                Color.primaryTxt :
-                                Color.secondaryTxt
-                            )
-                            .cornerRadius(20)
-                            .padding(4)
-                            .frame(minWidth: 44, minHeight: 44)
-                    })
+        GeometryReader { geometry in
+            ScrollView(.horizontal) {
+                HStack(spacing: 2) {
+                    Spacer()
+                    ForEach(FeaturedAuthorCategory.allCases, id: \.self) { category in
+                        Button(action: {
+                            selectedCategory = category
+                        }, label: {
+                            Text(category.text)
+                                .font(.callout)
+                                .padding(.vertical, 4)
+                                .padding(.horizontal, 8)
+                                .background(
+                                    selectedCategory == category ?
+                                    Color.pickerBackgroundSelected :
+                                        Color.clear
+                                )
+                                .foregroundColor(
+                                    selectedCategory == category ?
+                                    Color.primaryTxt :
+                                        Color.secondaryTxt
+                                )
+                                .cornerRadius(20)
+                                .padding(4)
+                                .frame(minWidth: 44, minHeight: 44)
+                        })
+                    }
+                    Spacer()
                 }
+                .frame(width: geometry.size.width)
+//                .padding(.leading, 10)
             }
-            .padding(.leading, 10)
+            .background(Color.profileBgTop)
         }
-        .background(Color.profileBgTop)
     }
 
     private func findOrCreateAuthors() {

--- a/Nos/Views/Discover/FeaturedAuthorsView.swift
+++ b/Nos/Views/Discover/FeaturedAuthorsView.swift
@@ -104,40 +104,45 @@ struct FeaturedAuthorsView: View {
     }
 
     var categoryPicker: some View {
-        GeometryReader { geometry in
+        ViewThatFits {
+            categoriesStack
+
             ScrollView(.horizontal) {
-                HStack(spacing: 2) {
-                    Spacer()
-                    ForEach(FeaturedAuthorCategory.allCases, id: \.self) { category in
-                        Button(action: {
-                            selectedCategory = category
-                        }, label: {
-                            Text(category.text)
-                                .font(.callout)
-                                .padding(.vertical, 4)
-                                .padding(.horizontal, 8)
-                                .background(
-                                    selectedCategory == category ?
-                                    Color.pickerBackgroundSelected :
-                                        Color.clear
-                                )
-                                .foregroundColor(
-                                    selectedCategory == category ?
-                                    Color.primaryTxt :
-                                        Color.secondaryTxt
-                                )
-                                .cornerRadius(20)
-                                .padding(4)
-                                .frame(minWidth: 44, minHeight: 44)
-                        })
-                    }
-                    Spacer()
-                }
-                .frame(width: geometry.size.width)
-//                .padding(.leading, 10)
+                categoriesStack
             }
-            .background(Color.profileBgTop)
         }
+        .background(Color.profileBgTop)
+    }
+
+    var categoriesStack: some View {
+        HStack(spacing: 2) {
+            Spacer()
+            ForEach(FeaturedAuthorCategory.allCases, id: \.self) { category in
+                Button(action: {
+                    selectedCategory = category
+                }, label: {
+                    Text(category.text)
+                        .font(.callout)
+                        .padding(.vertical, 4)
+                        .padding(.horizontal, 8)
+                        .background(
+                            selectedCategory == category ?
+                            Color.pickerBackgroundSelected :
+                                Color.clear
+                        )
+                        .foregroundColor(
+                            selectedCategory == category ?
+                            Color.primaryTxt :
+                                Color.secondaryTxt
+                        )
+                        .cornerRadius(20)
+                        .padding(4)
+                        .frame(minWidth: 44, minHeight: 44)
+                })
+            }
+            Spacer()
+        }
+        .padding(.leading, 10)
     }
 
     private func findOrCreateAuthors() {

--- a/Nos/Views/Discover/FeaturedAuthorsView.swift
+++ b/Nos/Views/Discover/FeaturedAuthorsView.swift
@@ -110,6 +110,7 @@ struct FeaturedAuthorsView: View {
             ScrollView(.horizontal) {
                 categoriesStack
             }
+            .scrollIndicators(.never)
         }
         .background(Color.profileBgTop)
     }


### PR DESCRIPTION
## Issues covered
#1107 

## Description
Uses `ViewThatFits` to display either an `HStack` if the screen/window is wide enough to show all categories or a `ScrollView` if the categories don't fit and need to scroll. Thanks again to @mplorentz for the solution (this is a recurring theme for my PRs).

## How to test
1. Run on iPad
2. Navigate to Discover
3. In portrait orientation, categories will probably scroll (depending on screen size, font size, etc)
4. In landscape orientation, categories will probably appear centered and not scroll.

## Screenshots/Video

| Portrait | Landscape |
|--------|--------|
| ![Simulator Screenshot - iPad (10th generation) - 2024-05-09 at 10 38 20](https://github.com/planetary-social/nos/assets/59564/2d366769-a4f3-4398-b8d1-201e00c861e4) | ![Simulator Screenshot - iPad (10th generation) - 2024-05-09 at 10 38 13](https://github.com/planetary-social/nos/assets/59564/4389d122-3ee7-427e-8c02-f1cdec29b507) | 