### PR TITLE
Track NIP-05 in PostHog

### DIFF
--- a/Nos/Service/Analytics.swift
+++ b/Nos/Service/Analytics.swift
@@ -140,9 +140,15 @@ class Analytics {
         track("Reported", properties: ["type": reportedObject.analyticsString])
     }
     
-    func identify(with keyPair: KeyPair) {
+    func identify(with keyPair: KeyPair, nip05: String? = nil) {
         Log.info("Analytics: Identified \(keyPair.npub)")
-        postHog?.identify(keyPair.npub)
+        let userProperties: [String: Any]?
+        if let nip05 {
+            userProperties = ["NIP-05": nip05]
+        } else {
+            userProperties = nil
+        }
+        postHog?.identify(keyPair.npub, userProperties: userProperties)
     }
     
     func databaseStatistics(_ statistics: [(String, Int)]) {

--- a/Nos/Views/AppView.swift
+++ b/Nos/Views/AppView.swift
@@ -44,7 +44,10 @@ struct AppView: View {
                                 // TODO: Move this somewhere better like CurrentUser when it becomes the source of truth
                                 // for who is logged in
                                 if let keyPair = currentUser.keyPair {
-                                    analytics.identify(with: keyPair)
+                                    analytics.identify(
+                                        with: keyPair,
+                                        nip05: currentUser.author?.nip05
+                                    )
                                     crashReporting.identify(with: keyPair)
                                 }
                             }


### PR DESCRIPTION
## Issues covered
#1178 

## Description
I'm using PostHog's userProperties to add the NIP-05 of the user when possible. I checked in PostHog that we indeed receive the property and can add a NIP-05 column there.

## How to test
1. Add the POSTHOG api key in devsecrets
2. Use the app, the NIP-05 will be set when the user opens the Home tab
3. Navigate to PostHog
4. Go to Activity
5. See the new events coming with a NIP-05 property attached to the user (bare in mind that events coming from nos-dev can be filtered using App Namespace there.

## Screens
![Captura de pantalla 2024-05-29 a la(s) 17 11 30](https://github.com/planetary-social/nos/assets/1703242/c29a46a7-ec0f-47de-8f10-2c3cfdd20eee)
![Captura de pantalla 2024-05-29 a la(s) 17 11 07](https://github.com/planetary-social/nos/assets/1703242/8cd7838c-0e6c-4a1d-aa6d-dfcb69c86aa1)
hots/Video

