### PR TITLE
Work around duplicate relay in the database

### DIFF
--- a/Nos/Models/CoreData/Author+CoreDataClass.swift
+++ b/Nos/Models/CoreData/Author+CoreDataClass.swift
@@ -366,7 +366,6 @@ import Logger
     
     func add(relay: Relay) {
         relays.insert(relay) 
-        print("Adding \(relay.address ?? "") to \(hexadecimalPublicKey ?? "")")
     }
     
     @MainActor func mute(viewContext context: NSManagedObjectContext) async throws {

--- a/Nos/Models/CoreData/Event+CoreDataClass.swift
+++ b/Nos/Models/CoreData/Event+CoreDataClass.swift
@@ -365,8 +365,17 @@ public class Event: NosManagedObject, VerifiableEvent {
     }
     
     @nonobjc public class func event(by identifier: String, seenOn relay: Relay) -> NSFetchRequest<Event> {
+        guard let relayAddress = relay.address else {
+            return Event.emptyRequest()
+        }
+        
         let fetchRequest = NSFetchRequest<Event>(entityName: "Event")
-        fetchRequest.predicate = NSPredicate(format: "identifier = %@ AND ANY seenOnRelays = %@", identifier, relay)
+        fetchRequest.predicate = NSPredicate(
+            format: "identifier = %@ AND ANY seenOnRelays.address = %@", 
+            identifier, 
+            relayAddress
+        )
+        fetchRequest.sortDescriptors = [NSSortDescriptor(keyPath: \Relay.createdAt, ascending: true)]
         fetchRequest.fetchLimit = 1
         return fetchRequest
     }

--- a/Nos/Models/CoreData/Relay+CoreDataClass.swift
+++ b/Nos/Models/CoreData/Relay+CoreDataClass.swift
@@ -57,6 +57,7 @@ public class Relay: NosManagedObject {
     @nonobjc public class func relay(by address: String) -> NSFetchRequest<Relay> {
         let fetchRequest = NSFetchRequest<Relay>(entityName: "Relay")
         fetchRequest.predicate = NSPredicate(format: "address = %@", address)
+        fetchRequest.sortDescriptors = [NSSortDescriptor(keyPath: \Relay.createdAt, ascending: true)]
         fetchRequest.fetchLimit = 1
         return fetchRequest
     }
@@ -116,7 +117,7 @@ public class Relay: NosManagedObject {
         metadataFetchedAt = Date.now
     }
 
-    convenience init(context: NSManagedObjectContext, address: String, author: Author? = nil) throws {
+    private convenience init(context: NSManagedObjectContext, address: String, author: Author? = nil) throws {
         guard let addressURL = URL(string: address),
             addressURL.scheme == "wss" else {
             throw RelayError.invalidAddress

--- a/Nos/Service/CurrentUser.swift
+++ b/Nos/Service/CurrentUser.swift
@@ -154,11 +154,8 @@ enum CurrentUserError: Error {
         
         // Recommended Relays for new user
         for address in Relay.recommended {
-            _ = try? Relay(
-                context: viewContext,
-                address: address,
-                author: author
-            )
+            let relay = try? Relay.findOrCreate(by: address, context: viewContext)
+            relay?.addToAuthors(author)
         }
         try viewContext.save()
         

--- a/Nos/Views/Discover/DiscoverTab.swift
+++ b/Nos/Views/Discover/DiscoverTab.swift
@@ -130,7 +130,8 @@ struct DiscoverTab_Previews: PreviewProvider {
     static func createRelayData(in context: NSManagedObjectContext, user: Author) {
         let addresses = ["wss://nostr.band", "wss://nos.social", "wss://a.long.domain.name.to.see.what.happens"]
         addresses.forEach {
-            _ = try? Relay(context: previewContext, address: $0, author: user)
+            let relay = try? Relay.findOrCreate(by: $0, context: previewContext)
+            relay?.addToAuthors(user)
         }
 
         try? previewContext.save()

--- a/Nos/Views/Onboarding/OnboardingLoginView.swift
+++ b/Nos/Views/Onboarding/OnboardingLoginView.swift
@@ -19,11 +19,7 @@ struct OnboardingLoginView: View {
 
         for address in Relay.allKnown {
             do {
-                let relay = try Relay(
-                    context: viewContext,
-                    address: address,
-                    author: currentUser.author
-                )
+                let relay = try Relay.findOrCreate(by: address, context: viewContext)
                 currentUser.onboardingRelays.append(relay)
             } catch {
                 Log.error(error.localizedDescription)

--- a/Nos/Views/RelayDetailView.swift
+++ b/Nos/Views/RelayDetailView.swift
@@ -82,7 +82,7 @@ struct RelayDetailView_Previews: PreviewProvider {
     static var previewContext = PersistenceController.preview.container.viewContext
     static var relay: Relay {
         do {
-            return try Relay(context: previewContext, address: "wss://example.com")
+            return try Relay.findOrCreate(by: "wss://example.com", context: previewContext) 
         } catch {
             return Relay(context: previewContext)
         }

--- a/Nos/Views/RelayPicker.swift
+++ b/Nos/Views/RelayPicker.swift
@@ -116,9 +116,10 @@ struct RelayPicker_Previews: PreviewProvider {
     
     static func createTestData(in context: NSManagedObjectContext, user: Author) {
         let addresses = ["wss://nostr.com", "wss://nos.social", "wss://alongdomainnametoseewhathappens.com"]
-        addresses.forEach {
+        addresses.forEach { address in
             do {
-                _ = try Relay(context: previewContext, address: $0, author: user)
+                let relay = try? Relay.findOrCreate(by: address, context: previewContext)
+                relay?.addToAuthors(user)
             } catch {
                 print(error)
             }


### PR DESCRIPTION
## Issues covered
This was done as part of #1112 

## Description
I noticed that the event processing loop was doing a lot of Core Data saves even when it was processing duplicate events - events we have already parsed and saved to the database. This was causing some unnecessary CPU cycles, more the more relays you have in your relay list. I narrowed the problem down to the code in EventProcessor where we link duplicate events to the relay we saw them on. This information is used later when we do things like repost an event, we are supposed to add a relay that we saw the original event on as a hint for other clients.

But I noticed we were linking events to relays multiple times for the same event and relay. This is because we have multiple `Relay` objects with the same `address` in our database 😞 First I thought I would add a unique constraint on the `address` field but the necessary migration was going to be a lot of work, so I created #1150 to do that later. Instead I decided to sort by `Relay.createdAt` when fetching relays so that we always use the oldest one even if there are duplicates. This fixes the unnecessary Core Data save operations. I also made our convenience initializer on `Relay` private so we use `Relay.findOrCreate(...)` instead to prevent inserting more duplicates into the database.

I also found that on login we were linking all the known relays to the user's current account 🤦‍♂️ this means in some cases we could add all these users to the relay list when they didn't want that. It was an easy fix.

Overall I don't think this will have a massive effect on CPU usage, but it will help some. My strategy right now is to approach this from several angles and hope that small gains add up. For instance a future PR will deal with some wasted cycles that happen when observing saves, but cutting down on overall saves helps too.

## How to test
This one is tricky, but you could put a breakpoint in `Event.markSeen(on:)` and verify that it isn't being called for the same event and relay pair multiple times.

