### PR TITLE
Bugfix: NIP-05 strikethrough in bad networks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Fixed an issue where NIP-05 could appear as invalid.
+
 ## [0.1.16] - 2024-05-31Z
 
 - Added feedback to the copy button in Settings.

--- a/Nos/Views/NIP05View.swift
+++ b/Nos/Views/NIP05View.swift
@@ -43,13 +43,17 @@ struct NIP05View: View {
                             username: nip05Identifier,
                             publicKey: publicKey
                         )
+                    } catch URLError.cancelled {
+                        // Cancelled requests are common in bad networks. We
+                        // should keep things as they were to avoid reproducing
+                        // https://github.com/planetary-social/nos/issues/1161
+                        return
                     } catch {
                         isVerified = false
-                        Log.debug(error.localizedDescription)
+                        let message = error.localizedDescription
+                        Log.debug("Error while verifying a NIP-05: \(message)")
                     }
-                    withAnimation {
-                        self.verifiedNip05Identifier = isVerified
-                    }
+                    self.verifiedNip05Identifier = isVerified
                 }
             }
         } else {

--- a/Nos/Views/NIP05View.swift
+++ b/Nos/Views/NIP05View.swift
@@ -44,9 +44,12 @@ struct NIP05View: View {
                             publicKey: publicKey
                         )
                     } catch URLError.cancelled {
-                        // Cancelled requests are common in bad networks. We
-                        // should keep things as they were to avoid reproducing
-                        // https://github.com/planetary-social/nos/issues/1161
+                        // URLSession cancels the request when the task is
+                        // cancelled. Cancelled requests are common specially in
+                        // bad networks because it is normal that the user
+                        // scrolls past the author before the requests
+                        // completes. Thus, we need to catch .cancelled so we
+                        // don't display a strike-through in those cases.
                         return
                     } catch {
                         isVerified = false


### PR DESCRIPTION
## Issues covered
#1161

## Description
While we don't show the NIP-05 with a strikethrough when we are fetching the server response, we do show it if the request fails. In order to fix this specific issue, I'm catching the "cancel" reason. This happens when we cancel the request programmatically, but also frequently happens when the user has a very bad network (I'm not sure why, we don't cancel the request programmatically, I want to find out).

Also, relevant discussion here https://planetary-app.slack.com/archives/CERN44F17/p1717190530026669?thread_ts=1717185627.726309&cid=CERN44F17

## How to test
1. Open iOS Settings
2. Go to the Developer section
3. Enable the network conditioner (not sure the exact words iOS when used in English) and select the Very Bad Network option
4. Go to Nos
5. Open the Discover screen because it displays many users with a NIP-05
6. In the production build, these NIPs are frequently strikethrough-ed, in this branch it should not.

## Screenshots/Video
It doesn't make sense to post a screenshot for the "after" state. But I can post a screenshot of how the bug looks when using the app with a bad network:

![IMG_8255](https://github.com/planetary-social/nos/assets/1703242/1a724252-f5cd-4dd7-b768-7394c4fd9fda)

