### PR TITLE
Move SwiftLint build phase before compile

### DIFF
--- a/Nos.xcodeproj/project.pbxproj
+++ b/Nos.xcodeproj/project.pbxproj
@@ -1505,8 +1505,8 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = C9DEBFF8298941020078B43A /* Build configuration list for PBXNativeTarget "Nos" */;
 			buildPhases = (
-				C9DEBFCA298941000078B43A /* Sources */,
 				C9BAB0992996BEEA0003A84E /* SwiftLint */,
+				C9DEBFCA298941000078B43A /* Sources */,
 				C9DEBFCB298941000078B43A /* Frameworks */,
 				C9DEBFCC298941000078B43A /* Resources */,
 			);


### PR DESCRIPTION
## Issues covered
#734

## Description
Moves the SwiftLint build phase before compile. This results in getting SwiftLint warnings much earlier.

## How to test
1. Open a file
2. Add a bunch of line breaks anywhere
3. Build
4. Observe SwiftLint warnings much earlier than before
