### PR TITLE
Update Reportinator to Tagr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Switched from Reportinator to Tagr bot for content labeling.
+
 ## [0.1.14] - 2024-05-22Z
 
 - Added the author's name to profile cards on the Discover tab and search results. 

--- a/Nos/Service/ReportPublisher.swift
+++ b/Nos/Service/ReportPublisher.swift
@@ -3,9 +3,9 @@ import Dependencies
 import Logger
 import CoreData
 
-enum Reportinator {
+enum TaggerBot {
     // swiftlint:disable:next force_unwrapping
-    static var publicKey = PublicKey(npub: "npub14h23jzlyvumks4rvrz6ktk36dxfyru8qdf679k7q8uvxv0gm0vnsyqe2sh")!
+    static var publicKey = PublicKey(npub: "npub12m2t8433p7kmw22t0uzp426xn30lezv3kxcmxvvcrwt2y3hk4ejsvre68j")!
 }
 
 class ReportPublisher {
@@ -120,7 +120,7 @@ class ReportPublisher {
             let reportRequestGiftWrap = try DirectMessageWrapper.wrap(
                 message: reportRequestJSON,
                 senderKeyPair: keyPair,
-                receiverPubkey: Reportinator.publicKey.hex
+                receiverPubkey: TaggerBot.publicKey.hex
             )
             return reportRequestGiftWrap
         } catch {

--- a/Nos/Service/ReportPublisher.swift
+++ b/Nos/Service/ReportPublisher.swift
@@ -3,7 +3,7 @@ import Dependencies
 import Logger
 import CoreData
 
-enum TaggerBot {
+enum Tagr {
     // swiftlint:disable:next force_unwrapping
     static var publicKey = PublicKey(npub: "npub12m2t8433p7kmw22t0uzp426xn30lezv3kxcmxvvcrwt2y3hk4ejsvre68j")!
 }
@@ -120,7 +120,7 @@ class ReportPublisher {
             let reportRequestGiftWrap = try DirectMessageWrapper.wrap(
                 message: reportRequestJSON,
                 senderKeyPair: keyPair,
-                receiverPubkey: TaggerBot.publicKey.hex
+                receiverPubkey: Tagr.publicKey.hex
             )
             return reportRequestGiftWrap
         } catch {

--- a/NosTests/Service/ReportPublisherTests.swift
+++ b/NosTests/Service/ReportPublisherTests.swift
@@ -39,7 +39,7 @@ final class ReportPublisherTests: CoreDataTestCase {
         XCTAssertNotEqual(reportRequestDM.pubKey, aliceKeyPair.publicKeyHex)
         XCTAssertNotEqual(reportRequestDM.pubKey, bobKeyPair.publicKeyHex)
         XCTAssertEqual(reportRequestDM.tags, [
-            ["p", TaggerBot.publicKey.hex]
+            ["p", Tagr.publicKey.hex]
         ])
     }
     

--- a/NosTests/Service/ReportPublisherTests.swift
+++ b/NosTests/Service/ReportPublisherTests.swift
@@ -39,7 +39,7 @@ final class ReportPublisherTests: CoreDataTestCase {
         XCTAssertNotEqual(reportRequestDM.pubKey, aliceKeyPair.publicKeyHex)
         XCTAssertNotEqual(reportRequestDM.pubKey, bobKeyPair.publicKeyHex)
         XCTAssertEqual(reportRequestDM.tags, [
-            ["p", Reportinator.publicKey.hex]
+            ["p", TaggerBot.publicKey.hex]
         ])
     }
     


### PR DESCRIPTION
## Note
This won't work until @dcadenas has the new Tagger bot ready with https://github.com/planetary-social/cleanstr/issues/48

Currently the plan is to do this Tuesday, May 28 in the morning, but we can merge this now so we're ready for the Tuesday release.

## Issues covered
#1120

## Description
Updated Reportinator npub and renamed enum to TaggerBot.

## How to test
1. Find a note to report
2. Tap the three-dots menu
3. Tap Flag This Content
4. Select a category
5. Tap Send to Nos
6. Tap Confirm
7. ???

I'm not sure how to confirm that this was actually sent to the right place.
