### PR TITLE
Disable testOutOfNetwork, which is flaky

### DIFF
--- a/NosTests/Controller/SocialGraphTests.swift
+++ b/NosTests/Controller/SocialGraphTests.swift
@@ -17,9 +17,7 @@ final class SocialGraphTests: CoreDataTestCase {
     }
     
     /// The `XCTExpectFailure` below does _not_ work in CI. That is, when the test fails, CI still fails.
-    /// Since all tests must start with the word "test", prefixing it with "disable" is a clear way to disable it
-    /// until we can fix the intermittent failure.
-    func disable_testOneFollower() async throws {
+    func testOneFollower() async throws {
         XCTExpectFailure("This test is failing intermittently, see #671", options: .nonStrict())
 
         // Arrange
@@ -44,9 +42,7 @@ final class SocialGraphTests: CoreDataTestCase {
     }
     
     /// The `XCTExpectFailure` below does _not_ work in CI. That is, when the test fails, CI still fails.
-    /// Since all tests must start with the word "test", prefixing it with "disable" is a clear way to disable it
-    /// until we can fix the intermittent failure.
-    func disable_testFollow() async throws {
+    func testFollow() async throws {
         XCTExpectFailure("This test is failing intermittently, see #671", options: .nonStrict())
 
         // Arrange
@@ -73,9 +69,7 @@ final class SocialGraphTests: CoreDataTestCase {
     }
     
     /// The `XCTExpectFailure` below does _not_ work in CI. That is, when the test fails, CI still fails.
-    /// Since all tests must start with the word "test", prefixing it with "disable" is a clear way to disable it
-    /// until we can fix the intermittent failure.
-    func disable_testTwoFollows() async throws {
+    func testTwoFollows() async throws {
         XCTExpectFailure("This test is failing intermittently, see #671", options: .nonStrict())
 
         // Arrange

--- a/NosTests/UnitTests.xctestplan
+++ b/NosTests/UnitTests.xctestplan
@@ -28,6 +28,12 @@
   },
   "testTargets" : [
     {
+      "skippedTests" : [
+        "SocialGraphTests\/testFollow()",
+        "SocialGraphTests\/testOneFollower()",
+        "SocialGraphTests\/testOutOfNetwork()",
+        "SocialGraphTests\/testTwoFollows()"
+      ],
       "target" : {
         "containerPath" : "container:Nos.xcodeproj",
         "identifier" : "C9DEBFE3298941020078B43A",


### PR DESCRIPTION
## Issues covered
Disables `SocialGraphTests.testOutOfNetwork()`, which should be fixed and reenabled in #671.

## Description
In addition to disabling another flaky test (which failed [here](https://github.com/planetary-social/nos/actions/runs/9354787884/job/25748409008?pr=1214)), I moved all disabled tests to the test plan. You can see disabled tests in the test navigator in Xcode -- they're grayed out -- and you can filter by Disabled at the bottom:

| Test Navigator | Filter by Disabled |
|--------|--------|
| <img width="1392" alt="Screenshot 2024-06-04 at 11 51 25 AM" src="https://github.com/planetary-social/nos/assets/59564/333972f2-39d1-4500-b872-35e3c2ca4a3a"> | <img width="1392" alt="Screenshot 2024-06-04 at 11 51 35 AM" src="https://github.com/planetary-social/nos/assets/59564/db25fc62-0be5-4ce6-97ec-988bff73981e"> | 

This also gives us the ability to run disabled tests manually in Xcode by clicking the run icon next to them, or by filtering (as shown above), selecting them, and running them all.

## How to test
Run unit tests
