### PR TITLE
Update recommended relays list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Updated the recommended relays list.
 - Fixed a bug when mentioning profiles with emojis in the name.
 - Added "Send To Nos" private reporting for profiles.
 - Added our third cohort of creators and journalists to the Discover tab.

--- a/Nos/Models/CoreData/Relay+CoreDataClass.swift
+++ b/Nos/Models/CoreData/Relay+CoreDataClass.swift
@@ -14,7 +14,7 @@ public class Relay: NosManagedObject {
         [
         "wss://relay.damus.io",
         "wss://purplepag.es",
-        "wss://relay.nos.social",
+        nosAddress.absoluteString,
         "wss://relay.snort.social",
         ]
     }
@@ -36,7 +36,7 @@ public class Relay: NosManagedObject {
         "wss://purplepag.es",
         "wss://soloco.nl",
         "wss://relayable.org",
-        "wss://relay.nos.social",
+        nosAddress.absoluteString,
         "wss://relay.causes.com",
         ]
     }

--- a/Nos/Models/CoreData/Relay+CoreDataClass.swift
+++ b/Nos/Models/CoreData/Relay+CoreDataClass.swift
@@ -13,13 +13,9 @@ public class Relay: NosManagedObject {
     static var recommended: [String] {
         [
         "wss://relay.damus.io",
-        "wss://e.nos.lol",
         "wss://purplepag.es",
-        "wss://relay.current.fyi",
         "wss://relay.nos.social",
-        "wss://relayable.org",
         "wss://relay.snort.social",
-        "wss://relay.causes.com",
         ]
     }
     

--- a/Nos/Views/RelayView.swift
+++ b/Nos/Views/RelayView.swift
@@ -23,6 +23,15 @@ struct RelayView: View {
     
     @FetchRequest var relays: FetchedResults<Relay>
 
+    private var sortedRelays: [Relay] {
+        relays.sorted { lhs, _ in
+            if lhs.address == Relay.nosAddress.absoluteString {
+                return true
+            }
+            return false
+        }
+    }
+
     var editable: Bool
     
     init(author: Author, editable: Bool = true) {
@@ -34,7 +43,7 @@ struct RelayView: View {
     var body: some View {
         List {
             Section {
-                ForEach(relays) { relay in
+                ForEach(sortedRelays) { relay in
                     VStack(alignment: .leading) {
                         if relay.hasMetadata {
                             NavigationLink {
@@ -55,7 +64,7 @@ struct RelayView: View {
                 .onDelete { indexes in
                     Task {
                         for index in indexes {
-                            let relay = relays[index]
+                            let relay = sortedRelays[index]
                             await relayService.closeConnection(to: relay.address)
                             analytics.removed(relay)
                             author.remove(relay: relay)

--- a/Nos/Views/RelayView.swift
+++ b/Nos/Views/RelayView.swift
@@ -24,11 +24,8 @@ struct RelayView: View {
     @FetchRequest var relays: FetchedResults<Relay>
 
     private var sortedRelays: [Relay] {
-        relays.sorted { lhs, _ in
-            if lhs.address == Relay.nosAddress.absoluteString {
-                return true
-            }
-            return false
+        relays.sorted { (lhs, _) in
+            lhs.address == Relay.nosAddress.absoluteString
         }
     }
 
@@ -107,8 +104,10 @@ struct RelayView: View {
             ))
             
             let authorRelayUrls = author.relays.compactMap { $0.address }
-            let recommendedRelays = Relay.recommended.filter { !authorRelayUrls.contains($0) }
-            
+            let recommendedRelays = Relay.recommended
+                .filter { !authorRelayUrls.contains($0) }
+                .sorted { (lhs, _) in lhs == Relay.nosAddress.absoluteString }
+
             if editable, !recommendedRelays.isEmpty {
                 Section {
                     ForEach(recommendedRelays, id: \.self) { address in


### PR DESCRIPTION
## Issues covered
#1212 

## Description
I updated the list of recommended relays. I checked that when creating an account, only these four relays are added initially. However, I don't understand what the allKnown list is for, @mplorentz can you explain that. For some reason, my test account ended with all those relays after using Nos for a while. Should I update that list as well?

## How to test
1. Create a new account
2. Go the the relays screen
3. Check the list

