### PR TITLE
Add Cohort 4 to Discover tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Discover tab now features new accounts in News, Music, Activists, and Art.
 - Use NIP-05 for shared links to profile.
 
 ## [0.1.19] - 2024-07-01Z

--- a/Nos/Views/Discover/FeaturedAuthor.swift
+++ b/Nos/Views/Discover/FeaturedAuthor.swift
@@ -31,7 +31,7 @@ struct FeaturedAuthor {
 
 extension FeaturedAuthor {
     /// All featured authors that should appear on the Discover tab.
-    static let all = cohort3 + cohort2 + cohort1
+    static let all = cohort4 + cohort3 + cohort2 + cohort1
 }
 
 extension FeaturedAuthor {
@@ -166,6 +166,46 @@ extension FeaturedAuthor {
             name: "JSTR",
             npub: "npub1vpdlxsc8dr4m580d43vj4ka0e6wmstzzxhvcermllhh5m9ytnhdq6wnaem",
             categories: [.music]
+        ),
+    ]
+}
+
+extension FeaturedAuthor {
+    static let cohort4 = [
+        FeaturedAuthor(
+            name: "NDP Media",
+            npub: "npub1ks7de0smt2v3aytrdsfh927sgml3666459mj9ghd7tvg3t42x9gqyvwjqf",
+            categories: [.news]
+        ),
+        FeaturedAuthor(
+            name: "Revolution Z",
+            npub: "npub1j4sumq8pyplks5nhchyhzmw72dyemkyv2fv50vwau5fhf2qa7zusq3tlyh",
+            categories: [.news, .activists]
+        ),
+        FeaturedAuthor(
+            name: "Existing Sprinkles",
+            npub: "npub1f5kc2agn63ecv2ua4909z9ahgmr2x9263na36jh6r908ql0926jq3nvk2u",
+            categories: [.art]
+        ),
+        FeaturedAuthor(
+            name: "MuckRock",
+            npub: "npub1u5nfvj4dzzmrcf9n5kptl26w7kfhc4vml0ll8svvhrv5jz2es46sl0vv2r",
+            categories: [.news]
+        ),
+        FeaturedAuthor(
+            name: "ArchJourney",
+            npub: "npub1qhjxfxpjm7udr0agr6nuhuwf9383e4g9907g64r9hf6y4fh6t6uqpcp36k",
+            categories: [.art]
+        ),
+        FeaturedAuthor(
+            name: "Neigsendoig Cocules",
+            npub: "npub1372csjhjv35sxcqm90ca2d0cfxsl6xku7j6hhswynwdy9m7zl98scn950w",
+            categories: [.music]
+        ),
+        FeaturedAuthor(
+            name: "Lexie Bean",
+            npub: "npub1s8c5mk68qn0erxrx5waqz7xxk39x5xx2367879eqcv270tqs4tvsf5ewgf",
+            categories: [.activists]
         ),
     ]
 }

--- a/Nos/Views/Discover/FeaturedAuthorCategory.swift
+++ b/Nos/Views/Discover/FeaturedAuthorCategory.swift
@@ -37,7 +37,7 @@ enum FeaturedAuthorCategory: CaseIterable {
         case .all:
             FeaturedAuthor.all
         case .new:
-            FeaturedAuthor.cohort3
+            FeaturedAuthor.cohort4
         default:
             FeaturedAuthor.all.filter { $0.categories.contains(self) }
         }


### PR DESCRIPTION
## Issues covered
#1283 

## Description
Added new authors to the Discover tab.

## How to test
1. Navigate to Discover
2. Observe new authors in All, New, Music, News, Activists, and Art.

## Screenshots/Video
https://github.com/planetary-social/nos/assets/59564/4e163cf3-9cec-4a43-8ab2-4cd3fade509b
