### PR TITLE
remove NosUITests from periphery config

### DIFF
--- a/.periphery.yml
+++ b/.periphery.yml
@@ -5,4 +5,3 @@ targets:
 - Nos
 - NosPerformanceTests
 - NosTests
-- NosUITests


### PR DESCRIPTION
## Issues covered
#1162 

## Description
Fixes the configuration for periphery so it can run again.

## How to test
From the project root in terminal, run the following command:

`./Scripts/periphery.sh`

It should work and show results.