### PR TITLE
Fix CHANGELOG which had an inaccurate entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Fixed an issue where following and mute lists could be replaced with older versions.
+
 
 ## [0.1.14] - 2024-05-22Z
 


### PR DESCRIPTION
## Issues covered
None

## Description
When I initially created PR #1182, I had expected to fix the bug. But it turns out my fix didn't work, and instead what I merged was some refactoring + unit tests. Unfortunately, I forgot to delete the CHANGELOG entry, so this fixes that.
