### PR TITLE
Fix links to nprofiles and nevents in notes, and deep linking of all kinds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - Fixed deep linking to profiles and notes.
-- Fixed issue where some nostrr:nprofile references did not appear as links.
+- Fixed issue where some nostr:nprofile references did not appear as links.
 - Decode nprofile, nevent, and naddr NIP-19 entities.
 
 ## [0.1.20] - 2024-07-10Z

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Fixed deep linking to profiles and notes.
+- Fixed issue where some nostrr:nprofile references did not appear as links.
+
 ## [0.1.20] - 2024-07-10Z
 
 - Discover tab now features new accounts in News, Music, Activists, and Art.

--- a/Nos/Models/NoteParser.swift
+++ b/Nos/Models/NoteParser.swift
@@ -94,8 +94,8 @@ struct NoteParser {
             } else if let npubOrNProfile {
                 let string = String(npubOrNProfile)
                 do {
-                    let entity = try NostrEntity.decode(bech32String: string)
-                    switch entity {
+                    let metadata = try NostrMetadata.decode(bech32String: string)
+                    switch metadata {
                     case .npub(let rawAuthorID), .nprofile(let rawAuthorID, _):
                         return findAndReplaceAuthorReference(rawAuthorID)
                     default:
@@ -129,8 +129,8 @@ struct NoteParser {
             let string = String(entity)
 
             do {
-                let nostrEntity = try NostrEntity.decode(bech32String: string)
-                switch nostrEntity {
+                let metadata = try NostrMetadata.decode(bech32String: string)
+                switch metadata {
                 case .npub(let rawAuthorID), .nprofile(let rawAuthorID, _):
                     return "\(prefix)[\(string)](@\(rawAuthorID))"
                 case .note(let rawEventID), .nevent(let rawEventID, _, _, _):

--- a/Nos/Models/NoteParser.swift
+++ b/Nos/Models/NoteParser.swift
@@ -114,7 +114,7 @@ struct NoteParser {
     /// Replaces Nostr entities embedded in the note (without a proper tag) with markdown links
     private func replaceNostrEntities(in content: String) -> String {
         // swiftlint:disable:next opening_brace
-        let unformattedRegex = /(?:^|\s)@?(?:nostr:)?(?<entity>((npub1|note1|nprofile1|nevent1)[a-zA-Z0-9]{58,}))/ // TODO: where'd we get the 58? is that right?
+        let unformattedRegex = /(?:^|\s)@?(?:nostr:)?(?<entity>((npub1|note1|nprofile1|nevent1)[a-zA-Z0-9]{58,}))/
 
         return content.replacing(unformattedRegex) { match in
             let substring = match.0

--- a/Nos/Models/NoteParser.swift
+++ b/Nos/Models/NoteParser.swift
@@ -93,8 +93,8 @@ struct NoteParser {
             } else if let npubOrNProfile {
                 let string = String(npubOrNProfile)
                 do {
-                    let metadata = try NostrMetadata.decode(bech32String: string)
-                    switch metadata {
+                    let identifier = try NostrIdentifier.decode(bech32String: string)
+                    switch identifier {
                     case .npub(let rawAuthorID), .nprofile(let rawAuthorID, _):
                         return findAndReplaceAuthorReference(rawAuthorID)
                     default:
@@ -127,8 +127,8 @@ struct NoteParser {
             let string = String(entity)
 
             do {
-                let metadata = try NostrMetadata.decode(bech32String: string)
-                switch metadata {
+                let identifier = try NostrIdentifier.decode(bech32String: string)
+                switch identifier {
                 case .npub(let rawAuthorID), .nprofile(let rawAuthorID, _):
                     return "\(prefix)[\(string)](@\(rawAuthorID))"
                 case .note(let rawEventID), .nevent(let rawEventID, _, _, _):

--- a/Nos/Models/NoteParser.swift
+++ b/Nos/Models/NoteParser.swift
@@ -45,16 +45,15 @@ struct NoteParser {
         }
     }
 
-    // swiftlint:disable function_body_length superfluous_disable_command
+    // swiftlint:disable function_body_length
     /// Replaces tagged references like #[0] or nostr:npub1... with markdown links
     private func replaceTaggedNostrEntities(
         in content: String,
         tags: [[String]],
         context: NSManagedObjectContext
     ) -> String {
-        // swiftlint:disable opening_brace operator_usage_whitespace closure_spacing comma
+        // swiftlint:disable:next opening_brace
         let regex = /(?:^|\s)#\[(?<index>\d+)\]|(?:^|\s)@?(?:nostr:)(?<npubornprofile>[a-zA-Z0-9]{2,256})/
-        // swiftlint:enable opening_brace operator_usage_whitespace closure_spacing comma
         return content.replacing(regex) { match in
             let substring = match.0
             let index = match.1
@@ -110,13 +109,12 @@ struct NoteParser {
             return String(substring)
         }
     }
-    // swiftlint:enable function_body_length superfluous_disable_command
+    // swiftlint:enable function_body_length
 
     /// Replaces Nostr entities embedded in the note (without a proper tag) with markdown links
     private func replaceNostrEntities(in content: String) -> String {
-        // swiftlint:disable opening_brace operator_usage_whitespace closure_spacing comma superfluous_disable_command
+        // swiftlint:disable:next opening_brace
         let unformattedRegex = /(?:^|\s)@?(?:nostr:)?(?<entity>((npub1|note1|nprofile1|nevent1)[a-zA-Z0-9]{58,}))/ // TODO: where'd we get the 58? is that right?
-        // swiftlint:enable opening_brace operator_usage_whitespace closure_spacing comma superfluous_disable_command
 
         return content.replacing(unformattedRegex) { match in
             let substring = match.0

--- a/Nos/Service/DeepLinkService.swift
+++ b/Nos/Service/DeepLinkService.swift
@@ -48,8 +48,8 @@ enum DeepLinkService {
                     let entity = match.1
                     let string = String(entity)
 
-                    let metadata = try NostrMetadata.decode(bech32String: string)
-                    switch metadata {
+                    let identifier = try NostrIdentifier.decode(bech32String: string)
+                    switch identifier {
                     case .npub(let rawAuthorID), .nprofile(let rawAuthorID, _):
                         router.pushAuthor(id: rawAuthorID)
                     case .note(let rawEventID), .nevent(let rawEventID, _, _, _):

--- a/Nos/Service/DeepLinkService.swift
+++ b/Nos/Service/DeepLinkService.swift
@@ -37,25 +37,26 @@ enum DeepLinkService {
             router.showNewNoteView(contents: noteContents)
         } else {
             /// Check for links like nos:nevent123174
-            let firstPathComponent = components.path
-            // swiftlint:disable:next opening_brace 
-            let unformattedRegex = /(?:nostr:)?(?<entity>((npub1|note1|nprofile1|nevent1)[a-zA-Z0-9]{58,255}))/
+            guard let host = components.host else {
+                Log.debug("No host in `nos:` deep link; cannot open. URLComponents: \(components)")
+                return
+            }
+            // swiftlint:disable:next opening_brace
+            let unformattedRegex = /(?:nostr:)?(?<entity>((npub1|note1|nprofile1|nevent1)[a-zA-Z0-9]{58,}))/
             do {
-                if let match = try unformattedRegex.firstMatch(in: firstPathComponent) {
+                if let match = try unformattedRegex.firstMatch(in: host) {
                     let entity = match.1
                     let string = String(entity)
-                    
-                    let (humanReadablePart, checksum) = try Bech32.decode(string)
-                    
-                    if humanReadablePart == Nostr.publicKeyPrefix, let hex = SHA256Key.decode(base5: checksum) {
-                        router.pushAuthor(id: hex)
-                    } else if humanReadablePart == Nostr.notePrefix, let hex = SHA256Key.decode(base5: checksum) {
-                        router.pushNote(id: hex)
-                    } else if humanReadablePart == Nostr.profilePrefix, let hex = TLV.decode(checksum: checksum) {
-                        router.pushAuthor(id: hex)
-                    } else if humanReadablePart == Nostr.eventPrefix, let hex = TLV.decode(checksum: checksum) {
-                        router.pushNote(id: hex)
-                    } 
+
+                    let metadata = try NostrMetadata.decode(bech32String: string)
+                    switch metadata {
+                    case .npub(let rawAuthorID), .nprofile(let rawAuthorID, _):
+                        router.pushAuthor(id: rawAuthorID)
+                    case .note(let rawEventID), .nevent(let rawEventID, _, _, _):
+                        router.pushNote(id: rawEventID)
+                    case .naddr:
+                        break
+                    }
                 }
             } catch {
                 Log.optional(error)


### PR DESCRIPTION
## Issues covered
#1234
#1231 
#1295 

## Description
This fixes issues with nprofiles and nevents:
- Fixes the issue with some nprofile references by removing the upper limit in the regex (#1234)
- Fixes the issue with some nevent references by removing the upper limit in the regex (#1231)
- Fixes deep linking to a nprofile or nevent (or npub or note) (#1295)

It also replaces older Bech32 decoding with NostrIdentifier decoding.

## How to test

### Linking to an nprofile in a note
1. Navigate to Discover
2. Tap search
3. Paste note1ar8gnwj6ugxyq6w9aqur74s2sn4dttk6zx0d25p34fsg476kqrksmkqqnr
4. Observe note

Expected: the note should have a link at the beginning which will take the user to the profile for brugeman.

You can also test the following notes that should link to a profile:

- note1alva8prc6ae0r973erz25fg5pcdfs8pq5gnfhzefvylf6zzv2vvsys344q
- note1w6u6stxxvr78lat6d9sknsac0jnpj7ylpm6sfjxgmg7euulpczyq5asrw2

### Linking to an nevent in a note

1. Navigate to Discover
2. Tap search
3. Paste note1qq7am022xm40yrj9k4agcfqwre4lflsq6mytky0suxunrk7ldf5sjwth8x
4. Observe note

Expected: the note from fiatjaf should have a _link_ to a note by 0xtr. Previously it just displayed plain text of the nevent string.

You can also test the following notes that should show the "🔗 Link to note":

- note1ypppzcue3svj2p0l80vp4lf52j3xmykn8yzjdv3gnq2sm4ljp5qqrqp9hd
- note16fddcyxfldwre2zywr96fnkmk7n3rtf4ehntdwy8ltyqgfntwfnq0dm347

### Deep linking to notes and profiles
See #1295 for details on testing deep links. But I suppose I'll reproduce the good parts here. These should all link to something in the Dev version of the app; for Staging, replace `nos-dev:` with `nos-staging:` (or just go to the issue and get the staging links there):

- nos-dev://npub1qfn650vj62j8ntttenwxlem9wqmaa26tw75thn7nvcasamceddvqy2zdu4
- nos-dev://note1w6u6stxxvr78lat6d9sknsac0jnpj7ylpm6sfjxgmg7euulpczyq5asrw2
- nos-dev://nprofile1qqsrhuxx8l9ex335q7he0f09aej04zpazpl0ne2cgukyawd24mayt8gpp4mhxue69uhhytnc9e3k7mgpz4mhxue69uhkg6nzv9ejuumpv34kytnrdaksjlyr9p

I'm not sure what's up with nevents, but they don't work for me. I'm not concerned since this isn't a high-priority issue.

## Screenshots/Video

### Linking to an nprofile
| Before | After |
|--------|--------|
| <img width="627" alt="Screenshot 2024-07-10 at 1 48 29 PM" src="https://github.com/planetary-social/nos/assets/59564/955ce9d9-fb35-4529-87af-ac751aa7ed89"> | <img width="627" alt="Screenshot 2024-07-10 at 1 48 01 PM" src="https://github.com/planetary-social/nos/assets/59564/e9e72f1f-75ed-4788-a157-a29ce6103b07"> | 

### Linking to an nevent
| Before | After |
|--------|--------|
| ![Simulator Screenshot - iPhone 15 Pro - 2024-07-11 at 13 17 22](https://github.com/planetary-social/nos/assets/59564/ddc3464a-99ac-4ca7-9c41-3ec9440a9610) | ![Simulator Screenshot - iPhone 15 Pro - 2024-07-11 at 13 16 29](https://github.com/planetary-social/nos/assets/59564/b7e1ff2f-0082-4d1f-b282-5bc96ca80214) |

### Deep linking

https://github.com/planetary-social/nos/assets/59564/0a731932-6d2a-459b-897e-d351f0f26f28

