### PR TITLE
Fix issue where Share Logs sheet reappeared

### DIFF
--- a/Nos/Views/SettingsView.swift
+++ b/Nos/Views/SettingsView.swift
@@ -178,13 +178,19 @@ struct SettingsView: View {
                     }        
                 }
                 .padding(.vertical, 5)
-                .sheet(isPresented: showActivitySheet) {
-                    if let logFileURL {
-                        ActivityViewController(activityItems: [logFileURL])
-                    } else {
-                        EmptyView()
+                .sheet(
+                    isPresented: showActivitySheet,
+                    onDismiss: {
+                        logFileURL = nil
+                    },
+                    content: {
+                        if let logFileURL {
+                            ActivityViewController(activityItems: [logFileURL])
+                        } else {
+                            EmptyView()
+                        }
                     }
-                }
+                )
 
                 #if DEBUG
                 Text(.localizable.sampleDataInstructions)


### PR DESCRIPTION
## Issues covered
#1097

## Description
The Share Logs sheet was reappearing after it was dismissed, which is bad. This fixes it.

## How to test
1. Navigate to Settings
2. Tap Share Logs
3. Close the sheet
4. Tap Back

## Screenshots/Video
Before:
https://github.com/planetary-social/nos/assets/59564/a260a11b-5239-42b9-8649-df206fb8345b

After:
https://github.com/planetary-social/nos/assets/59564/30577c67-4bee-4064-86f0-3193e518df7e

