### PR TITLE
Fix “Share logs” with new Binding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Fixed an issue where "Share logs" wasn't working.
 - On the Discover tab, center the category buttons.
 
 ## [0.1.12] - 2024-05-07Z

--- a/Nos/Views/SettingsView.swift
+++ b/Nos/Views/SettingsView.swift
@@ -18,6 +18,13 @@ struct SettingsView: View {
     @State private var privateKeyString = ""
     @State private var alert: AlertState<AlertAction>?
     @State private var logFileURL: URL?
+    private var showActivitySheet: Binding<Bool> {
+        Binding<Bool>(
+            get: { logFileURL != nil },
+            set: { _ in }
+        )
+    }
+
     @State private var showReportWarnings = true
     @State private var showOutOfNetworkWarning = true
     
@@ -171,8 +178,12 @@ struct SettingsView: View {
                     }        
                 }
                 .padding(.vertical, 5)
-                .sheet(unwrapping: $logFileURL) { logFileURL in
-                    ActivityViewController(activityItems: [logFileURL.wrappedValue])
+                .sheet(isPresented: showActivitySheet) {
+                    if let logFileURL {
+                        ActivityViewController(activityItems: [logFileURL])
+                    } else {
+                        EmptyView()
+                    }
                 }
 
                 #if DEBUG


### PR DESCRIPTION
## Issues covered
#1097

## Description
This fixes the issue where "Share logs" showed an empty sheet. It turns out there's a [bug](https://github.com/pointfreeco/swiftui-navigation/issues/150) in `swiftui-navigation` where `sheet(unwrapping:)` is just broken. So this replaces the swiftui-navigation `sheet(unwrapping:)` with Apple's `sheet(isPresented:)`.

## How to test
1. Navigate to Settings
2. Tap Share logs

## Screenshots/Video
https://github.com/planetary-social/nos/assets/59564/ec122769-98be-4ccf-af2c-98f36b7e2ece
