### PR TITLE
Maybe fix notification tab hang/crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Fixed a crash on the notifications tab
 - Fixed a performance issue after opening the Discover tab.
 - Cache NIP-05 validations to save network usage.
 

--- a/Nos/Controller/PersistenceController.swift
+++ b/Nos/Controller/PersistenceController.swift
@@ -124,9 +124,12 @@ class PersistenceController {
         })
     }
     
-    func saveAll() throws {
+    @MainActor
+    func saveAll() async throws {
         try viewContext.saveIfNeeded()
-        try backgroundViewContext.saveIfNeeded()
+        try await backgroundViewContext.perform {
+            try self.backgroundViewContext.saveIfNeeded()
+        }
     }
     
     static func clearCoreData(store storeURL: URL, in container: NSPersistentContainer) {

--- a/Nos/Models/CoreData/Event+CoreDataClass.swift
+++ b/Nos/Models/CoreData/Event+CoreDataClass.swift
@@ -1042,7 +1042,7 @@ public class Event: NosManagedObject, VerifiableEvent {
             
             event.isRead = true
             do {
-                try context.save()
+                try context.saveIfNeeded()
             } catch {
                 Log.error("markNoteAsRead error \(error.localizedDescription)")
             }

--- a/Nos/NosApp.swift
+++ b/Nos/NosApp.swift
@@ -33,15 +33,19 @@ struct NosApp: App {
                     await persistenceController.cleanupEntities()
                 }
                 .onChange(of: scenePhase) { _, newPhase in
-                    // TODO: save all contexts, not just the view and background.
-                    if newPhase == .inactive {
+                    switch newPhase {
+                    case .inactive:
                         Log.info("Scene change: inactive")
-                        try? persistenceController.saveAll()
-                    } else if newPhase == .active {
+                    case .active:
                         Log.info("Scene change: active")
-                    } else if newPhase == .background {
+                    case .background:
                         Log.info("Scene change: background")
-                        try? persistenceController.saveAll()
+                        Task {
+                            // TODO: save all contexts, not just the view and background.
+                            try await persistenceController.saveAll()
+                        }
+                    @unknown default:
+                        Log.info("Scene change: unknown type")
                     }
                 }
         }


### PR DESCRIPTION
## Issues covered
Maybe #970, #1077 and maybe even #474

## Description
While debugging memory usage on an account that follows a lot of users I finally experienced the frequently reported notification tab hang/crash (#970). I caught it in the debugger and saw that the the main thread was deadlocked waiting on the `PersistenceController.backgroundContext` to save because a background thread was also accessing the background context in `NosNotification.markAllAsRead(...)`. The problem is that `PersistenceController.saveAll()` was not saving the `backgroundContext` on the the `backgroundContext`'s associated thread using `backgroundContext.perform {...}`.

I think this deadlock in a production build would look like a hang or a crash - maybe even a crash that doesn't capture a stack trace. If this crash doesn't capture a stack trace then maybe the crash reports we thought were for out of memory errors were really this issue. We should be able to tell if this is true after #539 is deployed to production.

## How to test
The problem was difficult to reproduce but I was able to do it a couple times by backgrounding/foregrounding the app a lot and tapping between the notification and home tabs (which triggers the `NotificationsView` to mark everything as read). 