### PR TITLE
Fixed a crash when logging out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Fixed a crash on logout
 - Redesigned the Profile screen.
 - Fixed an issue where deleted notes still appeared in the Profile’s Notes view.
 - Sorted the featured profiles in the Discover tab.

--- a/Nos/Models/CoreData/Author+CoreDataClass.swift
+++ b/Nos/Models/CoreData/Author+CoreDataClass.swift
@@ -202,6 +202,7 @@ import Logger
     @nonobjc public class func emptyRequest() -> NSFetchRequest<Author> {
         let fetchRequest = NSFetchRequest<Author>(entityName: "Author")
         fetchRequest.predicate = NSPredicate.false
+        fetchRequest.sortDescriptors = [NSSortDescriptor(keyPath: \Author.hexadecimalPublicKey, ascending: false)]
         return fetchRequest
     }
     


### PR DESCRIPTION
## Issues covered
#1198

## Description
I didn't add a sort descriptor to this fetch request I added in #1183. It caused a crash on logout because CurrentUser.author changed to nil so Author.emptyRequest() was being used by @FetchRequest but it needs a sort descriptor to not crash 🙄 

## How to test
1. Log in or create a new key
2. Log out
The app should not crash. Except sometimes it does for #1113, but not very often. If you find steps to reproduce that other crash it would be great.