### PR TITLE
Remove follower counts from the profile screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Removed follower count from profile screen.
 - Discover tab now features new accounts in News, Music, Activists, and Art.
 - Use NIP-05 for shared links to profile.
 

--- a/Nos/Assets/Localization/Localizable.xcstrings
+++ b/Nos/Assets/Localization/Localizable.xcstrings
@@ -4492,103 +4492,13 @@
         }
       }
     },
-    "followedByOneAndMore" : {
+    "followedByOneAndOthers" : {
       "extractionState" : "manual",
       "localizations" : {
-        "de" : {
-          "variations" : {
-            "plural" : {
-              "one" : {
-                "stringUnit" : {
-                  "state" : "new",
-                  "value" : "Followed by **%1@** and **%2ld other**"
-                }
-              },
-              "other" : {
-                "stringUnit" : {
-                  "state" : "needs_review",
-                  "value" : "Gefolgt von **%1@** und **%2ld anderen**"
-                }
-              }
-            }
-          }
-        },
         "en" : {
-          "variations" : {
-            "plural" : {
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "Followed by **%1$@** and **%2$lld other**"
-                }
-              },
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "Followed by **%1$@** and **%2$lld others**"
-                }
-              }
-            }
-          }
-        },
-        "fa" : {
-          "variations" : {
-            "plural" : {
-              "one" : {
-                "stringUnit" : {
-                  "state" : "new",
-                  "value" : "Followed by **%@** and **%lld other**"
-                }
-              },
-              "other" : {
-                "stringUnit" : {
-                  "state" : "needs_review",
-                  "value" : "دنبال شده توسط **%@** و **%lld** نفر دیگر"
-                }
-              }
-            }
-          }
-        },
-        "sv" : {
-          "variations" : {
-            "plural" : {
-              "one" : {
-                "stringUnit" : {
-                  "state" : "new",
-                  "value" : "Followed by **%@** and **%lld other**"
-                }
-              },
-              "other" : {
-                "stringUnit" : {
-                  "state" : "needs_review",
-                  "value" : "Följs av **%@** och **%lld andra**"
-                }
-              }
-            }
-          }
-        },
-        "zh-Hans" : {
-          "variations" : {
-            "plural" : {
-              "other" : {
-                "stringUnit" : {
-                  "state" : "needs_review",
-                  "value" : "被**%@**和**%lld个其他用户**关注"
-                }
-              }
-            }
-          }
-        },
-        "zh-Hant" : {
-          "variations" : {
-            "plural" : {
-              "other" : {
-                "stringUnit" : {
-                  "state" : "needs_review",
-                  "value" : "被**%@**和**%lld個其他用戶**關注"
-                }
-              }
-            }
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Followed by **%@** and others"
           }
         }
       }
@@ -4731,6 +4641,17 @@
                 }
               }
             }
+          }
+        }
+      }
+    },
+    "followedByTwoAndOthers" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Followed by **%1$@**, **%2$@** and others"
           }
         }
       }
@@ -6534,6 +6455,17 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "靜音用戶"
+          }
+        }
+      }
+    },
+    "mutualFriends" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mutual Friends"
           }
         }
       }

--- a/Nos/Views/Profile/ProfileKnownFollowersView.swift
+++ b/Nos/Views/Profile/ProfileKnownFollowersView.swift
@@ -27,20 +27,13 @@ struct ProfileKnownFollowersView: View {
                 if followers.count > 2 {
                     Text(
                         attributedText(
-                            from: .localizable.followedByTwoAndMore(
-                                first.safeName,
-                                second.safeName,
-                                followers.count - 2
-                            )
+                            from: .localizable.followedByTwoAndOthers(first.safeName, second.safeName)
                         )
                     )
                 } else {
                     Text(
                         attributedText(
-                            from: .localizable.followedByTwo(
-                                first.safeName,
-                                second.safeName
-                            )
+                            from: .localizable.followedByTwo(first.safeName, second.safeName)
                         )
                     )
                 }
@@ -49,18 +42,13 @@ struct ProfileKnownFollowersView: View {
                 if followers.count > 1 {
                     Text(
                         attributedText(
-                            from: .localizable.followedByOneAndMore(
-                                first.safeName,
-                                followers.count - 1
-                            )
+                            from: .localizable.followedByOneAndOthers(first.safeName)
                         )
                     )
                 } else {
                     Text(
                         attributedText(
-                            from: .localizable.followedByOne(
-                                first.safeName
-                            )
+                            from: .localizable.followedByOne(first.safeName)
                         )
                     )
                 }

--- a/Nos/Views/Profile/ProfileView.swift
+++ b/Nos/Views/Profile/ProfileView.swift
@@ -115,7 +115,7 @@ struct ProfileView: View {
             FollowsView(title: .localizable.follows, authors: destination.follows)
         }
         .navigationDestination(for: FollowersDestination.self) { destination in
-            FollowsView(title: .localizable.followers, authors: destination.followers)
+            FollowsView(title: .localizable.mutualFriends, authors: destination.followers)
         }
         .navigationDestination(for: RelaysDestination.self) { destination in
             RelayView(author: destination.author, editable: false)


### PR DESCRIPTION
## Issues covered
This is a followup to #998.

## Description
@setch-l asked me to make this quick change because users are still misinterpreting the "known followers" list as a full count of followers.

## How to test
1. Navigate to the profile screen
2. Verify that we don't display a count of followers any more.

## Screenshots/Video
| Before          | After |
| ------------- | ------------- |
|  ![Screenshot 2024-07-09 at 3 46 20 PM](https://github.com/planetary-social/nos/assets/1165004/07171d96-6235-4a11-ba74-dc2417faa11c) | ![Screenshot 2024-07-09 at 3 46 02 PM](https://github.com/planetary-social/nos/assets/1165004/9e8fb610-2b16-4bc3-86cd-6d8b3826cf1a) |
