### PR TITLE
Tap to Refresh in empty profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Add a Tap to Refresh button in empty profiles.
 - Use NIP-05 for shared links to profile.
 
 ## [0.1.19] - 2024-07-01Z

--- a/Nos/Assets/Localization/Localizable.xcstrings
+++ b/Nos/Assets/Localization/Localizable.xcstrings
@@ -11925,6 +11925,23 @@
         }
       }
     },
+    "tapToRefresh" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tap to refresh"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Toca para actualizar"
+          }
+        }
+      }
+    },
     "termsOfServiceTitle" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/Nos/Controller/PagedNoteDataSource.swift
+++ b/Nos/Controller/PagedNoteDataSource.swift
@@ -176,8 +176,7 @@ class PagedNoteDataSource<Header: View, EmptyPlaceholder: View>: NSObject, UICol
                         collectionView?.reloadData()
                         if let refreshControl {
                             // Dismiss the refresh control
-                            let deadline = DispatchTime.now() + .seconds(1)
-                            DispatchQueue.main.asyncAfter(deadline: deadline) {
+                            DispatchQueue.main.asyncAfter(deadline: .now() + .seconds(1)) {
                                 refreshControl.endRefreshing()
                             }
                         }

--- a/Nos/Views/Home/HomeFeedView.swift
+++ b/Nos/Views/Home/HomeFeedView.swift
@@ -77,7 +77,7 @@ struct HomeFeedView: View {
                         selectedStoryAuthor: $selectedStoryAuthor
                     )
                 },
-                emptyPlaceholder: {
+                emptyPlaceholder: { _ in
                     VStack {
                         Text(.localizable.noEvents)
                             .padding()

--- a/Nos/Views/Profile/ProfileView.swift
+++ b/Nos/Views/Profile/ProfileView.swift
@@ -83,21 +83,16 @@ struct ProfileView: View {
                             .compositingGroup()
                             .shadow(color: .profileShadow, radius: 10, x: 0, y: 4)
                     },
-                    emptyPlaceholder: {
+                    emptyPlaceholder: { refresh in
                         VStack {
                             Text(.localizable.noEventsOnProfile)
                                 .padding()
                                 .readabilityPadding()
                             
                             SecondaryActionButton(
-                                title: .localizable.tapToRefresh
-                            ) {
-                                NotificationCenter.default.post(
-                                    name: .refresh,
-                                    object: nil,
-                                    userInfo: ["tab": AppDestination.profile]
-                                )
-                            }
+                                title: .localizable.tapToRefresh,
+                                action: refresh
+                            )
                         }
                         .frame(minHeight: 300)
                     },

--- a/Nos/Views/Profile/ProfileView.swift
+++ b/Nos/Views/Profile/ProfileView.swift
@@ -88,6 +88,16 @@ struct ProfileView: View {
                             Text(.localizable.noEventsOnProfile)
                                 .padding()
                                 .readabilityPadding()
+                            
+                            SecondaryActionButton(
+                                title: .localizable.tapToRefresh
+                            ) {
+                                NotificationCenter.default.post(
+                                    name: .refresh,
+                                    object: nil,
+                                    userInfo: ["tab": AppDestination.profile]
+                                )
+                            }
                         }
                         .frame(minHeight: 300)
                     },


### PR DESCRIPTION
## Issues covered
#1068

## Description

Adds a Tap to Refresh button and refreshes the Profile when tapped. I used the same functions we use when pulling down to refresh. Also, the ticket specifically requires that the button shows the same loading indicator we show when the user pulls down to refresh.

## How to test
1. Navigate to your profile
2. Delete some posts if they are just a few (otherwise, you'll need to create a new profile)
3. Write a new post
4. See how that new post appears after tapping on "Tap to refresh"

## Screenshots/Video

![Simulator Screenshot - iPhone 15 - 2024-07-05 at 17 22 33](https://github.com/planetary-social/nos/assets/1703242/7d0b8a2e-71a1-4f3b-afd0-6e68952c000c)
