### PR TITLE
Fix a memory cycle when writing to a websocket

### DIFF
--- a/Nos/Service/Relay/RelayService.swift
+++ b/Nos/Service/Relay/RelayService.swift
@@ -466,32 +466,32 @@ extension RelayService {
             socket.disconnect()
         }
         
-        return await withCheckedContinuation({ continuation in
+        return await withCheckedContinuation({ [weak socket] continuation in
             var written = false
             var continued = false
             
-            socket.onEvent = { (event: WebSocketEvent) in
+            socket?.onEvent = { [weak socket] (event: WebSocketEvent) in
                 switch event {
                 case WebSocketEvent.connected:
                     if !written {
-                        socket.write(string: message, completion: {
+                        socket?.write(string: message, completion: {
                             written = true
                         })
                     }
                 case WebSocketEvent.text(let text):
                     if written {
                         Log.info("Received \(text) after write, disconnecting")
-                        socket.disconnect()
+                        socket?.disconnect()
                     }
                 case WebSocketEvent.viabilityChanged(let isViable) where isViable:
                     if !written {
-                        socket.write(string: message, completion: {
+                        socket?.write(string: message, completion: {
                             written = true
                         })
                     }
                 case WebSocketEvent.error(let error):
                     Log.optional(error, "failed to send message: \(message) to websocket")
-                    socket.disconnect()
+                    socket?.disconnect()
                 case WebSocketEvent.disconnected, WebSocketEvent.cancelled:
                     timeoutTask.cancel()
                     if !continued {
@@ -505,7 +505,7 @@ extension RelayService {
                 }
             }
             
-            socket.connect()
+            socket?.connect()
         })
     }
     


### PR DESCRIPTION
## Issues covered
#474 

## Description
This fixes a memory cycle I found when working on #474. It was a simple case of a strong reference to an object in a closure referenced by the same object.

## How to test
1. Launch the app
2. Go to the notification tab
3. Click "debug memory graph" in the debugger
4. Filter for "Websocket" in the left sidebar
On `main` there will be a number of yellow warning icons next to some of the sockets. You can click on them to view the memory cycle. On this branch there are not.