### PR TITLE
1144/emoji mentions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Fixed a bug when mentioning profiles with emojis in the name.
+
 ## [0.1.17] - 2024-06-10Z
 
 - Added support for opening njump.me content in Nos.

--- a/Nos.xcodeproj/project.pbxproj
+++ b/Nos.xcodeproj/project.pbxproj
@@ -124,6 +124,7 @@
 		5BBA5E9C2BAE052F00D57D76 /* NiceWorkSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BBA5E9B2BAE052F00D57D76 /* NiceWorkSheet.swift */; };
 		5BC0D9CC2B867B9D005D6980 /* NamesAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BC0D9CB2B867B9D005D6980 /* NamesAPI.swift */; };
 		5BD08BB22A38E96F00BB926C /* JSONRelayMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B503F612A291A1A0098805A /* JSONRelayMetadata.swift */; };
+		5BD25E592C192BBC005CF884 /* NoteParserTests+Parse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BD25E582C192BBC005CF884 /* NoteParserTests+Parse.swift */; };
 		5BE281BE2AE2CCAE00880466 /* StoriesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BE281BD2AE2CCAE00880466 /* StoriesView.swift */; };
 		5BE281C12AE2CCB400880466 /* StoryNoteView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BE281C02AE2CCB400880466 /* StoryNoteView.swift */; };
 		5BE281C42AE2CCC300880466 /* AuthorStoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BE281C32AE2CCC300880466 /* AuthorStoryView.swift */; };
@@ -584,6 +585,7 @@
 		5BBA5E902BADF98E00D57D76 /* AlreadyHaveANIP05View.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlreadyHaveANIP05View.swift; sourceTree = "<group>"; };
 		5BBA5E9B2BAE052F00D57D76 /* NiceWorkSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NiceWorkSheet.swift; sourceTree = "<group>"; };
 		5BC0D9CB2B867B9D005D6980 /* NamesAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NamesAPI.swift; sourceTree = "<group>"; };
+		5BD25E582C192BBC005CF884 /* NoteParserTests+Parse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NoteParserTests+Parse.swift"; sourceTree = "<group>"; };
 		5BE281BD2AE2CCAE00880466 /* StoriesView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StoriesView.swift; sourceTree = "<group>"; };
 		5BE281C02AE2CCB400880466 /* StoryNoteView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StoryNoteView.swift; sourceTree = "<group>"; };
 		5BE281C32AE2CCC300880466 /* AuthorStoryView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AuthorStoryView.swift; sourceTree = "<group>"; };
@@ -1321,6 +1323,7 @@
 				C98298312ADD7EDB0096C5B5 /* Info.plist */,
 				5B098DBB2BDAF6CB00500A1B /* NoteParserTests+NIP08.swift */,
 				5B098DC82BDAF7CF00500A1B /* NoteParserTests+NIP27.swift */,
+				5BD25E582C192BBC005CF884 /* NoteParserTests+Parse.swift */,
 				C96D391A2B61AFD500D3D0A1 /* RawNostrIDTests.swift */,
 				5BFBB2942BD9D7EB002E909F /* URLParserTests.swift */,
 				0320C0E42BFBB27E00C4C080 /* PerformanceTests.xctestplan */,
@@ -1685,19 +1688,19 @@
 			);
 			mainGroup = C9DEBFC5298941000078B43A;
 			packageReferences = (
-				C9DEC066298965270078B43A /* XCRemoteSwiftPackageReference "Starscream.git" */,
+				C9DEC066298965270078B43A /* XCRemoteSwiftPackageReference "Starscream" */,
 				C94D855D29914D2300749478 /* XCRemoteSwiftPackageReference "swiftui-navigation" */,
-				C9ADB139299299570075E7F8 /* XCRemoteSwiftPackageReference "bech32.git" */,
+				C9ADB139299299570075E7F8 /* XCRemoteSwiftPackageReference "bech32" */,
 				C9646E9829B79E04007239A4 /* XCRemoteSwiftPackageReference "logger-ios" */,
-				C9646EA229B7A24A007239A4 /* XCRemoteSwiftPackageReference "posthog-ios.git" */,
+				C9646EA229B7A24A007239A4 /* XCRemoteSwiftPackageReference "posthog-ios" */,
 				C9646EA529B7A3DD007239A4 /* XCRemoteSwiftPackageReference "swift-dependencies" */,
-				C96CB98A2A6040C500498C4E /* XCRemoteSwiftPackageReference "swift-collections.git" */,
-				C9B71DBC2A8E9BAD0031ED9F /* XCRemoteSwiftPackageReference "sentry-cocoa.git" */,
+				C96CB98A2A6040C500498C4E /* XCRemoteSwiftPackageReference "swift-collections" */,
+				C9B71DBC2A8E9BAD0031ED9F /* XCRemoteSwiftPackageReference "sentry-cocoa" */,
 				C99DBF7C2A9E81CF00F7068F /* XCRemoteSwiftPackageReference "SDWebImageSwiftUI" */,
 				C9B737702AB24D5F00398BE7 /* XCRemoteSwiftPackageReference "SwiftGenPlugin" */,
 				C91565BF2B2368FA0068EECA /* XCRemoteSwiftPackageReference "ViewInspector" */,
-				3AD3185B2B294E6200026B07 /* XCRemoteSwiftPackageReference "xcstrings-tool-plugin.git" */,
-				C9FD34F42BCEC89C008F8D95 /* XCRemoteSwiftPackageReference "secp256k1.swift" */,
+				3AD3185B2B294E6200026B07 /* XCRemoteSwiftPackageReference "xcstrings-tool-plugin" */,
+				C9FD34F42BCEC89C008F8D95 /* XCRemoteSwiftPackageReference "secp256k1" */,
 				C9FD35112BCED5A6008F8D95 /* XCRemoteSwiftPackageReference "nostr-sdk-ios" */,
 			);
 			productRefGroup = C9DEBFCF298941000078B43A /* Products */;
@@ -2176,6 +2179,7 @@
 				5BFBB2962BD9D824002E909F /* URLParser.swift in Sources */,
 				C959DB772BD01DF4008F3627 /* GiftWrapper.swift in Sources */,
 				C9C9444229F6F0E2002F2C7A /* XCTest+Eventually.swift in Sources */,
+				5BD25E592C192BBC005CF884 /* NoteParserTests+Parse.swift in Sources */,
 				3FFF3BD029A9645F00DD0B72 /* AuthorReference+CoreDataClass.swift in Sources */,
 				035729B82BE416A6005FEE85 /* DirectMessageWrapperTests.swift in Sources */,
 				C9F0BB6C29A503D6000547FC /* PublicKey.swift in Sources */,
@@ -2221,11 +2225,11 @@
 /* Begin PBXTargetDependency section */
 		3AD3185D2B294E9000026B07 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			productRef = 3AD3185C2B294E9000026B07 /* plugin:XCStringsToolPlugin */;
+			productRef = 3AD3185C2B294E9000026B07 /* XCStringsToolPlugin */;
 		};
 		3AEABEF32B2BF806001BC933 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			productRef = 3AEABEF22B2BF806001BC933 /* plugin:XCStringsToolPlugin */;
+			productRef = 3AEABEF22B2BF806001BC933 /* XCStringsToolPlugin */;
 		};
 		C90862C229E9804B00C35A71 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -2234,11 +2238,11 @@
 		};
 		C9A6C7442AD83F7A001F9500 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			productRef = C9A6C7432AD83F7A001F9500 /* plugin:SwiftGenPlugin */;
+			productRef = C9A6C7432AD83F7A001F9500 /* SwiftGenPlugin */;
 		};
 		C9D573402AB24A3700E06BB4 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			productRef = C9D5733F2AB24A3700E06BB4 /* plugin:SwiftGenPlugin */;
+			productRef = C9D5733F2AB24A3700E06BB4 /* SwiftGenPlugin */;
 		};
 		C9DEBFE6298941020078B43A /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -2961,7 +2965,7 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		3AD3185B2B294E6200026B07 /* XCRemoteSwiftPackageReference "xcstrings-tool-plugin.git" */ = {
+		3AD3185B2B294E6200026B07 /* XCRemoteSwiftPackageReference "xcstrings-tool-plugin" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/liamnichols/xcstrings-tool-plugin.git";
 			requirement = {
@@ -2993,7 +2997,7 @@
 				minimumVersion = 1.1.0;
 			};
 		};
-		C9646EA229B7A24A007239A4 /* XCRemoteSwiftPackageReference "posthog-ios.git" */ = {
+		C9646EA229B7A24A007239A4 /* XCRemoteSwiftPackageReference "posthog-ios" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/PostHog/posthog-ios.git";
 			requirement = {
@@ -3009,7 +3013,7 @@
 				minimumVersion = 0.1.4;
 			};
 		};
-		C96CB98A2A6040C500498C4E /* XCRemoteSwiftPackageReference "swift-collections.git" */ = {
+		C96CB98A2A6040C500498C4E /* XCRemoteSwiftPackageReference "swift-collections" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/apple/swift-collections.git";
 			requirement = {
@@ -3025,7 +3029,7 @@
 				minimumVersion = 2.0.0;
 			};
 		};
-		C9ADB139299299570075E7F8 /* XCRemoteSwiftPackageReference "bech32.git" */ = {
+		C9ADB139299299570075E7F8 /* XCRemoteSwiftPackageReference "bech32" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/0xdeadp00l/bech32.git";
 			requirement = {
@@ -3033,7 +3037,7 @@
 				kind = branch;
 			};
 		};
-		C9B71DBC2A8E9BAD0031ED9F /* XCRemoteSwiftPackageReference "sentry-cocoa.git" */ = {
+		C9B71DBC2A8E9BAD0031ED9F /* XCRemoteSwiftPackageReference "sentry-cocoa" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/getsentry/sentry-cocoa.git";
 			requirement = {
@@ -3057,7 +3061,7 @@
 				minimumVersion = 6.6.2;
 			};
 		};
-		C9DEC066298965270078B43A /* XCRemoteSwiftPackageReference "Starscream.git" */ = {
+		C9DEC066298965270078B43A /* XCRemoteSwiftPackageReference "Starscream" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/daltoniam/Starscream.git";
 			requirement = {
@@ -3065,7 +3069,7 @@
 				minimumVersion = 4.0.0;
 			};
 		};
-		C9FD34F42BCEC89C008F8D95 /* XCRemoteSwiftPackageReference "secp256k1.swift" */ = {
+		C9FD34F42BCEC89C008F8D95 /* XCRemoteSwiftPackageReference "secp256k1" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/GigaBitcoin/secp256k1.swift";
 			requirement = {
@@ -3084,19 +3088,19 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		3AD3185C2B294E9000026B07 /* plugin:XCStringsToolPlugin */ = {
+		3AD3185C2B294E9000026B07 /* XCStringsToolPlugin */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 3AD3185B2B294E6200026B07 /* XCRemoteSwiftPackageReference "xcstrings-tool-plugin.git" */;
+			package = 3AD3185B2B294E6200026B07 /* XCRemoteSwiftPackageReference "xcstrings-tool-plugin" */;
 			productName = "plugin:XCStringsToolPlugin";
 		};
-		3AEABEF22B2BF806001BC933 /* plugin:XCStringsToolPlugin */ = {
+		3AEABEF22B2BF806001BC933 /* XCStringsToolPlugin */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 3AD3185B2B294E6200026B07 /* XCRemoteSwiftPackageReference "xcstrings-tool-plugin.git" */;
+			package = 3AD3185B2B294E6200026B07 /* XCRemoteSwiftPackageReference "xcstrings-tool-plugin" */;
 			productName = "plugin:XCStringsToolPlugin";
 		};
 		C905B0742A619367009B8A78 /* DequeModule */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = C96CB98A2A6040C500498C4E /* XCRemoteSwiftPackageReference "swift-collections.git" */;
+			package = C96CB98A2A6040C500498C4E /* XCRemoteSwiftPackageReference "swift-collections" */;
 			productName = DequeModule;
 		};
 		C91565C02B2368FA0068EECA /* ViewInspector */ = {
@@ -3125,7 +3129,7 @@
 		};
 		C9646EA329B7A24A007239A4 /* PostHog */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = C9646EA229B7A24A007239A4 /* XCRemoteSwiftPackageReference "posthog-ios.git" */;
+			package = C9646EA229B7A24A007239A4 /* XCRemoteSwiftPackageReference "posthog-ios" */;
 			productName = PostHog;
 		};
 		C9646EA629B7A3DD007239A4 /* Dependencies */ = {
@@ -3135,7 +3139,7 @@
 		};
 		C9646EA829B7A4F2007239A4 /* PostHog */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = C9646EA229B7A24A007239A4 /* XCRemoteSwiftPackageReference "posthog-ios.git" */;
+			package = C9646EA229B7A24A007239A4 /* XCRemoteSwiftPackageReference "posthog-ios" */;
 			productName = PostHog;
 		};
 		C9646EAB29B7A520007239A4 /* Dependencies */ = {
@@ -3145,7 +3149,7 @@
 		};
 		C96CB98B2A6040C500498C4E /* DequeModule */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = C96CB98A2A6040C500498C4E /* XCRemoteSwiftPackageReference "swift-collections.git" */;
+			package = C96CB98A2A6040C500498C4E /* XCRemoteSwiftPackageReference "swift-collections" */;
 			productName = DequeModule;
 		};
 		C99DBF7D2A9E81CF00F7068F /* SDWebImageSwiftUI */ = {
@@ -3163,44 +3167,44 @@
 			package = C99DBF7C2A9E81CF00F7068F /* XCRemoteSwiftPackageReference "SDWebImageSwiftUI" */;
 			productName = SDWebImageSwiftUI;
 		};
-		C9A6C7432AD83F7A001F9500 /* plugin:SwiftGenPlugin */ = {
+		C9A6C7432AD83F7A001F9500 /* SwiftGenPlugin */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = C9B737702AB24D5F00398BE7 /* XCRemoteSwiftPackageReference "SwiftGenPlugin" */;
 			productName = "plugin:SwiftGenPlugin";
 		};
 		C9B71DBD2A8E9BAD0031ED9F /* Sentry */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = C9B71DBC2A8E9BAD0031ED9F /* XCRemoteSwiftPackageReference "sentry-cocoa.git" */;
+			package = C9B71DBC2A8E9BAD0031ED9F /* XCRemoteSwiftPackageReference "sentry-cocoa" */;
 			productName = Sentry;
 		};
 		C9B71DBF2A8E9BAD0031ED9F /* SentrySwiftUI */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = C9B71DBC2A8E9BAD0031ED9F /* XCRemoteSwiftPackageReference "sentry-cocoa.git" */;
+			package = C9B71DBC2A8E9BAD0031ED9F /* XCRemoteSwiftPackageReference "sentry-cocoa" */;
 			productName = SentrySwiftUI;
 		};
 		C9B71DC42A9008300031ED9F /* Sentry */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = C9B71DBC2A8E9BAD0031ED9F /* XCRemoteSwiftPackageReference "sentry-cocoa.git" */;
+			package = C9B71DBC2A8E9BAD0031ED9F /* XCRemoteSwiftPackageReference "sentry-cocoa" */;
 			productName = Sentry;
 		};
-		C9D5733F2AB24A3700E06BB4 /* plugin:SwiftGenPlugin */ = {
+		C9D5733F2AB24A3700E06BB4 /* SwiftGenPlugin */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = C9C8450C2AB249DB00654BC1 /* XCRemoteSwiftPackageReference "SwiftGenPlugin" */;
 			productName = "plugin:SwiftGenPlugin";
 		};
 		C9DEC067298965270078B43A /* Starscream */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = C9DEC066298965270078B43A /* XCRemoteSwiftPackageReference "Starscream.git" */;
+			package = C9DEC066298965270078B43A /* XCRemoteSwiftPackageReference "Starscream" */;
 			productName = Starscream;
 		};
 		C9FD34F52BCEC89C008F8D95 /* secp256k1 */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = C9FD34F42BCEC89C008F8D95 /* XCRemoteSwiftPackageReference "secp256k1.swift" */;
+			package = C9FD34F42BCEC89C008F8D95 /* XCRemoteSwiftPackageReference "secp256k1" */;
 			productName = secp256k1;
 		};
 		C9FD34F72BCEC8B5008F8D95 /* secp256k1 */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = C9FD34F42BCEC89C008F8D95 /* XCRemoteSwiftPackageReference "secp256k1.swift" */;
+			package = C9FD34F42BCEC89C008F8D95 /* XCRemoteSwiftPackageReference "secp256k1" */;
 			productName = secp256k1;
 		};
 		C9FD35122BCED5A6008F8D95 /* NostrSDK */ = {
@@ -3210,7 +3214,7 @@
 		};
 		CDDA1F7A29A527650047ACD8 /* Starscream */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = C9DEC066298965270078B43A /* XCRemoteSwiftPackageReference "Starscream.git" */;
+			package = C9DEC066298965270078B43A /* XCRemoteSwiftPackageReference "Starscream" */;
 			productName = Starscream;
 		};
 		CDDA1F7C29A527650047ACD8 /* SwiftUINavigation */ = {

--- a/Nos/Models/EditableNoteText.swift
+++ b/Nos/Models/EditableNoteText.swift
@@ -16,17 +16,12 @@ struct EditableNoteText: Equatable {
         nsAttributedString.string
     }
     
-    private static var font = UIFont.preferredFont(forTextStyle: .body)
-    
     lazy var defaultAttributes: AttributeContainer = {
         AttributeContainer(defaultNSAttributes)
     }()
     
-    var defaultNSAttributes: [NSAttributedString.Key: Any] = [
-        .font: font,
-        .foregroundColor: UIColor.primaryTxt
-    ]
-    
+    var defaultNSAttributes: [NSAttributedString.Key: Any]
+
     var isEmpty: Bool {
         nsAttributedString.string.isEmpty
     }
@@ -34,16 +29,22 @@ struct EditableNoteText: Equatable {
     // MARK: - Init
     
     init() {
-        self.attributedString = AttributedString()
+        self.init(nsAttributedString: NSAttributedString(string: ""))
     }
     
     init(string: String) {
-        // We initialize this twice to avoid an error about `defaultAttributes` not being around before `self`.
-        self.attributedString = AttributedString(string)
-        self.attributedString = AttributedString(string, attributes: defaultAttributes)
+        self.init(nsAttributedString: NSAttributedString(string: string))
     }
     
-    init(nsAttributedString: NSAttributedString) {
+    init(
+        nsAttributedString: NSAttributedString,
+        font: UIFont = .preferredFont(forTextStyle: .body),
+        foregroundColor: UIColor = .primaryTxt
+    ) {
+        self.defaultNSAttributes = [
+           .font: font,
+           .foregroundColor: foregroundColor
+        ]
         self.attributedString = AttributedString(nsAttributedString)
     }
     
@@ -83,7 +84,10 @@ struct EditableNoteText: Equatable {
                 AttributeContainer([NSAttributedString.Key.link: url.absoluteString])
             )
         )
-        mention.append(AttributedString(stringLiteral: " "))
+        mention.append(AttributedString(
+            " ",
+            attributes: defaultAttributes
+        ))
 
         attributedString.replaceSubrange((attributedString.index(beforeCharacter: index))..<index, with: mention)
     }

--- a/NosTests/NoteParserTests+Parse.swift
+++ b/NosTests/NoteParserTests+Parse.swift
@@ -1,0 +1,92 @@
+//
+//  NoteParserTests+Parse.swift
+//  NosTests
+//
+//  Created by Martin Dutra on 11/6/24.
+//
+
+import Foundation
+import UIKit
+import XCTest
+
+extension NoteParserTests {
+
+    func testMention() throws {
+        // Arrange
+        let name = "mattn"
+        let npub = "npub1937vv2nf06360qn9y8el6d8sevnndy7tuh5nzre4gj05xc32tnwqauhaj6"
+        let hex = "2c7cc62a697ea3a7826521f3fd34f0cb273693cbe5e9310f35449f43622a5cdc"
+        let context = try XCTUnwrap(testContext)
+        let author = try Author.findOrCreate(by: hex, context: context)
+        author.displayName = name
+        try context.save()
+
+        var editableNoteText = EditableNoteText(
+            nsAttributedString: NSAttributedString(string: "@"),
+            font: .systemFont(ofSize: 17),
+            foregroundColor: .black
+        )
+        editableNoteText.insertMention(
+            of: author,
+            at: editableNoteText.attributedString.endIndex
+        )
+
+        let textStorage = NSTextStorage()
+        textStorage.setAttributedString(editableNoteText.nsAttributedString)
+        let result = textStorage.attributedSubstring(
+            from: NSRange(
+                location: 0,
+                length: editableNoteText.nsAttributedString.length
+            )
+        )
+
+        // Act
+        let expected = "nostr:\(npub) "
+        let (content, tags) = sut.parse(
+            attributedText: AttributedString(result)
+        )
+
+        // Assert
+        XCTAssertEqual(content, expected)
+    }
+
+    func testMentionWithEmoji() throws {
+        // Arrange
+        let name = "mattn 🍐"
+        let npub = "npub1937vv2nf06360qn9y8el6d8sevnndy7tuh5nzre4gj05xc32tnwqauhaj6"
+        let hex = "2c7cc62a697ea3a7826521f3fd34f0cb273693cbe5e9310f35449f43622a5cdc"
+        let context = try XCTUnwrap(testContext)
+        let author = try Author.findOrCreate(by: hex, context: context)
+        author.displayName = name
+        try context.save()
+
+        var editableNoteText = EditableNoteText(
+            nsAttributedString: NSAttributedString(string: "@"),
+            font: .systemFont(ofSize: 17),
+            foregroundColor: .black
+        )
+        editableNoteText.insertMention(
+            of: author,
+            at: editableNoteText.attributedString.endIndex
+        )
+
+        let textStorage = NSTextStorage()
+        textStorage.setAttributedString(editableNoteText.nsAttributedString)
+        let result = textStorage.attributedSubstring(
+            from: NSRange(
+                location: 0,
+                length: editableNoteText.nsAttributedString.length
+            )
+        )
+
+        // Act
+        let expected = "nostr:\(npub) "
+        let (content, tags) = sut.parse(
+            attributedText: AttributedString(result)
+        )
+
+        // Assert
+        XCTAssertEqual(content, expected)
+    }
+
+}

--- a/NosTests/NoteParserTests+Parse.swift
+++ b/NosTests/NoteParserTests+Parse.swift
@@ -1,14 +1,10 @@
-//
-//  NoteParserTests+Parse.swift
-//  NosTests
-//
-//  Created by Martin Dutra on 11/6/24.
-//
-
 import Foundation
 import UIKit
 import XCTest
 
+/// Collection of tests that exercise NoteParser.parse() function. This fubction
+/// is the one Nos uses for converting editor generated text to note content
+/// when publishing.
 extension NoteParserTests {
 
     func testMention() throws {
@@ -32,7 +28,8 @@ extension NoteParserTests {
         )
 
         // UITextViews use a NSTextStorage instance that can update the actual
-        // NSAttributedString we set.
+        // NSAttributedString we set. So, lets better use it here so we mimic
+        // the same behavior.
         let textStorage = NSTextStorage()
         textStorage.setAttributedString(editableNoteText.nsAttributedString)
         let result = textStorage.attributedSubstring(
@@ -44,7 +41,7 @@ extension NoteParserTests {
 
         // Act
         let expected = "nostr:\(npub) "
-        let (content, tags) = sut.parse(
+        let (content, _) = sut.parse(
             attributedText: AttributedString(result)
         )
 
@@ -73,7 +70,8 @@ extension NoteParserTests {
         )
 
         // UITextViews use a NSTextStorage instance that can update the actual
-        // NSAttributedString we set.
+        // NSAttributedString we set. So, lets better use it here so we mimic
+        // the same behavior.
         // In the case of emojis, it modifies the font.
         let textStorage = NSTextStorage()
         textStorage.setAttributedString(editableNoteText.nsAttributedString)
@@ -86,12 +84,11 @@ extension NoteParserTests {
 
         // Act
         let expected = "nostr:\(npub) "
-        let (content, tags) = sut.parse(
+        let (content, _) = sut.parse(
             attributedText: AttributedString(result)
         )
 
         // Assert
         XCTAssertEqual(content, expected)
     }
-
 }

--- a/NosTests/NoteParserTests+Parse.swift
+++ b/NosTests/NoteParserTests+Parse.swift
@@ -31,6 +31,8 @@ extension NoteParserTests {
             at: editableNoteText.attributedString.endIndex
         )
 
+        // UITextViews use a NSTextStorage instance that can update the actual
+        // NSAttributedString we set.
         let textStorage = NSTextStorage()
         textStorage.setAttributedString(editableNoteText.nsAttributedString)
         let result = textStorage.attributedSubstring(
@@ -70,6 +72,9 @@ extension NoteParserTests {
             at: editableNoteText.attributedString.endIndex
         )
 
+        // UITextViews use a NSTextStorage instance that can update the actual
+        // NSAttributedString we set.
+        // In the case of emojis, it modifies the font.
         let textStorage = NSTextStorage()
         textStorage.setAttributedString(editableNoteText.nsAttributedString)
         let result = textStorage.attributedSubstring(


### PR DESCRIPTION
## Issues covered
#1144 

## Description
When setting an AttributedString to UITextView's attributedText property, the NSTextStorage that this view uses can fix the NSAttributedString if it finds something that doesn't work. In case of emojis, it needs to update the font, to use the font that contains apple emojis. The note editor uses attributes to add links, so if the text that contains this attribute contains an emoji, UITextView splits the text in different texts with different attributes (one with the link and the text prior the emoji, another with the link and a different for displaying the emoji, and so on, the possibilities are infinite because it could contain more than one emoji).

I added unit tests to catch this. And a solution that joins consecutive attributes that have the same link. 

## How to test

I'm copying the steps to reproduce from the comment I made in the issue:
1. Open Nos on a mac
2. Create a new post
3. Type @ and use the mentions dialog to find a user with an emoji at the end. for example: npub1d4hqsmyejq3s0cc9sh4dngm2s7xdh4q62yy4wrpp6sfrsepq944qtauzgw
4. select the user
5. Write "hey" or do 3 again (without typing anything else in the middle)
6. Publish the post
Issue: The mentions have incorrect formatting.
Expected: Mentions display as @ username - which is a link out to the users' profile.
