### PR TITLE
Fix HomeFeedView Previews

### DIFF
--- a/Nos.xcodeproj/project.pbxproj
+++ b/Nos.xcodeproj/project.pbxproj
@@ -149,10 +149,10 @@
 		A336DD3C299FD78000A0CBA0 /* Filter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A336DD3B299FD78000A0CBA0 /* Filter.swift */; };
 		A34E439929A522F20057AFCB /* CurrentUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = A34E439829A522F20057AFCB /* CurrentUser.swift */; };
 		A351E1A229BA92240009B7F6 /* ProfileEditView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A351E1A129BA92240009B7F6 /* ProfileEditView.swift */; };
-		A3B943CF299AE00100A15A08 /* KeyChain.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3B943CE299AE00100A15A08 /* KeyChain.swift */; };
+		A3B943CF299AE00100A15A08 /* Keychain.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3B943CE299AE00100A15A08 /* Keychain.swift */; };
 		A3B943D5299D514800A15A08 /* Follow+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3B943D4299D514800A15A08 /* Follow+CoreDataClass.swift */; };
 		A3B943D7299D6DB700A15A08 /* Follow+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3B943D4299D514800A15A08 /* Follow+CoreDataClass.swift */; };
-		A3B943D8299D758F00A15A08 /* KeyChain.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3B943CE299AE00100A15A08 /* KeyChain.swift */; };
+		A3B943D8299D758F00A15A08 /* Keychain.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3B943CE299AE00100A15A08 /* Keychain.swift */; };
 		C9032C2E2BAE31ED001F4EC6 /* ProfileFeedType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9032C2D2BAE31ED001F4EC6 /* ProfileFeedType.swift */; };
 		C90352BA2C1235CD000A5993 /* NosNavigationDestination.swift in Sources */ = {isa = PBXBuildFile; fileRef = C90352B92C1235CD000A5993 /* NosNavigationDestination.swift */; };
 		C90352BB2C1235CD000A5993 /* NosNavigationDestination.swift in Sources */ = {isa = PBXBuildFile; fileRef = C90352B92C1235CD000A5993 /* NosNavigationDestination.swift */; };
@@ -617,7 +617,7 @@
 		A336DD3B299FD78000A0CBA0 /* Filter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Filter.swift; sourceTree = "<group>"; };
 		A34E439829A522F20057AFCB /* CurrentUser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentUser.swift; sourceTree = "<group>"; };
 		A351E1A129BA92240009B7F6 /* ProfileEditView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProfileEditView.swift; sourceTree = "<group>"; };
-		A3B943CE299AE00100A15A08 /* KeyChain.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyChain.swift; sourceTree = "<group>"; };
+		A3B943CE299AE00100A15A08 /* Keychain.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Keychain.swift; sourceTree = "<group>"; };
 		A3B943D4299D514800A15A08 /* Follow+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Follow+CoreDataClass.swift"; sourceTree = "<group>"; };
 		C9032C2D2BAE31ED001F4EC6 /* ProfileFeedType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileFeedType.swift; sourceTree = "<group>"; };
 		C90352B92C1235CD000A5993 /* NosNavigationDestination.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NosNavigationDestination.swift; sourceTree = "<group>"; };
@@ -1181,7 +1181,7 @@
 				C9BAB09A2996FBA10003A84E /* EventProcessor.swift */,
 				0350F12C2C0A7EF20024CC15 /* FeatureFlags.swift */,
 				C959DB752BD01DF4008F3627 /* GiftWrapper.swift */,
-				A3B943CE299AE00100A15A08 /* KeyChain.swift */,
+				A3B943CE299AE00100A15A08 /* Keychain.swift */,
 				C9F64D8B29ED840700563F2B /* Zipper.swift */,
 				C9EF84CE2C24D63000182B6F /* MockRelayService.swift */,
 				0320C1142BFE63DC00C4C080 /* MockRelaySubscriptionManager.swift */,
@@ -1973,7 +1973,7 @@
 				C94D6D5C2AC5D14400F0F11E /* WizardTextField.swift in Sources */,
 				3FB5E651299D28A200386527 /* OnboardingView.swift in Sources */,
 				C973AB5F2A323167002AED16 /* AuthorReference+CoreDataProperties.swift in Sources */,
-				A3B943CF299AE00100A15A08 /* KeyChain.swift in Sources */,
+				A3B943CF299AE00100A15A08 /* Keychain.swift in Sources */,
 				C9671D73298DB94C00EE7E12 /* Data+Encoding.swift in Sources */,
 				C9646EA129B7A22C007239A4 /* Analytics.swift in Sources */,
 				C9A6C74B2AD866A7001F9500 /* UNSSuccessView.swift in Sources */,
@@ -2207,7 +2207,7 @@
 				C9F84C1D298DBC6100C6714D /* Data+Sha.swift in Sources */,
 				C9F0BB7029A50437000547FC /* NostrConstants.swift in Sources */,
 				03B4E6AF2C125D61006E5F59 /* FileStorageUploadResponseJSON.swift in Sources */,
-				A3B943D8299D758F00A15A08 /* KeyChain.swift in Sources */,
+				A3B943D8299D758F00A15A08 /* Keychain.swift in Sources */,
 				035729B92BE416A6005FEE85 /* GiftWrapperTests.swift in Sources */,
 				032634702C10C40B00E489B5 /* NostrBuildAPIClientTests.swift in Sources */,
 				C9646EAA29B7A506007239A4 /* Analytics.swift in Sources */,

--- a/Nos/Service/CurrentUser.swift
+++ b/Nos/Service/CurrentUser.swift
@@ -12,6 +12,7 @@ import Dependencies
     @ObservationIgnored @Dependency(\.pushNotificationService) private var pushNotificationService
     @ObservationIgnored @Dependency(\.relayService) private var relayService
     @ObservationIgnored @Dependency(\.unsAPI) private var unsAPI
+    @ObservationIgnored @Dependency(\.keychain) private var keychain
     
     // TODO: it's time to cache this
     var keyPair: KeyPair? {
@@ -33,7 +34,7 @@ import Dependencies
     
     @MainActor func setPrivateKeyHex(_ newValue: String?) async {
         guard let privateKeyHex = newValue else {
-            let publicStatus = KeyChain.delete(key: KeyChain.keychainPrivateKey)
+            let publicStatus = keychain.delete(key: keychain.keychainPrivateKey)
             _privateKeyHex = nil
             reset()
             print("Deleted private key from keychain with status: \(publicStatus)")
@@ -46,7 +47,7 @@ import Dependencies
         }
         
         let privateKeyData = Data(privateKeyHex.utf8)
-        let status = KeyChain.save(key: KeyChain.keychainPrivateKey, data: privateKeyData)
+        let status = keychain.save(key: keychain.keychainPrivateKey, data: privateKeyData)
         let hex = keyPair.publicKeyHex
         let npub = keyPair.npub
         Log.info("Saved private key to keychain for user: " + "\(hex) / \(npub). Keychain storage status: \(status)")
@@ -81,7 +82,7 @@ import Dependencies
         self.viewContext = persistenceController.viewContext
         self.backgroundContext = persistenceController.newBackgroundContext()
         self.socialGraph = SocialGraphCache(userKey: nil, context: persistenceController.newBackgroundContext())
-        if let privateKeyData = KeyChain.load(key: KeyChain.keychainPrivateKey) {
+        if let privateKeyData = keychain.load(key: keychain.keychainPrivateKey) {
             Log.info("CurrentUser loaded a private key from keychain")
             let hexString = String(decoding: privateKeyData, as: UTF8.self)
             _privateKeyHex = hexString

--- a/Nos/Service/DependencyInjection.swift
+++ b/Nos/Service/DependencyInjection.swift
@@ -172,7 +172,7 @@ fileprivate enum FeatureFlagsKey: DependencyKey {
 }
 
 fileprivate enum KeychainKey: DependencyKey {
-    @MainActor static let liveValue = Keychain()
-    @MainActor static let testValue: Keychain = MockKeychain()
-    @MainActor static let previewValue: Keychain = MockKeychain()
+    @MainActor static let liveValue: Keychain = SystemKeychain()
+    @MainActor static let testValue: Keychain = InMemoryKeychain()
+    @MainActor static let previewValue: Keychain = InMemoryKeychain()
 }

--- a/Nos/Service/DependencyInjection.swift
+++ b/Nos/Service/DependencyInjection.swift
@@ -79,6 +79,11 @@ extension DependencyValues {
         get { self[FeatureFlagsKey.self] }
         set { self[FeatureFlagsKey.self] = newValue }
     }
+        
+    var keychain: Keychain {
+        get { self[KeychainKey.self] }
+        set { self[KeychainKey.self] = newValue }
+    }
 }
 
 fileprivate enum AnalyticsKey: DependencyKey {
@@ -164,4 +169,10 @@ fileprivate enum FeatureFlagsKey: DependencyKey {
     static let liveValue: any FeatureFlags = DefaultFeatureFlags.liveValue
     static let testValue: any FeatureFlags = MockFeatureFlags()
     static let previewValue: any FeatureFlags = MockFeatureFlags()
+}
+
+fileprivate enum KeychainKey: DependencyKey {
+    @MainActor static let liveValue = Keychain()
+    @MainActor static let testValue: Keychain = MockKeychain()
+    @MainActor static let previewValue: Keychain = MockKeychain()
 }

--- a/Nos/Service/Keychain.swift
+++ b/Nos/Service/Keychain.swift
@@ -1,8 +1,18 @@
 import Security
 import UIKit
 
+@MainActor protocol Keychain {
+    
+    var keychainPrivateKey: String { get }
+    
+    func save(key: String, data: Data) -> OSStatus 
+    func load(key: String) -> Data? 
+    func delete(key: String) -> OSStatus 
+}
+
 /// Don't use this outside CurrentUser
-@MainActor class Keychain {
+class SystemKeychain: Keychain {
+    
     let keychainPrivateKey = "privateKey"
         
     @discardableResult
@@ -51,20 +61,22 @@ import UIKit
     }
 }
 
-class MockKeychain: Keychain {
+class InMemoryKeychain: Keychain {
     
-    var keychain = [String: Data]()
+    let keychainPrivateKey = "privateKey"
     
-    override func save(key: String, data: Data) -> OSStatus {
+    private var keychain = [String: Data]()
+    
+    func save(key: String, data: Data) -> OSStatus {
         keychain[key] = data
         return 0
     }
     
-    override func load(key: String) -> Data? {
+    func load(key: String) -> Data? {
         keychain[key]
     }
     
-    override func delete(key: String) -> OSStatus {
+    func delete(key: String) -> OSStatus {
         keychain.removeValue(forKey: key)
         return 0
     }

--- a/Nos/Service/Keychain.swift
+++ b/Nos/Service/Keychain.swift
@@ -2,11 +2,11 @@ import Security
 import UIKit
 
 /// Don't use this outside CurrentUser
-enum KeyChain {
-    static let keychainPrivateKey = "privateKey"
+@MainActor class Keychain {
+    let keychainPrivateKey = "privateKey"
         
     @discardableResult
-    static func save(key: String, data: Data) -> OSStatus {
+    func save(key: String, data: Data) -> OSStatus {
         let query =
 		[
             kSecClass as String: kSecClassGenericPassword as String,
@@ -20,7 +20,7 @@ enum KeyChain {
         return SecItemAdd(query as CFDictionary, nil)
     }
     
-	static func load(key: String) -> Data? {
+	func load(key: String) -> Data? {
         let query =
 		[
             kSecClass as String: kSecClassGenericPassword,
@@ -40,7 +40,7 @@ enum KeyChain {
         }
     }
     
-    static func delete(key: String) -> OSStatus {
+    func delete(key: String) -> OSStatus {
         let query =
         [
             kSecClass as String: kSecClassGenericPassword as String,
@@ -48,5 +48,24 @@ enum KeyChain {
         ] as [String: Any]
         
         return SecItemDelete(query as CFDictionary)
+    }
+}
+
+class MockKeychain: Keychain {
+    
+    var keychain = [String: Data]()
+    
+    override func save(key: String, data: Data) -> OSStatus {
+        keychain[key] = data
+        return 0
+    }
+    
+    override func load(key: String) -> Data? {
+        keychain[key]
+    }
+    
+    override func delete(key: String) -> OSStatus {
+        keychain.removeValue(forKey: key)
+        return 0
     }
 }

--- a/Nos/Views/FollowButton.swift
+++ b/Nos/Views/FollowButton.swift
@@ -84,7 +84,6 @@ struct FollowButton_Previews: PreviewProvider {
         follow.destination = alice
         user.follows = Set([follow])
         try? previewContext.save()
-        KeyChain.save(key: KeyChain.keychainPrivateKey, data: Data(KeyFixture.privateKeyHex.utf8))
     }
     
     static var previews: some View {

--- a/Nos/Views/Home/HomeFeedView.swift
+++ b/Nos/Views/Home/HomeFeedView.swift
@@ -188,57 +188,14 @@ struct HomeFeedView: View {
     }
 }
 
-struct ContentView_Previews: PreviewProvider {
+#Preview {
+    var previewData = PreviewData()
     
-    static var previewData = PreviewData()
-    static var persistenceController = PersistenceController.preview
-    static var previewContext = persistenceController.container.viewContext
-    static var relayService = previewData.relayService
-    
-    static var emptyPersistenceController = PersistenceController.empty
-    static var emptyPreviewContext = emptyPersistenceController.container.viewContext
-    static var emptyRelayService = previewData.relayService
-    
-    static var router = Router()
-    
-    static var currentUser = previewData.currentUser
-    
-    static var shortNote: Event {
-        let note = Event(context: previewContext)
-        note.identifier = "p1"
-        note.kind = 1
-        note.content = "Hello, world!"
-        note.author = currentUser.author
-        return note
+    return NavigationStack {
+        HomeFeedView(user: previewData.alice)
     }
-    
-    static var longNote: Event {
-        let note = Event(context: previewContext)
-        note.identifier = "p2"
-        note.kind = 1
-        note.content = .loremIpsum(5)
-        note.author = currentUser.author
-        return note
-    }
-    
-    static var user: Author {
-        let author = Author(context: previewContext)
-        author.hexadecimalPublicKey = "d0a1ffb8761b974cec4a3be8cbcb2e96a7090dcf465ffeac839aa4ca20c9a59e"
-        return author
-    }
-    
-    static var previews: some View {
-        HomeFeedView(user: user)
-            .inject(previewData: previewData)
-            .onAppear {
-                print(shortNote)
-                print(longNote)
-            }
-        
-        HomeFeedView(user: user)
-            .environment(\.managedObjectContext, emptyPreviewContext)
-            .environmentObject(emptyRelayService)
-            .environmentObject(router)
-            .environment(currentUser)
+    .inject(previewData: previewData)
+    .onAppear {
+        _ = previewData.shortNote
     }
 }

--- a/Nos/Views/PreviewData.swift
+++ b/Nos/Views/PreviewData.swift
@@ -12,24 +12,25 @@ import CoreData
 /// and inject it into the view using the `inject(previewData:)` view modifier.
 struct PreviewData {
     
+    let currentUserKey: KeyPair 
+    
+    init(currentUserKey: KeyPair = KeyFixture.keyPair) {
+        self.currentUserKey = currentUserKey
+        Task { [currentUser] in
+            await currentUser.setPrivateKeyHex(currentUserKey.privateKeyHex)
+        }
+    }
+    
     // MARK: - Environment
     @Dependency(\.persistenceController) var persistenceController 
     @Dependency(\.router) var router
     @Dependency(\.relayService) var relayService
+    @Dependency(\.currentUser) var currentUser
     
     lazy var previewContext: NSManagedObjectContext = {
         persistenceController.container.viewContext  
     }()
     
-    // MARK: - User
-
-    @MainActor lazy var currentUser: CurrentUser = {
-        let currentUser = CurrentUser()
-        currentUser.viewContext = previewContext
-        Task { await currentUser.setKeyPair(KeyFixture.keyPair) }
-        return currentUser
-    }()
-
     // MARK: - Authors
     
     lazy var previewAuthor: Author = {

--- a/Nos/Views/Profile/ProfileView.swift
+++ b/Nos/Views/Profile/ProfileView.swift
@@ -235,15 +235,8 @@ struct ProfileView: View {
     lazy var previewContext: NSManagedObjectContext = {
         persistenceController.container.viewContext  
     }()
-
-    lazy var currentUser: CurrentUser = {
-        let currentUser = CurrentUser()
-        currentUser.viewContext = previewContext
-        Task { await currentUser.setKeyPair(KeyFixture.eve) }
-        return currentUser
-    }() 
     
-    var previewData = PreviewData(currentUser: currentUser)
+    var previewData = PreviewData(currentUserKey: KeyFixture.eve)
     
     return NavigationStack {
         ProfileView(author: previewData.eve)

--- a/Nos/Views/RepliesView.swift
+++ b/Nos/Views/RepliesView.swift
@@ -164,12 +164,8 @@ struct RepliesView: View {
 }
 struct RepliesView_Previews: PreviewProvider {
     
-    static var previewData = PreviewData()
-    static var persistenceController = {
-        let persistenceController = PersistenceController.preview
-        KeyChain.save(key: KeyChain.keychainPrivateKey, data: Data(KeyFixture.alice.privateKeyHex.utf8))
-        return persistenceController
-    }()
+    static var previewData = PreviewData(currentUserKey: KeyFixture.alice)
+    static var persistenceController = PersistenceController.preview
     static var previewContext = persistenceController.container.viewContext
     static var emptyPersistenceController = PersistenceController.empty
     static var emptyPreviewContext = emptyPersistenceController.container.viewContext


### PR DESCRIPTION
## Issues covered
This fixes the SwiftUI preview so I can work on #1291

## Description
The preview was crashing in `KeyChain.swift`. I'm not sure exactly why but we shouldn't be trying to write to the real keychain in previews anyway, so I moved the keychain code into our dependency injection system and made a `MockKeychain` that just stores values in memory that we can use for previews.

Then I had to do a little refactoring of the way `PreviewData` instantiates the `CurrentUser` to get the preview working.

## How to test
Make sure the live app still loads keys correctly, and verify that the HomeFeedView and other modified previews work.