### PR TITLE
Downgrade swift-ui-navigation and swift-dependencies

### DIFF
--- a/Nos.xcodeproj/project.pbxproj
+++ b/Nos.xcodeproj/project.pbxproj
@@ -2814,7 +2814,7 @@
 			repositoryURL = "https://github.com/pointfreeco/swiftui-navigation";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 1.0.0;
+				minimumVersion = 0.6.1;
 			};
 		};
 		C9646E9829B79E04007239A4 /* XCRemoteSwiftPackageReference "logger-ios" */ = {
@@ -2838,7 +2838,7 @@
 			repositoryURL = "https://github.com/pointfreeco/swift-dependencies";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 1.0.0;
+				minimumVersion = 0.1.4;
 			};
 		};
 		C96CB98A2A6040C500498C4E /* XCRemoteSwiftPackageReference "swift-collections" */ = {

--- a/Nos.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Nos.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/combine-schedulers",
       "state" : {
-        "revision" : "9dc9cbe4bc45c65164fa653a563d8d8db61b09bb",
-        "version" : "1.0.0"
+        "revision" : "ec62f32d21584214a4b27c8cee2b2ad70ab2c38a",
+        "version" : "0.11.0"
       }
     },
     {
@@ -113,8 +113,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-case-paths",
       "state" : {
-        "revision" : "79623dbe2c7672f5e450d8325613d231454390b3",
-        "version" : "1.3.2"
+        "revision" : "fc45e7b2cfece9dd80b5a45e6469ffe67fe67984",
+        "version" : "0.14.1"
       }
     },
     {
@@ -122,8 +122,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-clocks",
       "state" : {
-        "revision" : "a8421d68068d8f45fbceb418fbf22c5dad4afd33",
-        "version" : "1.0.2"
+        "revision" : "0fbaebfc013715dab44d715a4d350ba37f297e4d",
+        "version" : "0.4.0"
       }
     },
     {
@@ -140,8 +140,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-concurrency-extras",
       "state" : {
-        "revision" : "bb5059bde9022d69ac516803f4f227d8ac967f71",
-        "version" : "1.1.0"
+        "revision" : "479750bd98fac2e813fffcf2af0728b5b0085795",
+        "version" : "0.1.1"
       }
     },
     {
@@ -149,8 +149,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-custom-dump",
       "state" : {
-        "revision" : "f01efb26f3a192a0e88dcdb7c3c391ec2fc25d9c",
-        "version" : "1.3.0"
+        "revision" : "0a5bff05fe01dcd513932ed338a4efad8268b803",
+        "version" : "0.11.2"
       }
     },
     {
@@ -158,8 +158,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-dependencies",
       "state" : {
-        "revision" : "d3a5af3038a09add4d7682f66555d6212058a3c0",
-        "version" : "1.2.2"
+        "revision" : "16fd42ae04c6e7f74a6a86395d04722c641cccee",
+        "version" : "0.6.0"
       }
     },
     {
@@ -169,15 +169,6 @@
       "state" : {
         "revision" : "e97a6fcb1ab07462881ac165fdbb37f067e205d5",
         "version" : "1.5.4"
-      }
-    },
-    {
-      "identity" : "swift-syntax",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-syntax",
-      "state" : {
-        "revision" : "fa8f95c2d536d6620cc2f504ebe8a6167c9fc2dd",
-        "version" : "510.0.1"
       }
     },
     {
@@ -194,8 +185,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swiftui-navigation",
       "state" : {
-        "revision" : "2ec6c3a15293efff6083966b38439a4004f25565",
-        "version" : "1.3.0"
+        "revision" : "2aa885e719087ee19df251c08a5980ad3e787f12",
+        "version" : "0.8.0"
       }
     },
     {
@@ -221,8 +212,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
       "state" : {
-        "revision" : "6f30bdba373bbd7fbfe241dddd732651f2fbd1e2",
-        "version" : "1.1.2"
+        "revision" : "50843cbb8551db836adec2290bb4bc6bac5c1865",
+        "version" : "0.9.0"
       }
     }
   ],

--- a/Nos/Views/New Note/ComposerActionBar.swift
+++ b/Nos/Views/New Note/ComposerActionBar.swift
@@ -116,7 +116,7 @@ struct ComposerActionBar: View {
         .onChange(of: expirationTime) { _, _ in
             subMenu = .none
         }
-        .alert($alert) { (_: AlertAction?) in
+        .alert(unwrapping: $alert) { (_: AlertAction?) in
         }
         .background(
             LinearGradient(

--- a/Nos/Views/New Note/NewNoteView.swift
+++ b/Nos/Views/New Note/NewNoteView.swift
@@ -156,7 +156,7 @@ struct NewNoteView: View {
                 analytics.showedNewNote()
             }
         }
-        .alert($alert)
+        .alert(unwrapping: $alert)
     }
 
     private func postAction() async {

--- a/Nos/Views/Profile/ProfileView.swift
+++ b/Nos/Views/Profile/ProfileView.swift
@@ -188,7 +188,7 @@ struct ProfileView: View {
                 }
         )
         .reportMenu($showingReportMenu, reportedObject: .author(author))
-        .alert($alert)
+        .alert(unwrapping: $alert)
         .onAppear {
             Task { 
                 await downloadAuthorData()

--- a/Nos/Views/RelayView.swift
+++ b/Nos/Views/RelayView.swift
@@ -145,7 +145,7 @@ struct RelayView: View {
                 ))
             }
         }
-        .alert($alert)
+        .alert(unwrapping: $alert)
         .scrollContentBackground(.hidden)
         .background(Color.appBg)
         .toolbar {

--- a/Nos/Views/ReportMenu.swift
+++ b/Nos/Views/ReportMenu.swift
@@ -22,7 +22,7 @@ struct ReportMenuModifier: ViewModifier {
     func body(content: Content) -> some View {
         content
         // ReportCategory menu
-            .confirmationDialog($confirmationDialogState, action: processUserSelection)
+            .confirmationDialog(unwrapping: $confirmationDialogState, action: processUserSelection)
             .alert(
                 String(localized: .localizable.confirmFlag),
                 isPresented: $confirmReport,

--- a/Nos/Views/SettingsView.swift
+++ b/Nos/Views/SettingsView.swift
@@ -229,7 +229,7 @@ struct SettingsView: View {
         .scrollContentBackground(.hidden)
         .background(Color.appBg)
         .nosNavigationBar(title: .localizable.settings)
-        .alert($alert) { (action: AlertAction?) in
+        .alert(unwrapping: $alert) { (action: AlertAction?) in
             if let action {
                 await alertButtonTapped(action)
             }


### PR DESCRIPTION
This reduced the build time on my machine from 255 seconds to 52 seconds(!!!!!!!!!!!!!!)

I couldn't take the 4.5 minute build times anymore so I decided to take 15 minutes to see if I could remove our dependency on SwiftSyntax because that alone takes like 2 minutes to compile on my machine.

## Issues covered
This relates to #1035 but I think there is more we can do so I want to leave that ticket open.

## Description
I downgraded swiftui-navigation to the version we were using before we upgraded it in `d8389138d`. I also downgraded swift-dependencies because they share some dependencies and I remember getting conflicts when trying to upgrade one without the other in the past. This required a few source changes to use the older `.alert(unwrapping:)` versions of the swiftui-navigation APIs.

## How to test
1. Build the app. It's faster!
