### PR TITLE
Add note about disabling CompactNoteViewTests

### DIFF
--- a/NosTests/Views/CompactNoteViewTests.swift
+++ b/NosTests/Views/CompactNoteViewTests.swift
@@ -4,6 +4,12 @@ import XCTest
 
 final class CompactNoteViewTests: CoreDataTestCase {
     @MainActor func testNewMediaDisplayDisabledUsesLinkPreviewCarousel() throws {
+        // This test passes when run in isolation but it causes other random tests to fail on CI or if you run the 
+        // full test suite locally repeatedly (like 100 times). It seems like the link preview carousel is spinning up 
+        // some kind of webkit process that sticks around after the test is over and eventually crashes. I tried a few
+        // different ways of fixing it but none of them worked. Since it's a relatively simple test and it's for a 
+        // feature flag that is only temporary we are going to leave it disabled for now.
+        
         // Arrange
         let viewContext = persistenceController.viewContext
         let parseContext = persistenceController.parseContext
@@ -19,7 +25,6 @@ final class CompactNoteViewTests: CoreDataTestCase {
         fullEvent.contentLinks = [try XCTUnwrap(URL(string: eventContent))]
 
         let subject = CompactNoteView(note: fullEvent)
-        ViewHosting.host(view: subject.environment(\.managedObjectContext, persistenceController.container.viewContext))
         ViewHosting.host(view: subject.environmentObject(DependencyValues().router))
 
         // Assert


### PR DESCRIPTION
## Issues covered
Closes `#1253`

## Description
I tried a few more things to fix this test but couldn't find anything that worked. This adds a note about the failure.