### PR TITLE
Fix bug where “Profile” is lowercase and not centered

### DIFF
--- a/Nos/Assets/Localization/Localizable.xcstrings
+++ b/Nos/Assets/Localization/Localizable.xcstrings
@@ -9033,77 +9033,6 @@
         }
       }
     },
-    "profile" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Profile"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "profile"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Perfil"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "نمایه"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Profil"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "プロフィール"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "profiel"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Perfil"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "profil"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "个人档案"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "個人檔案"
-          }
-        }
-      }
-    },
     "profilePicture" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -9158,6 +9087,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Profile"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Perfil"
           }
         },
         "fa" : {

--- a/Nos/Models/ReportTarget.swift
+++ b/Nos/Models/ReportTarget.swift
@@ -16,12 +16,12 @@ enum ReportTarget {
         }
     }
     
-    var displayString: String {
+    var analyticsString: String {
         switch self {
         case .note:
-            return String(localized: .localizable.note)
+            return "note"
         case .author:
-            return String(localized: .localizable.profile)
+            return "profile"
         }
     }
     

--- a/Nos/Service/Analytics.swift
+++ b/Nos/Service/Analytics.swift
@@ -137,7 +137,7 @@ class Analytics {
     }
     
     func reported(_ reportedObject: ReportTarget) {
-        track("Reported", properties: ["type": reportedObject.displayString])
+        track("Reported", properties: ["type": reportedObject.analyticsString])
     }
     
     func identify(with keyPair: KeyPair) {

--- a/Nos/Views/Discover/DiscoverTab.swift
+++ b/Nos/Views/Discover/DiscoverTab.swift
@@ -78,7 +78,7 @@ struct DiscoverTab: View {
             .navigationDestination(for: EditProfileDestination.self) { destination in
                 ProfileEditView(author: destination.profile)
             }
-            .navigationBarTitle(String(localized: .localizable.discover), displayMode: .inline)
+            .nosNavigationBar(title: .localizable.discover)
             .toolbarBackground(.visible, for: .navigationBar)
             .toolbarBackground(Color.cardBgBottom, for: .navigationBar)
             .navigationBarItems(leading: SideMenuButton())

--- a/Nos/Views/NosNavigationBar.swift
+++ b/Nos/Views/NosNavigationBar.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct NosNavigationBarModifier: ViewModifier {
     
     var title: LocalizedStringResource
+    var leadingPadding: CGFloat
 
     func body(content: Content) -> some View {
         content
@@ -12,7 +13,7 @@ struct NosNavigationBarModifier: ViewModifier {
                     Text(title)
                         .font(.clarity(.bold, textStyle: .title3))
                         .foregroundColor(.primaryTxt)
-                        .padding(.leading, 14)
+                        .padding(.leading, leadingPadding)
                         .tint(.primaryTxt)
                         .allowsHitTesting(false)
                 }
@@ -23,8 +24,8 @@ struct NosNavigationBarModifier: ViewModifier {
 }
 
 extension View {
-    func nosNavigationBar(title: LocalizedStringResource) -> some View {
-        self.modifier(NosNavigationBarModifier(title: title))
+    func nosNavigationBar(title: LocalizedStringResource, leadingPadding: CGFloat = 14) -> some View {
+        self.modifier(NosNavigationBarModifier(title: title, leadingPadding: leadingPadding))
     }
 }
 

--- a/Nos/Views/NosNavigationBar.swift
+++ b/Nos/Views/NosNavigationBar.swift
@@ -3,7 +3,6 @@ import SwiftUI
 struct NosNavigationBarModifier: ViewModifier {
     
     var title: LocalizedStringResource
-    var leadingPadding: CGFloat
 
     func body(content: Content) -> some View {
         content
@@ -13,7 +12,6 @@ struct NosNavigationBarModifier: ViewModifier {
                     Text(title)
                         .font(.clarity(.bold, textStyle: .title3))
                         .foregroundColor(.primaryTxt)
-                        .padding(.leading, leadingPadding)
                         .tint(.primaryTxt)
                         .allowsHitTesting(false)
                 }
@@ -24,8 +22,8 @@ struct NosNavigationBarModifier: ViewModifier {
 }
 
 extension View {
-    func nosNavigationBar(title: LocalizedStringResource, leadingPadding: CGFloat = 14) -> some View {
-        self.modifier(NosNavigationBarModifier(title: title, leadingPadding: leadingPadding))
+    func nosNavigationBar(title: LocalizedStringResource) -> some View {
+        self.modifier(NosNavigationBarModifier(title: title))
     }
 }
 

--- a/Nos/Views/Profile/ProfileHeader.swift
+++ b/Nos/Views/Profile/ProfileHeader.swift
@@ -152,7 +152,7 @@ struct ProfileHeader: View {
             NavigationView {
                 BioSheet(author: author)
                     .background(Color.bioBgGradientBottom)
-                    .nosNavigationBar(title: .localizable.profile)
+                    .navigationBarTitle(String(localized: .localizable.profileTitle), displayMode: .inline)
                     .toolbar {
                         ToolbarItem(placement: .navigationBarTrailing) {
                             Button {

--- a/Nos/Views/Profile/ProfileHeader.swift
+++ b/Nos/Views/Profile/ProfileHeader.swift
@@ -152,7 +152,7 @@ struct ProfileHeader: View {
             NavigationView {
                 BioSheet(author: author)
                     .background(Color.bioBgGradientBottom)
-                    .navigationBarTitle(String(localized: .localizable.profileTitle), displayMode: .inline)
+                    .nosNavigationBar(title: .localizable.profileTitle, leadingPadding: 0)
                     .toolbar {
                         ToolbarItem(placement: .navigationBarTrailing) {
                             Button {

--- a/Nos/Views/Profile/ProfileHeader.swift
+++ b/Nos/Views/Profile/ProfileHeader.swift
@@ -152,7 +152,7 @@ struct ProfileHeader: View {
             NavigationView {
                 BioSheet(author: author)
                     .background(Color.bioBgGradientBottom)
-                    .nosNavigationBar(title: .localizable.profileTitle, leadingPadding: 0)
+                    .nosNavigationBar(title: .localizable.profileTitle)
                     .toolbar {
                         ToolbarItem(placement: .navigationBarTrailing) {
                             Button {


### PR DESCRIPTION
## Issues covered
#1137

## Description
Centers and capitalizes "Profile" in the sheet

## How to test
1. Navigate to a profile
2. Tap the bio
3. Observe the "Profile" header

## Screenshots/Video
| Before | After |
|--------|--------|
| ![IMG_8E9438E2CF3F-1](https://github.com/planetary-social/nos/assets/59564/66831b4d-5d8b-4dae-88cb-a484f4977409) | ![Simulator Screenshot - iPhone 15 Pro - 2024-05-15 at 14 15 02](https://github.com/planetary-social/nos/assets/59564/36827a30-0696-4cb6-a8b8-9915da2d1394) | 