### PR TITLE
Remove Save button and functionality from Settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added our third cohort of creators and journalists to the Discover tab.
 - Fixed a bug where the Flag User confirmation dialog wasn’t visible on iPad.
 - Fixed a bug where taking a photo in the app didn’t work.
+- Removed the Save button next to the private key in Settings.
 
 ## [0.1.17] - 2024-06-10Z
 

--- a/Nos/Views/SettingsView.swift
+++ b/Nos/Views/SettingsView.swift
@@ -44,7 +44,7 @@ struct SettingsView: View {
         Form {
             Section {
                 HStack {
-                    Text("•••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••")
+                    Text(String(repeating: "•", count: 63))
                         .foregroundColor(.primaryTxt)
                         .font(.clarity(.regular, textStyle: .body))
                         .lineLimit(1)

--- a/Nos/Views/SettingsView.swift
+++ b/Nos/Views/SettingsView.swift
@@ -31,13 +31,6 @@ struct SettingsView: View {
     @State private var copyButtonState: CopyButtonState = .copy
     @State private var copyButtonWidth: CGFloat = 0
 
-    func importKey(_ keyPair: KeyPair) async {
-        await currentUser.setKeyPair(keyPair)
-        analytics.identify(with: keyPair)
-        crashReporting.identify(with: keyPair)
-        analytics.changedKey()
-    }
-    
     fileprivate enum AlertAction {
         case logout
     }
@@ -51,27 +44,13 @@ struct SettingsView: View {
         Form {
             Section {
                 HStack {
-                    SecureField(String(localized: .localizable.privateKeyPlaceholder), text: $privateKeyString)
+                    Text("•••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••")
                         .foregroundColor(.primaryTxt)
                         .font(.clarity(.regular, textStyle: .body))
+                        .lineLimit(1)
+                        .accessibilityLabel(Text(.localizable.privateKey))
 
-                    SecondaryActionButton(title: .localizable.save) {
-                        if privateKeyString.isEmpty {
-                            await logout()
-                        } else if let keyPair = KeyPair(nsec: privateKeyString) {
-                            await importKey(keyPair)
-                        } else if let keyPair = KeyPair(privateKeyHex: privateKeyString) {
-                            await importKey(keyPair)
-                        } else {
-                            await currentUser.setKeyPair(nil)
-                            alert = AlertState(title: {
-                                TextState(String(localized: .localizable.invalidKey))
-                            }, message: {
-                                TextState(String(localized: .localizable.couldNotReadPrivateKeyMessage))
-                            })
-                        }
-                    }
-                    .padding(.vertical, 5)
+                    Spacer()
 
                     // The ZStack ensures that the copy and copied buttons
                     // have the same width


### PR DESCRIPTION
## Issues covered
#1243

## Description
Removed the Save button and importKey from Settings. Switched SecureField to a plain old Text with dots so the user can't edit their private key. Also added an accessibility label to that Text since otherwise it's just a bunch of dots, and I guess the user might figure out what that is, but a label telling them seems more appropriate.

## How to test
1. Navigate to Settings
2. Observe Private Key section

## Screenshots/Video
| Updated Settings | With VoiceOver label (bottom) |
|--------|--------|
| ![IMG_44058AFF4A45-1](https://github.com/planetary-social/nos/assets/59564/c03ff4ca-e527-4c95-9644-309e15bb7ef8) | ![IMG_0078](https://github.com/planetary-social/nos/assets/59564/655e266a-2f7f-4f50-bc26-7cf4a94a40c7) | 