### PR TITLE
sort authors by their order in FeaturedAuthor; fix warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - Fixed an issue where deleted notes still appeared in the Profile’s Notes view.
+- Sorted the featured profiles in the Discover tab.
 
 ## [0.1.14] - 2024-05-22Z
 

--- a/Nos/Views/Discover/FeaturedAuthorsView.swift
+++ b/Nos/Views/Discover/FeaturedAuthorsView.swift
@@ -16,8 +16,19 @@ struct FeaturedAuthorsView: View {
     @State private var subscriptions = [ObjectIdentifier: SubscriptionCancellable]()
     @State private var selectedCategory: FeaturedAuthorCategory = .all
 
+    private var sortedAuthors: [Author] {
+        authors.sorted { authorA, authorB in
+            let allFeatured = FeaturedAuthor.all
+            guard let indexA = allFeatured.firstIndex(where: { $0.npub == authorA.npubString }),
+                let indexB = allFeatured.firstIndex(where: { $0.npub == authorB.npubString }) else {
+                return false
+            }
+            return indexA < indexB
+        }
+    }
+
     private var filteredAuthors: [Author] {
-        authors.filter { author in
+        sortedAuthors.filter { author in
             guard let npubString = author.npubString else { return false }
             return selectedCategory.npubs.contains(npubString)
         }
@@ -62,7 +73,7 @@ struct FeaturedAuthorsView: View {
                             .padding(.bottom, 16)
                         }
                         .doubleTapToPop(tab: .discover) { proxy in
-                            if let firstAuthor = authors.first {
+                            if let firstAuthor = sortedAuthors.first {
                                 proxy.scrollTo(firstAuthor.id)
                             }
                         }

--- a/Nos/Views/RelayPicker.swift
+++ b/Nos/Views/RelayPicker.swift
@@ -117,12 +117,8 @@ struct RelayPicker_Previews: PreviewProvider {
     static func createTestData(in context: NSManagedObjectContext, user: Author) {
         let addresses = ["wss://nostr.com", "wss://nos.social", "wss://alongdomainnametoseewhathappens.com"]
         addresses.forEach { address in
-            do {
-                let relay = try? Relay.findOrCreate(by: address, context: previewContext)
-                relay?.addToAuthors(user)
-            } catch {
-                print(error)
-            }
+            let relay = try? Relay.findOrCreate(by: address, context: previewContext)
+            relay?.addToAuthors(user)
         }
 
         try? previewContext.save()

--- a/NosTests/Model/EventTests.swift
+++ b/NosTests/Model/EventTests.swift
@@ -430,7 +430,7 @@ final class EventTests: CoreDataTestCase {
     func test_eventByIdentifierSeenOnRelay_givenNotSeen() throws {
         // Arrange
         let eventID = "foo"
-        let event = try Event.findOrCreateStubBy(id: eventID, context: testContext)
+        _ = try Event.findOrCreateStubBy(id: eventID, context: testContext)
         let relay = try Relay.findOrCreate(by: "wss://relay.nos.social", context: testContext)
         
         // Act


### PR DESCRIPTION
## Issues covered
#1191 

## Description
Sorts authors on the Discover tab by their order in FeaturedAuthor. Since that code is unchanged in this PR and won't appear in the diff, here's what it looks like:

```
extension FeaturedAuthor {
    /// All featured authors that should appear on the Discover tab.
    static let all = cohort1
}

extension FeaturedAuthor {
    /// The first cohort of authors to display on the Discover tab.
    static let cohort1 = [
        FeaturedAuthor(
            name: "Mark Cubey",
            npub: "npub1j9gcqjheu50kyzkjjmh3pq0msknh58sxu6ugsp33hxfwf5a78r3sfx59e7",
            categories: [.news]
        ),
        FeaturedAuthor(
            name: "Miguel Almodo",
            npub: "npub1ajt9gp0prf4xrp4j07j9rghlcyukahncs0fw5ywr977jccued9nqrcc0cs",
            categories: [.activists]
        ),
        // ...many more here...
```

So the sort order of the Discover tab is based on `FeaturedAuthor.all`. Additionally, @mplorentz posted this awesome suggestion in the ticket:

> Bonus points if it's easy for us to shuffle authors from week to week

It turns out the bonus points were easier than expected ([luckily](https://xkcd.com/356/)). Here's how we'd do that (which I tested):

```
extension FeaturedAuthor {
    /// All featured authors that should appear on the Discover tab.
    static let all = cohort1.shuffled()
}
```

More cohorts? No problem! Let's put Cohort 2 first since they're newer. And we might as well shuffle Cohort 1 while we're at it (but leave Cohort 2 ordered the way they're listed in the array):

```
static let all = cohort2 + cohort1.shuffled()
```

I didn't test this part, but it'll work. Why wouldn't it?

## How to test
1. Navigate to Discover
2. Verify that the authors are ordered the way they are in the `FeaturedAuthor.cohort1` array (see `FeaturedAuthor.swift`)

## Screenshots/Video

https://github.com/planetary-social/nos/assets/59564/6139c617-5b23-4578-b718-db94675f8a9d

