### PR TITLE
Add third cohort of creators and journalists to the Discover tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+ 
+- Added our third cohort of creators and journalists to the Discover tab.
 
 ## [0.1.17] - 2024-06-10Z
 

--- a/Nos/Views/Discover/FeaturedAuthor.swift
+++ b/Nos/Views/Discover/FeaturedAuthor.swift
@@ -16,7 +16,7 @@ struct FeaturedAuthor {
 
 extension FeaturedAuthor {
     /// All featured authors that should appear on the Discover tab.
-    static let all = cohort2 + cohort1
+    static let all = cohort3 + cohort2 + cohort1
 }
 
 extension FeaturedAuthor {
@@ -31,11 +31,6 @@ extension FeaturedAuthor {
             name: "The Conversation",
             npub: "npub1uuxnz0sq60thc098xfxqst7wnw77l0sm3r8nn48yspuvz4ecprksxdahzv",
             categories: [.news]
-        ),
-        FeaturedAuthor(
-            name: "Nela Biedermann",
-            npub: "npub1fv9u4drq4hdrr7k45vn0krqy7mkgy8ajf059m0wq8szvcrsjlsrs8tdz3p",
-            categories: [.art]
         ),
         FeaturedAuthor(
             name: "Ainsley Costello",
@@ -98,11 +93,6 @@ extension FeaturedAuthor {
             categories: [.music]
         ),
         FeaturedAuthor(
-            name: "The 74 Million",
-            npub: "npub1kkk52065zqg85c0auvashalkrqewj6cnlr7c236r2hp5sx9rgzgs46gj84",
-            categories: [.news]
-        ),
-        FeaturedAuthor(
             name: "BTCPhoto",
             npub: "npub1vjl6n2llukcc6pe3am2hkwqh8twzh2ymlp7pdrdfq5tlqg08y26sd7ygzx",
             categories: [.art]
@@ -121,6 +111,46 @@ extension FeaturedAuthor {
             name: "Josh Brown",
             npub: "npub1yl8jc6znttslcpj3p6p8vuq98awu6w0xh4lqtu0lkjr772kpx4ysfqvz34",
             categories: [.art]
+        ),
+    ]
+}
+
+extension FeaturedAuthor {
+    static let cohort3 = [
+        FeaturedAuthor(
+            name: "INPC",
+            npub: "npub1q33jywkl8r0e5g48lvrenxnr3lw59kzrw4e7p0cecslqzwc56eesjymqu0",
+            categories: [.music]
+        ),
+        FeaturedAuthor(
+            name: "Mama Ganush",
+            npub: "npub1lq9lx5mh2m3pvdnckcta7h7h07qexa3gxvyakdzt73lqp3prt3jqx9pa2e",
+            categories: [.activists]
+        ),
+        FeaturedAuthor(
+            name: "Fight for the Future",
+            npub: "npub1jcwuf0dh5vqsq44qavygqwjfecawf53fmx7gadlcdtuexz0548hqy4jyrz",
+            categories: [.activists, .tech]
+        ),
+        FeaturedAuthor(
+            name: "Z Network",
+            npub: "npub1xm0rvnpw52nh7tk59ntly55w74rmd2cqvt3kg5zxrzz3rlssvspsk0gs6s",
+            categories: [.news, .activists]
+        ),
+        FeaturedAuthor(
+            name: "Z Network Chomsky",
+            npub: "npub1a7mxreazql8ld0csdzk7wk6a5xjzcg7h632q78u3008lyr32lxks5t4ske",
+            categories: [.activists]
+        ),
+        FeaturedAuthor(
+            name: "Patrick Boehler",
+            npub: "npub1n8gvnx827tdl46ke406sjx0t5ey4mrtptux766ejp9y2ff8cc3uqe4ufd0",
+            categories: [.news, .tech]
+        ),
+        FeaturedAuthor(
+            name: "JSTR",
+            npub: "npub1vpdlxsc8dr4m580d43vj4ka0e6wmstzzxhvcermllhh5m9ytnhdq6wnaem",
+            categories: [.music]
         ),
     ]
 }

--- a/Nos/Views/Discover/FeaturedAuthorCategory.swift
+++ b/Nos/Views/Discover/FeaturedAuthorCategory.swift
@@ -37,7 +37,7 @@ enum FeaturedAuthorCategory: CaseIterable {
         case .all:
             FeaturedAuthor.all.map { $0.npub }
         case .new:
-            FeaturedAuthor.cohort2.map { $0.npub }
+            FeaturedAuthor.cohort3.map { $0.npub }
         default:
             FeaturedAuthor.all.filter { $0.categories.contains(self) }
                 .map { $0.npub }


### PR DESCRIPTION
## Issues covered
#1221

## Description
This adds cohort 3 and removes a couple other people.

## How to test
Open up the Discover tab and compare it to the list described in the ticket and given in the Google Doc.

## Screenshots/Video
| Before | After |
|--------|--------|
|  ![simulator_screenshot_0017C019-F430-4781-B1DE-80058ABAAF11](https://github.com/planetary-social/nos/assets/1165004/a5d19f09-c8cc-4b35-9592-9521d5b7dde7) | ![simulator_screenshot_6E6D8918-2D1C-4E8A-918D-46DAD6E404D2](https://github.com/planetary-social/nos/assets/1165004/946ea1bc-a0e1-473f-bee9-523f895d6fe5) |

