### PR TITLE
NIP 56 mapping changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Add impersonation flag category and better NIP-56 mapping.
 - Discover tab now features new accounts in News, Music, Activists, and Art.
 - Use NIP-05 for shared links to profile.
 

--- a/Nos/Models/ReportCategory.swift
+++ b/Nos/Models/ReportCategory.swift
@@ -157,7 +157,7 @@ extension ReportCategoryType {
     static let authorCategories = [
         ReportCategoryType.spam,
         ReportCategoryType.harassment,
-        ReportCategoryType.nsfw,
+        ReportCategoryType.nudity,
         ReportCategoryType.illegal,
         ReportCategoryType.impersonation,
         ReportCategoryType.other,

--- a/Nos/Models/ReportCategory.swift
+++ b/Nos/Models/ReportCategory.swift
@@ -42,7 +42,7 @@ struct ReportCategory: Identifiable, Equatable {
 }
 
 enum NIP56Code: String {
-    case nudity, profanity, illegal, spam, impersonation, other
+    case nudity, malware, profanity, illegal, spam, impersonation, other
 }
 
 enum ReportCategoryType {
@@ -61,7 +61,7 @@ enum ReportCategoryType {
     static let harassment = ReportCategory(
         name: .moderation.harassment,
         code: "IL-har",
-        nip56Code: .other
+        nip56Code: .profanity
     )
 
     static let intoleranceAndHate = ReportCategory(
@@ -89,7 +89,13 @@ enum ReportCategoryType {
     static let nsfw = ReportCategory(
         name: .moderation.nsfw,
         code: "NW",
-        nip56Code: .other
+        nip56Code: .nudity
+    )
+    
+    static let impersonation = ReportCategory(
+        name: .moderation.impersonation,
+        code: "IM",
+        nip56Code: .impersonation
     )
 
     static let nudity = ReportCategory(
@@ -138,6 +144,7 @@ extension ReportCategoryType {
         ReportCategoryType.likelyToCauseHarm,
         ReportCategoryType.harassment,
         ReportCategoryType.intoleranceAndHate,
+        ReportCategoryType.impersonation,
         ReportCategoryType.illegal,
         ReportCategoryType.nsfw,
         ReportCategoryType.nudity,
@@ -152,6 +159,7 @@ extension ReportCategoryType {
         ReportCategoryType.harassment,
         ReportCategoryType.nsfw,
         ReportCategoryType.illegal,
+        ReportCategoryType.impersonation,
         ReportCategoryType.other,
     ]
 

--- a/Nos/Service/ReportPublisher.swift
+++ b/Nos/Service/ReportPublisher.swift
@@ -83,10 +83,7 @@ class ReportPublisher {
         var event = JSONEvent(
             pubKey: pubKey,
             kind: .report,
-            tags: [
-                ["L", "MOD"],
-                ["l", "MOD>\(category.code)", "MOD"]
-            ],
+            tags: [],
             content: String(localized: .localizable.reportEventContent(category.displayName))
         )
         

--- a/Nos/Views/PreviewData.swift
+++ b/Nos/Views/PreviewData.swift
@@ -322,8 +322,8 @@ struct PreviewData {
         note.kind = EventKind.report.rawValue
         note.content = "this person is spammy"
         note.allTags = [
-            [ "p", "6b165e83a3b7d333a6e7db1f200dc627e31eb5170285c29ded271be203c5da37", "other" ],
-            [ "e", "ad0cea87d9c81e3bc5b15ddf561b1a2bbbff3d8318d4ea9ccd4644def9e035b8", "other" ],
+            [ "p", "6b165e83a3b7d333a6e7db1f200dc627e31eb5170285c29ded271be203c5da37", "spam" ],
+            [ "e", "ad0cea87d9c81e3bc5b15ddf561b1a2bbbff3d8318d4ea9ccd4644def9e035b8", "spam" ],
         ] as NSObject
         note.author = alice
         note.createdAt = .now

--- a/Nos/Views/PreviewData.swift
+++ b/Nos/Views/PreviewData.swift
@@ -324,8 +324,6 @@ struct PreviewData {
         note.allTags = [
             [ "p", "6b165e83a3b7d333a6e7db1f200dc627e31eb5170285c29ded271be203c5da37", "other" ],
             [ "e", "ad0cea87d9c81e3bc5b15ddf561b1a2bbbff3d8318d4ea9ccd4644def9e035b8", "other" ],
-            [ "L", "MOD" ],
-            [ "l", "MOD>SP", "MOD", "{\"confidence\":0.9876784682273865}" ]
         ] as NSObject
         note.author = alice
         note.createdAt = .now

--- a/NosTests/Model/ReportTests.swift
+++ b/NosTests/Model/ReportTests.swift
@@ -5,11 +5,7 @@ final class ReportTests: XCTestCase {
     func testFindCategory() throws {
         XCTAssertEqual(
             ReportCategory.findCategory(from: "PN"),
-            ReportCategoryType.allCategories[7]
-        )
-        XCTAssertEqual(
-            ReportCategory.findCategory(from: "VI-hum"),
-            ReportCategoryType.allCategories[9].subCategories![0]
+            ReportCategoryType.allCategories[8]
         )
     }
 }

--- a/NosTests/Service/ReportPublisherTests.swift
+++ b/NosTests/Service/ReportPublisherTests.swift
@@ -17,8 +17,6 @@ final class ReportPublisherTests: CoreDataTestCase {
         XCTAssertEqual(publicReport.kind, EventKind.report.rawValue)
         XCTAssertEqual(publicReport.pubKey, aliceKeyPair.publicKeyHex)
         XCTAssertEqual(publicReport.tags, [
-            ["L", "MOD"],
-            ["l", "MOD>CL", "MOD"],
             ["e", note.identifier!, "profanity"],
             ["p", bobKeyPair.publicKeyHex]
         ])


### PR DESCRIPTION
## Issues covered
https://github.com/planetary-social/nos/issues/1247

## Description
To correctly map with the new changes for the manual moderation channel in Slack we are tweaking how we map some categories and adding `impersonation`

## How to test

- [x] 1. Get https://github.com/planetary-social/reportinator_server/pull/44 and https://github.com/planetary-social/cleanstr/pull/50 merged
- [ ] 2. Ensure each option for all `Send To Nos` categories appear in the Slack channel message

## Screenshots/Video
<img width="397" alt="Screenshot 2024-07-10 at 1 52 04 PM" src="https://github.com/planetary-social/nos/assets/18184/085262df-2255-4359-bbda-bfd80e9e9b3e">

