### PR TITLE
Fixes #1034: NIP-05 sheet layout bug

### DIFF
--- a/Nos/Views/Components/WizardNavigationStack.swift
+++ b/Nos/Views/Components/WizardNavigationStack.swift
@@ -16,7 +16,7 @@ struct WizardNavigationStack<Root>: View where Root: View {
     var body: some View {
         NavigationStack(root: root)
             .frame(idealWidth: 320, idealHeight: 480)
-            .presentationDetents([.medium])
+            .presentationDetents([.height(480)])
     }
 }
 


### PR DESCRIPTION
## Issues covered
#1034

## Description
I tried updating the presentationIntents just for that screen, so the dialog would increase when the user advances to that screen, but the visual effect looks broken. So, I found a quick workaround which is just making the sheet look a bit larger, and specifically, the height we have on the designs.

## How to test
1. Navigate to Profile
2. Tap on Options > Edit Profile
3. Claim your username
4. Tap on No, thanks. I already have a NIP-05
5. See that the screen is not cut-off

## Screenshots/Video

![IMG_D6A247FF1838-1](https://github.com/planetary-social/nos/assets/1703242/f39726cf-3d59-4ca4-842d-9dd946a7a297)
