### PR TITLE
Remove Alastair from Sports

### DIFF
--- a/Nos/Views/Discover/FeaturedAuthor.swift
+++ b/Nos/Views/Discover/FeaturedAuthor.swift
@@ -90,7 +90,7 @@ extension FeaturedAuthor {
         FeaturedAuthor(
             name: "Alastair Thompson",
             npub: "npub157pk8t8njtnldqzankrk2syzmkp6qtrv2ewgq3fnuc4k78dr797shfngev",
-            categories: [.news, .sports]
+            categories: [.news]
         ),
     ]
 }


### PR DESCRIPTION
## Issues covered
#1134

## Description
Whoops. This fixes it.

## How to test
1. Navigate to Discover
2. Observe that Alastair (althecat@nos.social) is no longer in Sports but only All, New, and News.

## Screenshots/Video
![Simulator Screenshot - iPhone 15 Pro - 2024-05-15 at 10 36 14](https://github.com/planetary-social/nos/assets/59564/42087938-aeb4-4bc8-8402-88a4e029e1c5)
