### PR TITLE
Fix issue where taking photo from app does nothing

### DIFF
--- a/Nos/Views/New Note/ImagePickerUIViewController.swift
+++ b/Nos/Views/New Note/ImagePickerUIViewController.swift
@@ -1,3 +1,4 @@
+import Logger
 import SwiftUI
 import UniformTypeIdentifiers
 
@@ -30,7 +31,6 @@ struct ImagePickerUIViewController: UIViewControllerRepresentable {
     }
 
     final class Coordinator: NSObject, UIImagePickerControllerDelegate, UINavigationControllerDelegate {
-        
         var onCompletion: ((URL?) -> Void)
 
         init(onCompletion: @escaping ((URL?) -> Void)) {
@@ -40,6 +40,7 @@ struct ImagePickerUIViewController: UIViewControllerRepresentable {
         func imagePickerControllerDidCancel(_ picker: UIImagePickerController) {
             onCompletion(nil)
         }
+
         func imagePickerController(
             _ picker: UIImagePickerController,
             didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey: Any]
@@ -48,8 +49,29 @@ struct ImagePickerUIViewController: UIViewControllerRepresentable {
                 onCompletion(videoURL)
             } else if let imageURL = info[.imageURL] as? URL {
                 onCompletion(imageURL)
+            } else if let image = info[.originalImage] as? UIImage,
+                let imageData = image.jpegData(compressionQuality: 1.0) {
+                let url = saveImage(imageData)
+                onCompletion(url)
             } else {
                 onCompletion(nil)
+            }
+        }
+
+        /// Saves the given image data to a JPG file and returns the URL of the file.
+        /// - Parameter imageData: The image data to save to disk.
+        /// - Returns: The URL of the image file.
+        private func saveImage(_ imageData: Data) -> URL? {
+            let urls = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)
+            let documentDirectory = urls[0]
+            let fileURL = documentDirectory.appendingPathComponent("capturedImage.jpg")
+
+            do {
+                try imageData.write(to: fileURL, options: .atomic)
+                return fileURL
+            } catch {
+                Log.debug("Error saving image: \(error)")
+                return nil
             }
         }
     }


### PR DESCRIPTION
## Issues covered
#1211

## Description
Fixes the issue where taking a photo in the app does nothing. In my testing, taking a video from the app did work, so there's no fix here for that.

## How to test
1. Navigate to Post
2. Tap the image upload button
3. Tap Take photo or video
4. Take a photo
5. Tap Use Photo
6. Observe that it works now, and the URL for the photo appears

Previously, nothing happened after tapping Use Photo -- the Post screen did not show the uploaded image URL, because no image was uploaded.
