### PR TITLE
prefer NIP-05 for Author webLink

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Use NIP-05 for shared links to profile.
+
 ## [0.1.19] - 2024-07-01Z
 
 - Fixed a crash on the notifications tab
@@ -15,7 +17,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Cache NIP-05 validations to save network usage.
 - Set Xcode version to 15.2, where SwiftUI Previews work reliably.
 - Add "Share database" button to Settings to help with debugging.
-- Use NIP-05 for shared links to profile.
 
 ## [0.1.18] - 2024-06-24Z
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Cache NIP-05 validations to save network usage.
 - Set Xcode version to 15.2, where SwiftUI Previews work reliably.
 - Add "Share database" button to Settings to help with debugging.
+- Use NIP-05 for shared links to profile.
 
 ## [0.1.18] - 2024-06-24Z
 

--- a/Nos/Models/CoreData/Author+CoreDataClass.swift
+++ b/Nos/Models/CoreData/Author+CoreDataClass.swift
@@ -106,10 +106,14 @@ import Logger
     }
     
     var webLink: String {
-        if let publicKey {
+        if hasNosNIP05 {
+            return "https://\(nosNIP05Username).nos.social"
+        } else if let formattedNIP05 {
+            return "https://njump.me/\(formattedNIP05)"
+        } else if let publicKey {
             return "https://njump.me/\(publicKey.npub)"
         } else {
-            Log.error("Coudln't find public key when creating weblink")
+            Log.error("Couldn't find public key when creating weblink")
             return "https://njump.me/"
         }
     }

--- a/NosTests/Model/AuthorTests.swift
+++ b/NosTests/Model/AuthorTests.swift
@@ -146,6 +146,32 @@ final class AuthorTests: CoreDataTestCase {
         XCTAssertEqual(author.formattedNIP05, expected)
     }
     
+    func test_weblink_with_nos_social_NIP05() throws {
+        let context = persistenceController.viewContext
+        let author = try Author.findOrCreate(by: "test", context: context)
+        author.nip05 = "test@nos.social"
+        let expected = "https://test.nos.social"
+        
+        XCTAssertEqual(author.webLink, expected)
+    }
+    
+    func test_weblink_with_non_nos_social_NIP05() throws {
+        let expected = "https://njump.me/user@test.net"
+        let context = persistenceController.viewContext
+        let author = try Author.findOrCreate(by: "test", context: context)
+        author.nip05 = "user@test.net"
+        
+        XCTAssertEqual(author.webLink, expected)
+    }
+    
+    func test_weblink_with_nil_NIP05() throws {
+        let expected = "https://njump.me/\(KeyFixture.alice.npub)"
+        let context = persistenceController.viewContext
+        let author = try Author.findOrCreate(by: KeyFixture.alice.publicKeyHex, context: context)
+        author.nip05 = nil
+        XCTAssertEqual(author.webLink, expected)
+    }
+    
     // MARK: Fetch requests
     
     @MainActor func test_knownFollowers_givenMultipleFollowers() throws {


### PR DESCRIPTION
## Issues covered
https://github.com/planetary-social/nos/issues/1227

## Description
Copying a link to a user's profile will now use the NIP-05 address and fall back to the user's npub if there is no NIP-05. It also adds a different special format for @nos.social NIP-05s.

## How to test
1. Navigate to a user's profile.
2. Tap the three dots button at top-right.
3. Tap the Copy Link button.
4. Paste it anywhere to see its contents.

Unit tests were added to cover the various cases.
