### PR TITLE
Add caching to NIP-05 validations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Cache NIP-05 validations to save network usage.
+
 ## [0.1.18] - 2024-06-24Z
 
 - Updated the recommended relays list.

--- a/Nos/Service/NamesAPI.swift
+++ b/Nos/Service/NamesAPI.swift
@@ -5,6 +5,32 @@ import Foundation
 /// or not.
 class NamesAPI {
 
+    /// A shared URLCache instance to store responses from NIP-05 providers
+    private let urlCache = URLCache(
+        memoryCapacity: 4 * 1024 * 1024, // 4 MB
+        diskCapacity: 20 * 1024 * 1024,  // 20 MB
+        directory: .cachesDirectory.appending(component: "NamesAPI")
+    )
+
+    /// The maximum Data size we allow when caching responses to prevent
+    /// a large response from taking all the space.
+    private lazy var maximumURLCacheItemSize: Int = {
+        // Use the 5% of disk cache size
+        let maximum = Double(urlCache.diskCapacity) * 0.05
+        return Int(
+            exactly: maximum.rounded(.toNearestOrEven)
+        ) ?? 1024
+    }()
+
+    /// A shared URLSession instance to fetch responses from NIP-05 providers
+    private lazy var session: URLSession = {
+        let configuration = URLSessionConfiguration.default
+        configuration.urlCache = urlCache
+        return URLSession(
+            configuration: configuration
+        )
+    }()
+
     private enum Error: LocalizedError {
         case unexpected
         case usernameNotAvailable
@@ -53,6 +79,7 @@ class NamesAPI {
         }
         self.verificationURL = verificationURL
         self.registrationURL = registrationURL
+        self.urlCache.removeAllCachedResponses()
     }
 
     /// Deletes a given username from `nos.social`
@@ -157,7 +184,14 @@ class NamesAPI {
                 queryItems: [URLQueryItem(name: "name", value: username)]
             )
         )
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let (data, response): (Data, URLResponse)
+        if let cachedResponse = urlCache.cachedResponse(for: request) {
+            data = cachedResponse.data
+            response = cachedResponse.response
+        } else {
+            (data, response) = try await session.data(for: request)
+        }
+
         if let response = response as? HTTPURLResponse {
             let statusCode = response.statusCode
             if statusCode == 404 {
@@ -165,6 +199,16 @@ class NamesAPI {
             } else if statusCode == 200 {
                 let jsonObject = try JSONSerialization.jsonObject(with: data)
                 if let json = jsonObject as? [String: Any] {
+                    if data.count < maximumURLCacheItemSize {
+                        let cachedResponse = CachedURLResponse(
+                            response: response,
+                            data: data
+                        )
+                        urlCache.storeCachedResponse(
+                            cachedResponse,
+                            for: request
+                        )
+                    }
                     let names = json["names"] as? [String: String]
                     let npub = names?[username]
                     if npub == publicKey.hex {

--- a/Nos/Views/NIP05View.swift
+++ b/Nos/Views/NIP05View.swift
@@ -36,23 +36,14 @@ struct NIP05View: View {
             }
             .task(priority: .userInitiated) {
                 if let nip05Identifier = author.nip05, let publicKey = author.publicKey {
-
-                    let isVerified: Bool
+                    let isVerified: Bool?
                     do {
                         isVerified = try await namesAPI.verify(
                             username: nip05Identifier,
                             publicKey: publicKey
                         )
-                    } catch URLError.cancelled {
-                        // URLSession cancels the request when the task is
-                        // cancelled. Cancelled requests are common specially in
-                        // bad networks because it is normal that the user
-                        // scrolls past the author before the requests
-                        // completes. Thus, we need to catch .cancelled so we
-                        // don't display a strike-through in those cases.
-                        return
                     } catch {
-                        isVerified = false
+                        isVerified = nil
                         let message = error.localizedDescription
                         Log.debug("Error while verifying a NIP-05: \(message)")
                     }

--- a/Nos/Views/NIP05View.swift
+++ b/Nos/Views/NIP05View.swift
@@ -42,6 +42,12 @@ struct NIP05View: View {
                             username: nip05Identifier,
                             publicKey: publicKey
                         )
+                    } catch URLError.cannotFindHost {
+                        isVerified = false
+                        Log.debug("Server cannot be found")
+                    } catch URLError.cannotConnectToHost {
+                        isVerified = false
+                        Log.debug("Server cannot be connected to")
                     } catch {
                         isVerified = nil
                         let message = error.localizedDescription


### PR DESCRIPTION
## Issues covered
#1215 

## Description

`URLSession` has a delete with a function that is invoked when a response will be cached so the developer can opt-out or modify the response that will be cached per request. However, that won't be called if the `URLSession` thinks it shouldn't be cached by reading the protocol rules. This is what happens in our cases, most NIP-05 servers aren't using the Cache-Control header so, per HTTP rules, the responses should not be cached.

The cleanest solution in our case is to use our custom cache instance and read/store the responses programmatically. `URLCache` is already good enough but we don't want to mess with the shared `URLCache` instance as we will want to wipe the contents of the cache, so, we make a new instance just for the URLSession that will be used for making NIP-05 validations.

## How to test
1. Navigate to Discover screen
2. Realize that the users there have their NIP-05 validated
3. Disconnect from the Internet
4. Navigate to the Profile of one of them
5. The NIP-05 also looks as validated there
