### PR TITLE
Fix issue where Discover tab was constantly sorting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Fixed a performance issue after opening the Discover tab.
 - Updated the recommended relays list.
 - Fixed a bug where @npubs could be displayed instead of names in note text.
 - Fixed a bug when mentioning profiles with emojis in the name.

--- a/Nos/Views/Discover/FeaturedAuthor.swift
+++ b/Nos/Views/Discover/FeaturedAuthor.swift
@@ -12,6 +12,21 @@ struct FeaturedAuthor {
     /// The categories in which to show the author on the Discover tab.
     /// No need to include the `.all` category; that's done automatically.
     let categories: [FeaturedAuthorCategory]
+    
+    let rawID: RawAuthorID
+    
+    internal init(name: String, npub: String, categories: [FeaturedAuthorCategory]) {
+        self.name = name
+        self.npub = npub
+        self.categories = categories
+        
+        guard let rawID = PublicKey(npub: npub)?.hex else {
+            assertionFailure("A FeaturedAuthor has a invalid npub: \(npub)")
+            self.rawID = ""
+            return
+        } 
+        self.rawID = rawID
+    }
 }
 
 extension FeaturedAuthor {

--- a/Nos/Views/Discover/FeaturedAuthorCategory.swift
+++ b/Nos/Views/Discover/FeaturedAuthorCategory.swift
@@ -32,15 +32,22 @@ enum FeaturedAuthorCategory: CaseIterable {
         }
     }
 
-    var npubs: [String] {
+    var featuredAuthors: [FeaturedAuthor] {
         switch self {
         case .all:
-            FeaturedAuthor.all.map { $0.npub }
+            FeaturedAuthor.all
         case .new:
-            FeaturedAuthor.cohort3.map { $0.npub }
+            FeaturedAuthor.cohort3
         default:
             FeaturedAuthor.all.filter { $0.categories.contains(self) }
-                .map { $0.npub }
         }
+    }
+    
+    var npubs: [String] {
+        featuredAuthors.map { $0.npub }
+    }
+    
+    var rawIDs: [RawNostrID] {
+        featuredAuthors.map { $0.rawID }
     }
 }


### PR DESCRIPTION
## Issues covered
This performance issue was blocking my work on #474 so I picked it up.

## Description
My simulator was being super slow and I found that the `FeaturedAuthorsView` was constantly sorting its authors even when the user wasn't looking at it. I think every time the viewContext was being saved swiftUI was trying to read the `authors` property, which is a computed property that does in-memory sorting and some CoreData fetch requests on the main thread.

I refactored so that instead of using an @FetchRequest for observation and then sorting the results of that in memory we keep a sorted list of IDs as @State and use `AuthorObservationView` for observation.

## How to test
1. Open the Discover tab
2. Verify that the behavior of the FeaturedAuthorsView is identical