### PR TITLE
Fix issue where Report user menu isn’t visible on iPad

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added "Send To Nos" private reporting for profiles.
 - Added our third cohort of creators and journalists to the Discover tab.
+- Fixed a bug where the Flag User confirmation dialog wasn’t visible on iPad.
 - Fixed a bug where taking a photo in the app didn’t work.
 
 ## [0.1.17] - 2024-06-10Z

--- a/Nos/Views/Profile/ProfileView.swift
+++ b/Nos/Views/Profile/ProfileView.swift
@@ -82,7 +82,6 @@ struct ProfileView: View {
                         ProfileHeader(author: author, selectedTab: $selectedTab)
                             .compositingGroup()
                             .shadow(color: .profileShadow, radius: 10, x: 0, y: 4)
-                            .reportMenu($showingReportMenu, reportedObject: .author(author))
                     },
                     emptyPlaceholder: {
                         VStack {
@@ -135,6 +134,7 @@ struct ProfileView: View {
                             Image(systemName: "ellipsis")
                         }
                     )
+                    .reportMenu($showingReportMenu, reportedObject: .author(author))
                     .confirmationDialog(String(localized: .localizable.share), isPresented: $showingOptions) {
                         Button(String(localized: .localizable.copyUserIdentifier)) {
                             UIPasteboard.general.string = author.publicKey?.npub ?? ""

--- a/Nos/Views/Profile/ProfileView.swift
+++ b/Nos/Views/Profile/ProfileView.swift
@@ -82,6 +82,7 @@ struct ProfileView: View {
                         ProfileHeader(author: author, selectedTab: $selectedTab)
                             .compositingGroup()
                             .shadow(color: .profileShadow, radius: 10, x: 0, y: 4)
+                            .reportMenu($showingReportMenu, reportedObject: .author(author))
                     },
                     emptyPlaceholder: {
                         VStack {
@@ -196,7 +197,6 @@ struct ProfileView: View {
                     }
                 }
         )
-        .reportMenu($showingReportMenu, reportedObject: .author(author))
         .alert(unwrapping: $alert)
         .onAppear {
             Task { 


### PR DESCRIPTION
## Issues covered
#868

## Description
Fixes the issue where the Flag this User menu isn't visible on iPad.

## How to test
1. Navigate to a profile
2. Tap the three dots in the upper right
3. Tap Flag this user
4. Observe confirmation dialog near middle of screen

## Screenshots/Video

https://github.com/planetary-social/nos/assets/59564/f8200905-d788-4a16-91c3-dc628b7f38f4

