### PR TITLE
Add Share database to Settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Cache NIP-05 validations to save network usage.
 - Set Xcode version to 15.2, where SwiftUI Previews work reliably.
+- Add "Share database" button to Settings to help with debugging.
 
 ## [0.1.18] - 2024-06-24Z
 

--- a/Nos.xcodeproj/project.pbxproj
+++ b/Nos.xcodeproj/project.pbxproj
@@ -441,8 +441,8 @@
 		C9F204672ADEDBA80029A858 /* String+Extra.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9F204662ADEDBA80029A858 /* String+Extra.swift */; };
 		C9F204802AE029D90029A858 /* AppDestination.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9F2047F2AE029D90029A858 /* AppDestination.swift */; };
 		C9F204812AE02D8C0029A858 /* AppDestination.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9F2047F2AE029D90029A858 /* AppDestination.swift */; };
-		C9F64D8C29ED840700563F2B /* LogHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9F64D8B29ED840700563F2B /* LogHelper.swift */; };
-		C9F64D8D29ED840700563F2B /* LogHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9F64D8B29ED840700563F2B /* LogHelper.swift */; };
+		C9F64D8C29ED840700563F2B /* Zipper.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9F64D8B29ED840700563F2B /* Zipper.swift */; };
+		C9F64D8D29ED840700563F2B /* Zipper.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9F64D8B29ED840700563F2B /* Zipper.swift */; };
 		C9F75AD22A02D41E005BBE45 /* ComposerActionBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9F75AD12A02D41E005BBE45 /* ComposerActionBar.swift */; };
 		C9F75AD62A041FF7005BBE45 /* ExpirationTimePicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9F75AD52A041FF7005BBE45 /* ExpirationTimePicker.swift */; };
 		C9F84C1A298DBB6300C6714D /* Data+Encoding.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9671D72298DB94C00EE7E12 /* Data+Encoding.swift */; };
@@ -816,7 +816,7 @@
 		C9F0BB6E29A50437000547FC /* NostrConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NostrConstants.swift; sourceTree = "<group>"; };
 		C9F204662ADEDBA80029A858 /* String+Extra.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "String+Extra.swift"; sourceTree = "<group>"; };
 		C9F2047F2AE029D90029A858 /* AppDestination.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDestination.swift; sourceTree = "<group>"; };
-		C9F64D8B29ED840700563F2B /* LogHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogHelper.swift; sourceTree = "<group>"; };
+		C9F64D8B29ED840700563F2B /* Zipper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Zipper.swift; sourceTree = "<group>"; };
 		C9F75AD12A02D41E005BBE45 /* ComposerActionBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposerActionBar.swift; sourceTree = "<group>"; };
 		C9F75AD52A041FF7005BBE45 /* ExpirationTimePicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpirationTimePicker.swift; sourceTree = "<group>"; };
 		C9F84C1B298DBBF400C6714D /* Data+Sha.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data+Sha.swift"; sourceTree = "<group>"; };
@@ -1182,7 +1182,7 @@
 				0350F12C2C0A7EF20024CC15 /* FeatureFlags.swift */,
 				C959DB752BD01DF4008F3627 /* GiftWrapper.swift */,
 				A3B943CE299AE00100A15A08 /* KeyChain.swift */,
-				C9F64D8B29ED840700563F2B /* LogHelper.swift */,
+				C9F64D8B29ED840700563F2B /* Zipper.swift */,
 				C9EF84CE2C24D63000182B6F /* MockRelayService.swift */,
 				0320C1142BFE63DC00C4C080 /* MockRelaySubscriptionManager.swift */,
 				5BC0D9CB2B867B9D005D6980 /* NamesAPI.swift */,
@@ -1712,7 +1712,7 @@
 				C9B737702AB24D5F00398BE7 /* XCRemoteSwiftPackageReference "SwiftGenPlugin" */,
 				C91565BF2B2368FA0068EECA /* XCRemoteSwiftPackageReference "ViewInspector" */,
 				3AD3185B2B294E6200026B07 /* XCRemoteSwiftPackageReference "xcstrings-tool-plugin" */,
-				C9FD34F42BCEC89C008F8D95 /* XCRemoteSwiftPackageReference "secp256k1.swift" */,
+				C9FD34F42BCEC89C008F8D95 /* XCRemoteSwiftPackageReference "secp256k1" */,
 				C9FD35112BCED5A6008F8D95 /* XCRemoteSwiftPackageReference "nostr-sdk-ios" */,
 			);
 			productRefGroup = C9DEBFCF298941000078B43A /* Products */;
@@ -1852,7 +1852,7 @@
 				C9C547512A4F1CC3006B0741 /* SearchController.swift in Sources */,
 				C992B32A2B3613CC00704A9C /* SubscriptionCancellable.swift in Sources */,
 				C9DEC06E2989668E0078B43A /* Relay+CoreDataClass.swift in Sources */,
-				C9F64D8C29ED840700563F2B /* LogHelper.swift in Sources */,
+				C9F64D8C29ED840700563F2B /* Zipper.swift in Sources */,
 				C9C2B78529E073E300548B4A /* RelaySubscription.swift in Sources */,
 				0350F12D2C0A7EF20024CC15 /* FeatureFlags.swift in Sources */,
 				3FFB1D9C29A7DF9D002A755D /* StackedAvatarsView.swift in Sources */,
@@ -2125,7 +2125,7 @@
 				C9EE3E642A053910008A7491 /* ExpirationTimeOption.swift in Sources */,
 				65D066AA2BD55E160011C5CD /* DirectMessageWrapper.swift in Sources */,
 				C973AB5E2A323167002AED16 /* Event+CoreDataProperties.swift in Sources */,
-				C9F64D8D29ED840700563F2B /* LogHelper.swift in Sources */,
+				C9F64D8D29ED840700563F2B /* Zipper.swift in Sources */,
 				C98298342ADD7F9A0096C5B5 /* DeepLinkService.swift in Sources */,
 				CD09A75929A521D20063464F /* Color+Hex.swift in Sources */,
 				5B88051D2A2104CC00E21F06 /* SHA256Key.swift in Sources */,
@@ -2243,11 +2243,11 @@
 /* Begin PBXTargetDependency section */
 		3AD3185D2B294E9000026B07 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			productRef = 3AD3185C2B294E9000026B07 /* plugin:XCStringsToolPlugin */;
+			productRef = 3AD3185C2B294E9000026B07 /* XCStringsToolPlugin */;
 		};
 		3AEABEF32B2BF806001BC933 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			productRef = 3AEABEF22B2BF806001BC933 /* plugin:XCStringsToolPlugin */;
+			productRef = 3AEABEF22B2BF806001BC933 /* XCStringsToolPlugin */;
 		};
 		C90862C229E9804B00C35A71 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -2256,11 +2256,11 @@
 		};
 		C9A6C7442AD83F7A001F9500 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			productRef = C9A6C7432AD83F7A001F9500 /* plugin:SwiftGenPlugin */;
+			productRef = C9A6C7432AD83F7A001F9500 /* SwiftGenPlugin */;
 		};
 		C9D573402AB24A3700E06BB4 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			productRef = C9D5733F2AB24A3700E06BB4 /* plugin:SwiftGenPlugin */;
+			productRef = C9D5733F2AB24A3700E06BB4 /* SwiftGenPlugin */;
 		};
 		C9DEBFE6298941020078B43A /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -3091,7 +3091,7 @@
 				minimumVersion = 4.0.0;
 			};
 		};
-		C9FD34F42BCEC89C008F8D95 /* XCRemoteSwiftPackageReference "secp256k1.swift" */ = {
+		C9FD34F42BCEC89C008F8D95 /* XCRemoteSwiftPackageReference "secp256k1" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/GigaBitcoin/secp256k1.swift";
 			requirement = {
@@ -3110,12 +3110,12 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		3AD3185C2B294E9000026B07 /* plugin:XCStringsToolPlugin */ = {
+		3AD3185C2B294E9000026B07 /* XCStringsToolPlugin */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 3AD3185B2B294E6200026B07 /* XCRemoteSwiftPackageReference "xcstrings-tool-plugin" */;
 			productName = "plugin:XCStringsToolPlugin";
 		};
-		3AEABEF22B2BF806001BC933 /* plugin:XCStringsToolPlugin */ = {
+		3AEABEF22B2BF806001BC933 /* XCStringsToolPlugin */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 3AD3185B2B294E6200026B07 /* XCRemoteSwiftPackageReference "xcstrings-tool-plugin" */;
 			productName = "plugin:XCStringsToolPlugin";
@@ -3189,7 +3189,7 @@
 			package = C99DBF7C2A9E81CF00F7068F /* XCRemoteSwiftPackageReference "SDWebImageSwiftUI" */;
 			productName = SDWebImageSwiftUI;
 		};
-		C9A6C7432AD83F7A001F9500 /* plugin:SwiftGenPlugin */ = {
+		C9A6C7432AD83F7A001F9500 /* SwiftGenPlugin */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = C9B737702AB24D5F00398BE7 /* XCRemoteSwiftPackageReference "SwiftGenPlugin" */;
 			productName = "plugin:SwiftGenPlugin";
@@ -3209,7 +3209,7 @@
 			package = C9B71DBC2A8E9BAD0031ED9F /* XCRemoteSwiftPackageReference "sentry-cocoa" */;
 			productName = Sentry;
 		};
-		C9D5733F2AB24A3700E06BB4 /* plugin:SwiftGenPlugin */ = {
+		C9D5733F2AB24A3700E06BB4 /* SwiftGenPlugin */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = C9C8450C2AB249DB00654BC1 /* XCRemoteSwiftPackageReference "SwiftGenPlugin" */;
 			productName = "plugin:SwiftGenPlugin";
@@ -3221,12 +3221,12 @@
 		};
 		C9FD34F52BCEC89C008F8D95 /* secp256k1 */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = C9FD34F42BCEC89C008F8D95 /* XCRemoteSwiftPackageReference "secp256k1.swift" */;
+			package = C9FD34F42BCEC89C008F8D95 /* XCRemoteSwiftPackageReference "secp256k1" */;
 			productName = secp256k1;
 		};
 		C9FD34F72BCEC8B5008F8D95 /* secp256k1 */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = C9FD34F42BCEC89C008F8D95 /* XCRemoteSwiftPackageReference "secp256k1.swift" */;
+			package = C9FD34F42BCEC89C008F8D95 /* XCRemoteSwiftPackageReference "secp256k1" */;
 			productName = secp256k1;
 		};
 		C9FD35122BCED5A6008F8D95 /* NostrSDK */ = {

--- a/Nos/Assets/Localization/Localizable.xcstrings
+++ b/Nos/Assets/Localization/Localizable.xcstrings
@@ -4088,6 +4088,18 @@
         }
       }
     },
+    "failedToShareDatabase" : {
+      "comment" : "Error message for when we can't find the Core Data database.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "We're sorry, but we couldn't find your database to share."
+          }
+        }
+      }
+    },
     "featuredAuthorCategoryActivists" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -11072,6 +11084,17 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "分享"
+          }
+        }
+      }
+    },
+    "shareDatabase" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Share database"
           }
         }
       }

--- a/Nos/Controller/PersistenceController.swift
+++ b/Nos/Controller/PersistenceController.swift
@@ -223,4 +223,8 @@ class PersistenceController {
             return statistics.sorted(by: { $0.key < $1.key })
         }
     }
+
+    func sqliteURL() -> URL? {
+        container.persistentStoreDescriptions.first?.url
+    }
 }

--- a/Nos/Controller/PersistenceController.swift
+++ b/Nos/Controller/PersistenceController.swift
@@ -37,7 +37,11 @@ class PersistenceController {
     lazy var backgroundViewContext = {
         self.newBackgroundContext()
     }()
-    
+
+    var sqliteURL: URL? {
+        container.persistentStoreDescriptions.first?.url
+    }
+
     private(set) var container: NSPersistentContainer
     private var model: NSManagedObjectModel
     private var inMemory: Bool
@@ -222,9 +226,5 @@ class PersistenceController {
             
             return statistics.sorted(by: { $0.key < $1.key })
         }
-    }
-
-    func sqliteURL() -> URL? {
-        container.persistentStoreDescriptions.first?.url
     }
 }

--- a/Nos/Service/Zipper.swift
+++ b/Nos/Service/Zipper.swift
@@ -19,7 +19,7 @@ enum Zipper {
     /// - Parameter controller: The persistence controller that contains the SQLite database.
     /// - Returns: The file URL of the zipped database.
     static func zipDatabase(controller: PersistenceController) async throws -> URL {
-        guard let sqliteURL = controller.sqliteURL() else {
+        guard let sqliteURL = controller.sqliteURL else {
             throw ZipperError.fileNotFound
         }
         return try await zipFiles([sqliteURL])

--- a/Nos/Service/Zipper.swift
+++ b/Nos/Service/Zipper.swift
@@ -1,9 +1,34 @@
 import Foundation
 import Logger
 
-enum LogHelper {
+/// An error that may be thrown by `Zipper`.
+enum ZipperError: Error {
+    /// The file to zip was not found.
+    case fileNotFound
+}
+
+/// A utility that knows how to zip.
+enum Zipper {
+    /// Zips the log files.
+    /// - Returns: The file URL of the zip.
     static func zipLogs() async throws -> URL {
-        let appFileUrls = Log.fileUrls
+        try await zipFiles(Log.fileUrls)
+    }
+
+    /// Zips the SQLite database of the given persistence controller.
+    /// - Parameter controller: The persistence controller that contains the SQLite database.
+    /// - Returns: The file URL of the zipped database.
+    static func zipDatabase(controller: PersistenceController) async throws -> URL {
+        guard let sqliteURL = controller.sqliteURL() else {
+            throw ZipperError.fileNotFound
+        }
+        return try await zipFiles([sqliteURL])
+    }
+    
+    /// Zips the files at the given URLs.
+    /// - Parameter fileURLs: the URLs of the files to zip.
+    /// - Returns: The file URL of the zip.
+    static func zipFiles(_ fileURLs: [URL]) async throws -> URL {
         let temporaryDirectory = URL(fileURLWithPath: NSTemporaryDirectory())
         let url = temporaryDirectory.appendingPathComponent(UUID().uuidString)
         return try await Task {
@@ -14,8 +39,8 @@ enum LogHelper {
                 try FileManager.default.copyItem(at: appFileURL, to: destFileURL)
             }
             
-            try appFileUrls.forEach { try copy($0) }
-            
+            try fileURLs.forEach { try copy($0) }
+
             let coord = NSFileCoordinator()
             var readError: NSError?
             return try await withCheckedThrowingContinuation { continuation in

--- a/Nos/Views/ReportABugMailView.swift
+++ b/Nos/Views/ReportABugMailView.swift
@@ -52,7 +52,7 @@ struct ReportABugMailView: UIViewControllerRepresentable {
         Task {
             do {
                 mailViewController.addAttachmentData(
-                    try Data(contentsOf: try await LogHelper.zipLogs()),
+                    try Data(contentsOf: try await Zipper.zipLogs()),
                     mimeType: "application/zip", 
                     fileName: "diagnostics.zip"
                 )

--- a/Nos/Views/SettingsView.swift
+++ b/Nos/Views/SettingsView.swift
@@ -18,10 +18,10 @@ struct SettingsView: View {
 
     @State private var privateKeyString = ""
     @State private var alert: AlertState<AlertAction>?
-    @State private var logFileURL: URL?
+    @State private var fileToShare: URL?
     private var showActivitySheet: Binding<Bool> {
         Binding<Bool>(
-            get: { logFileURL != nil },
+            get: { fileToShare != nil },
             set: { _ in }
         )
     }
@@ -171,38 +171,48 @@ struct SettingsView: View {
             }
             
             Section {
-                HStack {
-                    Text("\(String(localized: .localizable.appVersion)) \(Bundle.current.versionAndBuild)")
-                        .foregroundColor(.primaryTxt)
-                    Spacer()
-                    SecondaryActionButton(title: .localizable.shareLogs) {
-                        Task {
-                            do {
-                                logFileURL = try await LogHelper.zipLogs()
-                            } catch {
-                                alert = AlertState(title: {
-                                    TextState(String(localized: .localizable.error))
-                                }, message: {
-                                    TextState(String(localized: .localizable.failedToExportLogs))
-                                })
+                Text("\(String(localized: .localizable.appVersion)) \(Bundle.current.versionAndBuild)")
+                    .foregroundColor(.primaryTxt)
+                    .padding(.vertical, 5)
+                    .sheet(
+                        isPresented: showActivitySheet,
+                        onDismiss: {
+                            fileToShare = nil
+                        },
+                        content: {
+                            if let fileToShare {
+                                ActivityViewController(activityItems: [fileToShare])
+                            } else {
+                                EmptyView()
                             }
                         }
-                    }        
+                    )
+
+                SecondaryActionButton(title: .localizable.shareDatabase) {
+                    if let url = persistenceController.sqliteURL() {
+                        fileToShare = url
+                    } else {
+                        alert = AlertState(title: {
+                            TextState(String(localized: .localizable.error))
+                        }, message: {
+                            TextState(String(localized: .localizable.failedToShareDatabase))
+                        })
+                    }
                 }
-                .padding(.vertical, 5)
-                .sheet(
-                    isPresented: showActivitySheet,
-                    onDismiss: {
-                        logFileURL = nil
-                    },
-                    content: {
-                        if let logFileURL {
-                            ActivityViewController(activityItems: [logFileURL])
-                        } else {
-                            EmptyView()
+
+                SecondaryActionButton(title: .localizable.shareLogs) {
+                    Task {
+                        do {
+                            fileToShare = try await LogHelper.zipLogs()
+                        } catch {
+                            alert = AlertState(title: {
+                                TextState(String(localized: .localizable.error))
+                            }, message: {
+                                TextState(String(localized: .localizable.failedToExportLogs))
+                            })
                         }
                     }
-                )
+                }
 
                 #if DEBUG
                 debugControls

--- a/Nos/Views/SettingsView.swift
+++ b/Nos/Views/SettingsView.swift
@@ -189,21 +189,23 @@ struct SettingsView: View {
                     )
 
                 SecondaryActionButton(title: .localizable.shareDatabase) {
-                    if let url = persistenceController.sqliteURL() {
-                        fileToShare = url
-                    } else {
-                        alert = AlertState(title: {
-                            TextState(String(localized: .localizable.error))
-                        }, message: {
-                            TextState(String(localized: .localizable.failedToShareDatabase))
-                        })
+                    Task {
+                        do {
+                            fileToShare = try await Zipper.zipDatabase(controller: persistenceController)
+                        } catch {
+                            alert = AlertState(title: {
+                                TextState(String(localized: .localizable.error))
+                            }, message: {
+                                TextState(String(localized: .localizable.failedToShareDatabase))
+                            })
+                        }
                     }
                 }
 
                 SecondaryActionButton(title: .localizable.shareLogs) {
                     Task {
                         do {
-                            fileToShare = try await LogHelper.zipLogs()
+                            fileToShare = try await Zipper.zipLogs()
                         } catch {
                             alert = AlertState(title: {
                                 TextState(String(localized: .localizable.error))


### PR DESCRIPTION
## Issues covered
#1244, #1245

## Description
Added the Share database button to Settings, including functionality to actually share it.

## How to test
1. Navigate to Settings
2. Tap Share database
3. Send it to yourself
4. Make sure it's a database

I also commented out the line in PersistenceController to return `nil` so I could see the error message. You could do that, too, if you want to see it for yourself. Or you can scroll down... 👇 

## Screenshots/Video
| Settings view | Error message |
|--------|--------|
| ![Screenshot 2024-06-27 at 10 58 01 AM](https://github.com/planetary-social/nos/assets/59564/62c6016c-a889-494a-8d89-1d5a18a3964f) | ![Screenshot 2024-06-27 at 10 55 08 AM](https://github.com/planetary-social/nos/assets/59564/5da7f8be-9b75-4f8c-86c5-938c672d7927) | 