### PR TITLE
Add LazyHStack to AuthorStoryCarousel

### DIFF
--- a/Nos/Views/Home/AuthorStoryCarousel.swift
+++ b/Nos/Views/Home/AuthorStoryCarousel.swift
@@ -10,7 +10,7 @@ struct AuthorStoryCarousel: View {
     
     var body: some View {
         ScrollView(.horizontal, showsIndicators: false) {
-            HStack(spacing: 15) {
+            LazyHStack(spacing: 15) {
                 ForEach(authors) { author in
                     Button {
                         withAnimation {


### PR DESCRIPTION
## Issues covered
Part of #1112

## Description
Reduce CPU usage with this one weird trick.

I found that animated images can use up roughly 20-40% of a CPU. The `AuthorStoryCarousel` was loading an avatar image for every person you follow, so if you follow a lot of people with animated avatars that was a lot of CPU being used to animate images you weren't even looking at. This helps by only loading the avatars when you are going to look at.