### PR TITLE
Optimize the KnownFollowersView

### DIFF
--- a/Nos/Models/CoreData/Author+CoreDataClass.swift
+++ b/Nos/Models/CoreData/Author+CoreDataClass.swift
@@ -199,6 +199,25 @@ import Logger
         return fetchRequest
     }
     
+    @nonobjc public class func emptyRequest() -> NSFetchRequest<Author> {
+        let fetchRequest = NSFetchRequest<Author>(entityName: "Author")
+        fetchRequest.predicate = NSPredicate.false
+        return fetchRequest
+    }
+    
+    /// Returns the authors that this author (self) follows who also follow the given `author`.
+    @nonobjc public func knownFollowers(of author: Author) -> NSFetchRequest<Author> {
+        let fetchRequest = NSFetchRequest<Author>(entityName: "Author")
+        fetchRequest.sortDescriptors = [NSSortDescriptor(keyPath: \Author.lastUpdatedContactList, ascending: false)]
+        fetchRequest.predicate = NSPredicate(
+            format: "ANY followers.source = %@ AND ANY follows.destination = %@ AND SELF != %@", 
+            self, 
+            author, 
+            self
+        )
+        return fetchRequest
+    }
+    
     /// Builds a predicate that queries for all notes (root or replies), reposts and long forms for a
     /// given profile
     ///

--- a/Nos/Models/CoreData/Author+CoreDataClass.swift
+++ b/Nos/Models/CoreData/Author+CoreDataClass.swift
@@ -210,10 +210,11 @@ import Logger
         let fetchRequest = NSFetchRequest<Author>(entityName: "Author")
         fetchRequest.sortDescriptors = [NSSortDescriptor(keyPath: \Author.lastUpdatedContactList, ascending: false)]
         fetchRequest.predicate = NSPredicate(
-            format: "ANY followers.source = %@ AND ANY follows.destination = %@ AND SELF != %@", 
+            format: "ANY followers.source = %@ AND ANY follows.destination = %@ AND SELF != %@ AND SELF != %@", 
             self, 
             author, 
-            self
+            self,
+            author
         )
         return fetchRequest
     }

--- a/Nos/Views/AuthorCard.swift
+++ b/Nos/Views/AuthorCard.swift
@@ -76,7 +76,7 @@ struct AuthorCard: View {
                 }
                 .padding(.bottom, 12)
 
-                KnownFollowersView(author: author)
+                KnownFollowersView(source: currentUser.author, destination: author)
                     .padding(.top, -8)
             }
             .padding(.top, 20)

--- a/Nos/Views/AuthorCard.swift
+++ b/Nos/Views/AuthorCard.swift
@@ -25,7 +25,7 @@ struct AuthorCard: View {
         Button {
             tapAction?()
         } label: {
-            VStack(spacing: 0) {
+            VStack(spacing: 12) {
                 HStack(alignment: .top) {
                     ZStack(alignment: .bottomTrailing) {
                         AvatarView(imageUrl: author.profilePhotoURL, size: 80)
@@ -74,12 +74,11 @@ struct AuthorCard: View {
                         }
                     }
                 }
-                .padding(.bottom, 12)
 
                 KnownFollowersView(source: currentUser.author, destination: author)
-                    .padding(.top, -8)
             }
             .padding(.top, 20)
+            .padding(.bottom, 12)
             .padding(.horizontal, 15)
             .background(
                 LinearGradient(

--- a/Nos/Views/KnownFollowersView.swift
+++ b/Nos/Views/KnownFollowersView.swift
@@ -16,7 +16,7 @@ struct KnownFollowersView: View {
         knownFollowers
             .filter { $0.hasHumanFriendlyName }
             .filter { $0.profilePhotoURL != nil }
-            .prefix(2)
+            .prefix(3)
     }
     
     /// The avatars of the authors that will be featured with profile pictures and names
@@ -28,7 +28,7 @@ struct KnownFollowersView: View {
     var followText: Text {
         let stringResource: LocalizedStringResource
         let authors = self.displayedAuthors
-        switch knownFollowers.count {
+        switch authors.count {
         case 0: 
             return Text("")
         case 1:

--- a/NosTests/Model/AuthorTests.swift
+++ b/NosTests/Model/AuthorTests.swift
@@ -151,7 +151,9 @@ final class AuthorTests: CoreDataTestCase {
         // Arrange
         let alice = try Author.findOrCreate(by: "alice", context: testContext)
         let bob   = try Author.findOrCreate(by: "bob", context: testContext)
+        bob.lastUpdatedContactList = Date(timeIntervalSince1970: 1) // for sorting
         let carl  = try Author.findOrCreate(by: "carl", context: testContext)
+        carl.lastUpdatedContactList = Date(timeIntervalSince1970: 0) // for sorting
         let eve   = try Author.findOrCreate(by: "eve", context: testContext)
         
         // Act

--- a/NosTests/Model/AuthorTests.swift
+++ b/NosTests/Model/AuthorTests.swift
@@ -202,6 +202,7 @@ final class AuthorTests: CoreDataTestCase {
         _ = try Follow.findOrCreate(source: alice, destination: alice, context: testContext)
         _ = try Follow.findOrCreate(source: alice, destination: eve, context: testContext)
         _ = try Follow.findOrCreate(source: eve, destination: alice, context: testContext)
+        _ = try Follow.findOrCreate(source: eve, destination: eve, context: testContext)
         
         try testContext.saveIfNeeded()
         

--- a/NosTests/Model/AuthorTests.swift
+++ b/NosTests/Model/AuthorTests.swift
@@ -144,4 +144,68 @@ final class AuthorTests: CoreDataTestCase {
 
         XCTAssertEqual(author.formattedNIP05, expected)
     }
+    
+    // MARK: Fetch requests
+    
+    func test_knownFollowers_givenMultipleFollowers() throws {
+        // Arrange
+        let alice = try Author.findOrCreate(by: "alice", context: testContext)
+        let bob   = try Author.findOrCreate(by: "bob", context: testContext)
+        let carl  = try Author.findOrCreate(by: "carl", context: testContext)
+        let eve   = try Author.findOrCreate(by: "eve", context: testContext)
+        
+        // Act
+        // Alice follows bob and carl who both follow eve
+        _ = try Follow.findOrCreate(source: alice, destination: bob, context: testContext)
+        _ = try Follow.findOrCreate(source: alice, destination: carl, context: testContext)
+        _ = try Follow.findOrCreate(source: bob, destination: eve, context: testContext)
+        _ = try Follow.findOrCreate(source: carl, destination: eve, context: testContext)
+        
+        try testContext.saveIfNeeded()
+        
+        // Assert
+        XCTAssertEqual(try testContext.fetch(alice.knownFollowers(of: eve)), [bob, carl])
+        XCTAssertEqual(try testContext.fetch(alice.knownFollowers(of: bob)), [])
+        XCTAssertEqual(try testContext.fetch(alice.knownFollowers(of: carl)), [])
+        XCTAssertEqual(try testContext.fetch(alice.knownFollowers(of: alice)), [])
+    }
+    
+    func test_knownFollowers_givenFollowCircle() throws {
+        // Arrange
+        let alice = try Author.findOrCreate(by: "alice", context: testContext)
+        let bob   = try Author.findOrCreate(by: "bob", context: testContext)
+        let carl  = try Author.findOrCreate(by: "carl", context: testContext)
+        let eve   = try Author.findOrCreate(by: "eve", context: testContext)
+        
+        // Act
+        // Create a circle of follows.
+        _ = try Follow.findOrCreate(source: alice, destination: bob, context: testContext)
+        _ = try Follow.findOrCreate(source: bob, destination: carl, context: testContext)
+        _ = try Follow.findOrCreate(source: carl, destination: eve, context: testContext)
+        _ = try Follow.findOrCreate(source: eve, destination: alice, context: testContext)
+        
+        try testContext.saveIfNeeded()
+        
+        // Assert
+        XCTAssertEqual(try testContext.fetch(alice.knownFollowers(of: carl)), [bob])
+        XCTAssertEqual(try testContext.fetch(alice.knownFollowers(of: eve)), [])
+        XCTAssertEqual(try testContext.fetch(alice.knownFollowers(of: bob)), [])
+        XCTAssertEqual(try testContext.fetch(alice.knownFollowers(of: alice)), [])
+    }
+    
+    func test_knownFollowers_givenSelfFollow() throws {
+        // Arrange
+        let alice = try Author.findOrCreate(by: "alice", context: testContext)
+        let eve   = try Author.findOrCreate(by: "eve", context: testContext)
+        
+        // Act
+        _ = try Follow.findOrCreate(source: alice, destination: alice, context: testContext)
+        _ = try Follow.findOrCreate(source: alice, destination: eve, context: testContext)
+        _ = try Follow.findOrCreate(source: eve, destination: alice, context: testContext)
+        
+        try testContext.saveIfNeeded()
+        
+        // Assert
+        XCTAssertEqual(try testContext.fetch(alice.knownFollowers(of: eve)), [])
+    }
 }


### PR DESCRIPTION
## Issues covered
Part of #1112

## Description
One cause of CPU spikes, especially on accounts that follow a lot of users, is the `CurrentUser.isFollowing` function. It does in-memory calculations with a temporary list of followed keys that gets recreated every time the function is called. It also doesn't use a background context but does the database fetches on the main thread. 

I found that `KnownFollowersView` was the most frequent caller of this function, calling it once for every follower of an author, for every instance of the view (and again whenever the followers change). The DiscoverView is always showing some of these and they are always listening for changes in the database, so the result is spikes of cpu usage in the background as we download and parse contact lists in other parts of the app.

This PR moves most of the calculation into an NSFetchRequest so the database can do the filtering more efficiently. I also refactored some of the computed properties on the view to make their names and roles more intuitive to me.

I would like to get rid of the `CurrentUser.isFollowing` function entirely. There are a few other views using it and I may refactor those in another PR.

## How to test
1. Profile the app in Instruments on `main`
2. Open the discover tab and let it run for a few seconds
3. Observe CPU spikes where the heaviest stack trace is in KnownFollowersView.
4. Repeat on this branch. CPU spikes no longer show a heavy stack trace in KnownFollowersView.