### PR TITLE
Remove placeholder categories & people from Discover tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- On the Discover tab, center the category buttons.
+- Discover tab: Center the category buttons.
+- Discover tab: Remove placeholder categories and people.
 
 ## [0.1.12] - 2024-05-07Z
 

--- a/Nos/Assets/Localization/Localizable.xcstrings
+++ b/Nos/Assets/Localization/Localizable.xcstrings
@@ -4081,17 +4081,6 @@
         }
       }
     },
-    "featuredAuthorCategoryEnvironment" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : " Environment"
-          }
-        }
-      }
-    },
     "featuredAuthorCategoryGaming" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -4099,17 +4088,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Gaming"
-          }
-        }
-      }
-    },
-    "featuredAuthorCategoryJournalists" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Journalists"
           }
         }
       }
@@ -4154,17 +4132,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sports"
-          }
-        }
-      }
-    },
-    "featuredAuthorCategoryTech" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tech"
           }
         }
       }

--- a/Nos/Views/Discover/FeaturedAuthor.swift
+++ b/Nos/Views/Discover/FeaturedAuthor.swift
@@ -16,62 +16,11 @@ struct FeaturedAuthor {
 
 extension FeaturedAuthor {
     /// All featured authors that should appear on the Discover tab.
-    static let all = cohort0 + cohort1
+    static let all = cohort1
 }
 
 extension FeaturedAuthor {
-    /// The seed cohort of authors to display on the Discover tab.
-    static let cohort0 = [
-        FeaturedAuthor(
-            name: "Teder",
-            npub: "npub1asuq0pxedwfagpqkdf4lrfmcyfaffgptmayel9947j8krad3x58srs20ap",
-            categories: [.music]
-        ),
-        FeaturedAuthor(
-            name: "Taylor Lorenz",
-            npub: "npub1d9nndmy3lx6f00cysrmn2v9t6hz280uwycw0kgcfdhvg99azry8sududfv",
-            categories: [.journalists, .tech]
-        ),
-        FeaturedAuthor(
-            name: "Mike Masnick",
-            npub: "npub1grz7afdguc67jkjly6fu0xmw0r386t8mtxafutu9u34dy207nt9ql335cv",
-            categories: [.journalists, .tech]
-        ),
-        FeaturedAuthor(
-            name: "Cory Doctorow",
-            npub: "npub1yxzkmtuyctjw2pffp6e9uvyrkp29hrqra2tm3xp3z9707z06muxsg75qvv",
-            categories: [.tech]
-        ),
-        FeaturedAuthor(
-            name: "Matt Blaze",
-            npub: "npub1d7ggne0xsy8e2999q8cyh9zxda688axm07cwncufjeku0nahvfgsyz6qzr",
-            categories: [.art]
-        ),
-        FeaturedAuthor(
-            name: "LotteZ",
-            npub: "npub17a49ajzjlwjv4znh85jcfgmk7qq5ck8m5advx66rudz8g0v034kss2hnk3",
-            categories: [.art]
-        ),
-        FeaturedAuthor(
-            name: "Karine Studio",
-            npub: "npub1l9kr6ajfwp6vfjp60vuzxwqwwlw884dff98a9cznujs520shsf9s35xfwh",
-            categories: [.art]
-        ),
-        FeaturedAuthor(
-            name: "Victor",
-            npub: "npub1uh8e4y97tvs5zhsq6srr43qy0u66zk8xfy08xcrhef2803sdfcrslq62el",
-            categories: [.environment]
-        ),
-        FeaturedAuthor(
-            name: "Premier League Scores",
-            npub: "npub1aylzctp5p20yc842qfpu2w9j8q0kpqcfx8q3p42ugnp3t8uxg3xq3k8nn0",
-            categories: [.sports]
-        ),
-    ]
-}
-
-extension FeaturedAuthor {
-    /// The first official cohort of authors to display on the Discover tab.
+    /// The first cohort of authors to display on the Discover tab.
     static let cohort1 = [
         FeaturedAuthor(
             name: "Mark Cubey",

--- a/Nos/Views/Discover/FeaturedAuthorCategory.swift
+++ b/Nos/Views/Discover/FeaturedAuthorCategory.swift
@@ -13,9 +13,6 @@ enum FeaturedAuthorCategory: CaseIterable {
     case art // swiftlint:disable:this identifier_name
     case activists
     case gaming
-    case journalists
-    case tech
-    case environment
     case sports
 
     var text: LocalizedStringResource {
@@ -27,9 +24,6 @@ enum FeaturedAuthorCategory: CaseIterable {
         case .art: LocalizedStringResource.localizable.featuredAuthorCategoryArt
         case .activists: LocalizedStringResource.localizable.featuredAuthorCategoryActivists
         case .gaming: LocalizedStringResource.localizable.featuredAuthorCategoryGaming
-        case .journalists: LocalizedStringResource.localizable.featuredAuthorCategoryJournalists
-        case .tech: LocalizedStringResource.localizable.featuredAuthorCategoryTech
-        case .environment: LocalizedStringResource.localizable.featuredAuthorCategoryEnvironment
         case .sports: LocalizedStringResource.localizable.featuredAuthorCategorySports
         }
     }


### PR DESCRIPTION
## Issues covered
#1108 

## Description
Removed the placeholder people and categories from the Discover tab.

## How to test
1. Navigate to Discover
2. Observe

## Screenshots/Video
https://github.com/planetary-social/nos/assets/59564/648ca1b9-3701-49c5-9612-85f62cfa3cc4

