### PR TITLE
Fix deletes not appearing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Fixed an issue where deleted notes still appeared in the Profile’s Notes view.
+
 ## [0.1.14] - 2024-05-22Z
 
 - Added the author's name to profile cards on the Discover tab and search results. 

--- a/Nos/Models/CoreData/Author+CoreDataClass.swift
+++ b/Nos/Models/CoreData/Author+CoreDataClass.swift
@@ -223,7 +223,8 @@ import Logger
             "$reference.marker = 'root' OR $reference.marker = 'reply' OR $reference.marker = nil" +
         ").@count = 0)"
         return NSPredicate(
-            format: "(\(onlyRootPostsClause) OR kind = %i) AND author = %@ AND createdAt <= %@",
+            format: "(\(onlyRootPostsClause) OR kind = %i) " +
+                "AND author = %@ AND deletedOn.@count = 0 AND createdAt <= %@",
             EventKind.longFormContent.rawValue,
             self,
             before as CVarArg

--- a/NosTests/Model/AuthorTests.swift
+++ b/NosTests/Model/AuthorTests.swift
@@ -1,3 +1,4 @@
+import CoreData
 import XCTest
 
 /// Tests for the `Author` model.
@@ -143,5 +144,41 @@ final class AuthorTests: CoreDataTestCase {
         author.nip05 = nip05
 
         XCTAssertEqual(author.formattedNIP05, expected)
+    }
+
+    func test_allPostsRequest_onlyRootPosts() throws {
+        // Arrange
+        let publicKey = "test"
+        _ = try createTestEvent(in: testContext, publicKey: publicKey, deletedOn: [Relay(context: testContext)])
+        let author = try XCTUnwrap(Author.find(by: publicKey, context: testContext))
+
+        // Act
+        let fetchRequest = author.allPostsRequest(onlyRootPosts: true)
+        let events = try testContext.fetch(fetchRequest)
+
+        // Assert
+        XCTAssertEqual(events.count, 0)
+    }
+
+    // MARK: - Helpers
+
+    private func createTestEvent(
+        in context: NSManagedObjectContext,
+        publicKey: RawAuthorID = KeyFixture.pubKeyHex,
+        deletedOn: Set<Relay> = []
+    ) throws -> Event {
+        let event = Event(context: context)
+        event.createdAt = Date(timeIntervalSince1970: TimeInterval(1_675_264_762))
+        event.content = "Testing nos #[0]"
+        event.deletedOn = deletedOn
+        event.kind = 1
+
+        let author = Author(context: context)
+        author.hexadecimalPublicKey = publicKey
+        event.author = author
+
+        let tags = [["p", "d0a1ffb8761b974cec4a3be8cbcb2e96a7090dcf465ffeac839aa4ca20c9a59e"]]
+        event.allTags = tags as NSObject
+        return event
     }
 }


### PR DESCRIPTION
## Issues covered
#1143

## Description
Fixed deletes not appearing by filtering out deleted posts for an author on the Notes view. We were already doing this on the Activity view, so now they match.

## How to test
1. Navigate to Profile
2. Delete a note
3. Observe that the note is deleted right in front of your eyes

## Screenshots/Video
https://github.com/planetary-social/nos/assets/59564/c3be1029-4cb9-4629-846c-c7884a4bfd96
