### PR TITLE
Clean up unecessary subscriptions in PagedRelaySubscription

### DIFF
--- a/Nos/Models/RelaySubscription.swift
+++ b/Nos/Models/RelaySubscription.swift
@@ -2,7 +2,7 @@ import Foundation
 import Logger
 
 /// Models a request to a relay for Nostr Events. 
-struct RelaySubscription: Identifiable {
+struct RelaySubscription: Identifiable, Hashable {
     
     var id: String 
     

--- a/Nos/Service/Relay/PagedRelaySubscription.swift
+++ b/Nos/Service/Relay/PagedRelaySubscription.swift
@@ -73,7 +73,7 @@ class PagedRelaySubscription {
                     }
                           
                     newUntilDates[subscription.relayAddress] = newDate
-                    await subscriptionManager.decrementSubscriptionCount(for: subscription.id)
+                    await subscriptionManager.decrementSubscriptionCount(for: subscriptionID)
                     subscriptionsToRemove.append(subscription)
                 }
             }


### PR DESCRIPTION
## Issues covered
This was something I noticed and fixed while debugging #1192, but I put it in a separate PR.

## Description
We weren't clearing out old subscriptions from the PagedRelaySubscription.pagedSubscriptionID array. The actual websocket subscriptions were being closed, but we were keeping references to the `RelaySubscription` objects around unnecessarily. It wasn't hurting anything necessarily but this cleans them up.

## How to test
You can put `Log.debug("pagedSubscriptionIDs count: \(pagedSubscriptionIDs.count)")` at the end of the `PagedRelaySubscription.loadMore()` function before this PR  and watch the number climb the more you scroll the home feed. After it should remain equal to the number of relays you have in your relay list.