### PR TITLE
Add LazyVStack to RepliesView

### DIFF
--- a/Nos/Views/RepliesView.swift
+++ b/Nos/Views/RepliesView.swift
@@ -95,7 +95,7 @@ struct RepliesView: View {
         GeometryReader { _ in
             VStack {
                 ScrollView(.vertical) {
-                    VStack {
+                    LazyVStack {
                         NoteButton(
                             note: note,
                             shouldTruncate: false,


### PR DESCRIPTION
## Issues covered
A quick win for #1115. I have more PRs coming for this issue.

## Description
This just avoids loading ThreadViews in a big thread until we need them.

## How to test
1. Find a note with a lot of replies (I have been using `note1d0f6l4jzt2wg2e8efcsll4pn8lc2qs85yselradp4m6k44dq22ws0ggvru`).
2. Open the thread view for the note and scroll around. This PR improves the performance _after a few seconds_. I still have work to do to optimize the initial load.
