### PR TITLE
Add relay selector to home feed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Added a filter button to the Home tab that let's you browse all notes on a specific relay.
+- Added a filter button to the Home tab that lets you browse all notes on a specific relay.
 - Add a Tap to Refresh button in empty profiles.
 - Update the reply count shown below each Note in a Feed.
 - Removed follower count from profile screen.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Added a filter button to the Home tab that let's you browse all notes on a specific relay.
 - Removed follower count from profile screen.
 - Fixed deep linking to profiles and notes.
 - Fixed issue where some nostr:nprofile references did not appear as links.

--- a/Nos.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Nos.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -216,5 +216,5 @@
       }
     }
   ],
-  "version": 2
+  "version" : 2
 }

--- a/Nos/Assets/Localization/Localizable.xcstrings
+++ b/Nos/Assets/Localization/Localizable.xcstrings
@@ -7174,73 +7174,73 @@
       "localizations" : {
         "ar" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "لا يوجد ملاحظات (بعد)! اطلع على علامة التصفح واتبع بعض الأشخاص للبدء."
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "(Noch) keine Notizen! Durchsuche das Tab \\\"Entdecken\\\" und folge einigen Leuten, um loszulegen."
           }
         },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "No notes (yet)! Browse the Discover tab and follow some people to get started."
+            "value" : "No notes (yet), but we'll keep looking!"
           }
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "¡No hay notas (aún)! Navega a la pestaña de Descubrir y sigue a algunas personas para empezar."
           }
         },
         "fa" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "(هنوز) هیچ یادداشتی نیست! برای شروع سربرگ یافتن را بگردید و چند نفر را دنبال کنید."
           }
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Aucune note (pour l'instant) ! Allez sur l'onglet \\\"Découvrir\\\" et suivez des gens pour commencer."
           }
         },
         "ja" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "メモはまだありません！ディスカバー / 検索 タブをタップして、何人かのユーザーをフォローして始めましょう。"
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Nog geen notes! Blader de Ontdek tab en volg enkele accounts om te beginnen."
           }
         },
         "pt-BR" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Sem notas (ainda)! Navegue na guia \"Descobrir\" e siga algumas pessoas para começar."
           }
         },
         "sv" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Inga anteckningar (ännu)! Bläddra i fliken Upptäck och följ några personer för att komma igång."
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "（还）没有笔记！浏览发现选项卡并关注一些帐户以开始操作。"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "（還）沒有筆記！瀏覽發現選項卡並關注一些帳戶以開始操作。"
           }
         }

--- a/Nos/Assets/Localization/Localizable.xcstrings
+++ b/Nos/Assets/Localization/Localizable.xcstrings
@@ -433,6 +433,17 @@
         }
       }
     },
+    "accountsIFollow" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Accounts I Follow"
+          }
+        }
+      }
+    },
     "activity" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -4312,6 +4323,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "已索取"
+          }
+        }
+      }
+    },
+    "filter" : {
+      "comment" : "verb for filtering your feed in various ways",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "filter"
           }
         }
       }

--- a/Nos/Controller/PagedNoteDataSource.swift
+++ b/Nos/Controller/PagedNoteDataSource.swift
@@ -259,7 +259,9 @@ class PagedNoteDataSource<Header: View, EmptyPlaceholder: View>: NSObject, UICol
 
                 if self.largestLoadedRowIndex > lastPageStartIndex {
                     // we are still on the last page of results, keep loading
-                    self.pager?.loadMore()
+                    Task {
+                        await self.pager?.loadMore()
+                    }
                 } else {
                     // we've loaded enough, go back to normal paging
                     self.stopAggressivePaging()

--- a/Nos/Controller/PagedNoteDataSource.swift
+++ b/Nos/Controller/PagedNoteDataSource.swift
@@ -224,7 +224,9 @@ class PagedNoteDataSource<Header: View, EmptyPlaceholder: View>: NSObject, UICol
             startAggressivePaging()
             return
         } else if indexPath.row.isMultiple(of: pageSize / 2) {
-            pager?.loadMore()
+            Task {
+                await pager?.loadMore()
+            }
         } 
     }
     

--- a/Nos/Models/CoreData/Event+CoreDataClass.swift
+++ b/Nos/Models/CoreData/Event+CoreDataClass.swift
@@ -459,21 +459,32 @@ public class Event: NosManagedObject, VerifiableEvent {
         return fetchRequest
     }
     
-    @nonobjc public class func homeFeedPredicate(for user: Author, before: Date) -> NSPredicate {
-        NSPredicate(
-            // swiftlint:disable line_length
-            format: "((kind = 1 AND SUBQUERY(eventReferences, $reference, $reference.marker = 'root' OR $reference.marker = 'reply' OR $reference.marker = nil).@count = 0) OR kind = 6 OR kind = 30023) AND (ANY author.followers.source = %@ OR author = %@) AND author.muted = 0 AND createdAt <= %@ AND deletedOn.@count = 0",
-            // swiftlint:enable line_length
-            user,
-            user,
-            before as CVarArg
-        )
+    @nonobjc public class func homeFeedPredicate(
+        for user: Author, 
+        before: Date,
+        seenOn relay: Relay? = nil
+    ) -> NSPredicate {
+        // swiftlint:disable:next line_length
+        var queryString = "((kind = 1 AND SUBQUERY(eventReferences, $reference, $reference.marker = 'root' OR $reference.marker = 'reply' OR $reference.marker = nil).@count = 0) OR kind = 6 OR kind = 30023) AND author.muted = 0 AND createdAt <= %@ AND deletedOn.@count = 0"
+        var arguments: [CVarArg] = [before as CVarArg]
+        if let relay {
+            queryString.append(" AND ANY seenOnRelays = %@")
+            arguments.append(relay)
+        } else {
+            queryString.append(" AND (ANY author.followers.source = %@ OR author = %@)")
+            arguments += [user, user]
+        }
+        return NSPredicate(format: queryString, argumentArray: arguments)
     }
     
-    @nonobjc public class func homeFeed(for user: Author, before: Date) -> NSFetchRequest<Event> {
+    @nonobjc public class func homeFeed(
+        for user: Author, 
+        before: Date, 
+        seenOn relay: Relay? = nil
+    ) -> NSFetchRequest<Event> {
         let fetchRequest = NSFetchRequest<Event>(entityName: "Event")
         fetchRequest.sortDescriptors = [NSSortDescriptor(keyPath: \Event.createdAt, ascending: false)]
-        fetchRequest.predicate = homeFeedPredicate(for: user, before: before)
+        fetchRequest.predicate = homeFeedPredicate(for: user, before: before, seenOn: relay)
         return fetchRequest
     }
 

--- a/Nos/Models/RelaySubscription.swift
+++ b/Nos/Models/RelaySubscription.swift
@@ -22,8 +22,7 @@ class RelaySubscription: Identifiable, Hashable {
     /// when a filter can be closed.
     var referenceCount: Int = 0
     
-    // TODO: actor isolate?
-    /// A closure that will be called for each Event this subscription downloads.
+    /// An observable stream of events that should emit every event downloaded on this subscription 
     let events: PassthroughSubject<JSONEvent, Never> = PassthroughSubject<JSONEvent, Never>()
     
     var isActive: Bool {

--- a/Nos/Models/RelaySubscription.swift
+++ b/Nos/Models/RelaySubscription.swift
@@ -1,8 +1,9 @@
 import Foundation
 import Logger
+import Combine
 
 /// Models a request to a relay for Nostr Events. 
-struct RelaySubscription: Identifiable, Hashable {
+class RelaySubscription: Identifiable, Hashable {
     
     var id: String 
     
@@ -14,15 +15,16 @@ struct RelaySubscription: Identifiable, Hashable {
     /// The date this Filter was opened as a subscription on relays. Used to close stale subscriptions
     var subscriptionStartDate: Date?
     
-    /// The oldest creation date on an event processed by this filter. Used for pagination.
-    var oldestEventCreationDate: Date?
-    
     /// The number of events that have been returned for this subscription
     var receivedEventCount = 0
     
     /// The number of objects using this filter. This is incremented and decremented by the RelayService to determine
     /// when a filter can be closed.
     var referenceCount: Int = 0
+    
+    // TODO: actor isolate?
+    /// A closure that will be called for each Event this subscription downloads.
+    let events: PassthroughSubject<JSONEvent, Never> = PassthroughSubject<JSONEvent, Never>()
     
     var isActive: Bool {
         subscriptionStartDate != nil
@@ -38,7 +40,6 @@ struct RelaySubscription: Identifiable, Hashable {
         filter: Filter, 
         relayAddress: URL, 
         subscriptionStartDate: Date? = nil, 
-        oldestEventCreationDate: Date? = nil, 
         referenceCount: Int = 0
     ) {
         self.filter = filter
@@ -46,7 +47,24 @@ struct RelaySubscription: Identifiable, Hashable {
         // Compute a unique ID but predictable ID. The sha256 cuts the length down to an acceptable size.
         self.id = (filter.id + "-" + relayAddress.absoluteString).data(using: .utf8)?.sha256 ?? "error"
         self.subscriptionStartDate = subscriptionStartDate
-        self.oldestEventCreationDate = oldestEventCreationDate
         self.referenceCount = referenceCount
+    }
+    
+    static func == (lhs: RelaySubscription, rhs: RelaySubscription) -> Bool {
+        lhs.id == rhs.id &&
+        lhs.filter == rhs.filter &&
+        lhs.relayAddress == rhs.relayAddress &&
+        lhs.subscriptionStartDate == rhs.subscriptionStartDate &&
+        lhs.referenceCount == rhs.referenceCount &&
+        lhs.isActive == rhs.isActive
+    }
+    
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
+        hasher.combine(filter)
+        hasher.combine(relayAddress)
+        hasher.combine(subscriptionStartDate)
+        hasher.combine(referenceCount)
+        hasher.combine(isActive)
     }
 }

--- a/Nos/Service/MockRelaySubscriptionManager.swift
+++ b/Nos/Service/MockRelaySubscriptionManager.swift
@@ -43,9 +43,9 @@ class MockRelaySubscriptionManager: RelaySubscriptionManager {
     }
 
     var queueSubscriptionFilter: Filter?
-    func queueSubscription(with filter: Filter, to relayAddress: URL) async -> RelaySubscription.ID {
+    func queueSubscription(with filter: Filter, to relayAddress: URL) async -> RelaySubscription {
         queueSubscriptionFilter = filter
-        return RelaySubscription.ID()
+        return RelaySubscription(filter: filter, relayAddress: relayAddress)
     }
 
     func remove(_ socket: any WebSocketClient) async {

--- a/Nos/Service/Relay/Filter.swift
+++ b/Nos/Service/Relay/Filter.swift
@@ -27,7 +27,7 @@ struct Filter: Hashable, Identifiable {
         since: Date? = nil,
         until: Date? = nil
     ) {
-        self.authorKeys = authorKeys.sorted(by: { $0 > $1 })
+        self.authorKeys = authorKeys.sorted()
         self.eventIDs = eventIDs
         self.kinds = kinds.sorted(by: { $0.rawValue > $1.rawValue })
         self.eTags = eTags

--- a/Nos/Service/Relay/Filter.swift
+++ b/Nos/Service/Relay/Filter.swift
@@ -4,9 +4,9 @@ import Foundation
 /// See [NIP-01](https://github.com/nostr-protocol/nips/blob/master/01.md#communication-between-clients-and-relays).
 struct Filter: Hashable, Identifiable {
     
-    let authorKeys: [RawAuthorID]
+    var authorKeys: [RawAuthorID]
     let eventIDs: [RawEventID]
-    let kinds: [EventKind]
+    var kinds: [EventKind]
     let eTags: [RawEventID]
     let pTags: [RawAuthorID]
     let search: String?

--- a/Nos/Service/Relay/PagedRelaySubscription.swift
+++ b/Nos/Service/Relay/PagedRelaySubscription.swift
@@ -35,6 +35,7 @@ class PagedRelaySubscription {
             pagedEventsFilter.until = startDate
             var newEventsFilter = filter
             newEventsFilter.since = startDate
+            newEventsFilter.limit = nil
             for relayAddress in relayAddresses {
                 newEventsSubscriptionIDs.insert(
                     await subscriptionManager.queueSubscription(with: filter, to: relayAddress)

--- a/Nos/Service/Relay/PagedRelaySubscription.swift
+++ b/Nos/Service/Relay/PagedRelaySubscription.swift
@@ -1,9 +1,11 @@
 import Foundation
 import Logger
+import Combine
 
 /// This class manages a Filter and fetches events in reverse-chronological order as `loadMore()` is called. This
 /// can be used to paginate a list of events. The underlying relay subscriptions will be deallocated when this object
-/// goes out of scope. 
+/// goes out of scope.  
+@RelaySubscriptionManagerActor
 class PagedRelaySubscription {
     let startDate: Date
     let filter: Filter
@@ -17,6 +19,10 @@ class PagedRelaySubscription {
     /// A set of subscriptions always listening for new events published after the `startDate`.
     private var newEventsSubscriptionIDs = Set<RelaySubscription.ID>()
     
+    private var relayAddresses: Set<URL>
+    private var oldestEventByRelay = [URL: Date]()
+    private var cancellables = [AnyCancellable]()
+    
     init(
         startDate: Date, 
         filter: Filter, 
@@ -28,22 +34,22 @@ class PagedRelaySubscription {
         self.filter = filter
         self.relayService = relayService
         self.subscriptionManager = subscriptionManager
+        self.relayAddresses = relayAddresses
         Task {
             // We keep two sets of subscriptions. One is always listening for new events and the other fetches 
             // progressively older events as we page down.
             var pagedEventsFilter = filter
             pagedEventsFilter.until = startDate
             var newEventsFilter = filter
+            
             newEventsFilter.since = startDate
             newEventsFilter.limit = nil
             for relayAddress in relayAddresses {
                 newEventsSubscriptionIDs.insert(
-                    await subscriptionManager.queueSubscription(with: filter, to: relayAddress)
-                )
-                pagedSubscriptionIDs.insert(
-                    await subscriptionManager.queueSubscription(with: pagedEventsFilter, to: relayAddress)
+                    await subscriptionManager.queueSubscription(with: filter, to: relayAddress).id
                 )
             }
+            loadMore()
         }
     }
     
@@ -61,33 +67,40 @@ class PagedRelaySubscription {
     /// `Filter` and updating all its managed subscriptions.
     func loadMore() {
         Task { [self] in
-            var newUntilDates = [URL: Date]()
-            var subscriptionsToRemove = Set<RelaySubscription.ID>()
-            
             for subscriptionID in pagedSubscriptionIDs {
-                if let subscription = await subscriptionManager.subscription(from: subscriptionID),
-                    let newDate = subscription.oldestEventCreationDate {
-                    
-                    guard newDate != subscription.filter.until else {
-                        // Optimization. Don't close and reopen an identical filter.
-                        continue
-                    }
-                          
-                    newUntilDates[subscription.relayAddress] = newDate
-                    relayService.decrementSubscriptionCount(for: subscriptionID)
-                    subscriptionsToRemove.insert(subscription.id)
-                }
+                relayService.decrementSubscriptionCount(for: subscriptionID)
             }
+            pagedSubscriptionIDs.removeAll()
+            cancellables.removeAll()
             
-            pagedSubscriptionIDs.subtract(subscriptionsToRemove)            
-            
-            for (relayAddress, until) in newUntilDates {
-                var newEventsFilter = self.filter
-                newEventsFilter.until = until
-                pagedSubscriptionIDs.insert(
-                    await subscriptionManager.queueSubscription(with: newEventsFilter, to: relayAddress)
+            for relayAddress in relayAddresses {
+                let newPageStartDate = oldestEventByRelay[relayAddress] ?? startDate
+                var newPageFilter = self.filter
+                newPageFilter.until = newPageStartDate
+                newPageFilter.keepSubscriptionOpen = false
+                
+                let pagedEventSubscription = await subscriptionManager.queueSubscription(
+                    with: newPageFilter, 
+                    to: relayAddress
                 )
+                
+                // TODO: actor isolate
+                pagedEventSubscription.events.sink { [weak self] jsonEvent in
+                    self?.track(event: jsonEvent, from: relayAddress)
+                }
+                .store(in: &cancellables)
+                
+                pagedSubscriptionIDs.insert(pagedEventSubscription.id)
             }
+        }
+    }
+    
+    func track(event: JSONEvent, from relay: URL) {
+        if let oldestSeen = oldestEventByRelay[relay],
+           event.createdDate < oldestSeen {
+            oldestEventByRelay[relay] = event.createdDate
+        } else {
+            oldestEventByRelay[relay] = event.createdDate
         }
     }
 }

--- a/Nos/Service/Relay/RelayService.swift
+++ b/Nos/Service/Relay/RelayService.swift
@@ -178,6 +178,11 @@ extension RelayService {
     /// Asks the relay to download a page of events matching the given `filter` from relays and save them to Core Data.
     /// You can cause the service to download the next page by calling `loadMore()` on the returned subscription object.
     /// The subscription will be cancelled when the returned subscription object is deallocated.
+    /// - Parameters:
+    ///   - filter: an object describing the set of events that should be downloaded.
+    ///   - specificRelay: a specific relay to download events from. If `nil` the user's relay list will be used.
+    /// - Returns: A handle that can be used to load more pages of events. It will close the relay subscriptions
+    ///     when deallocated.
     func subscribeToPagedEvents(
         matching filter: Filter, 
         from specificRelay: URL? = nil

--- a/Nos/Service/Relay/RelayService.swift
+++ b/Nos/Service/Relay/RelayService.swift
@@ -178,13 +178,23 @@ extension RelayService {
     /// Asks the relay to download a page of events matching the given `filter` from relays and save them to Core Data.
     /// You can cause the service to download the next page by calling `loadMore()` on the returned subscription object.
     /// The subscription will be cancelled when the returned subscription object is deallocated.
-    func subscribeToPagedEvents(matching filter: Filter) async -> PagedRelaySubscription {
-        PagedRelaySubscription(
+    func subscribeToPagedEvents(
+        matching filter: Filter, 
+        from specificRelay: URL? = nil
+    ) async -> PagedRelaySubscription {
+        var relays = Set<URL>()
+        if let specificRelay {
+            relays.insert(specificRelay)
+        } else {
+            relays = await self.relayAddresses(for: currentUser)
+        }
+        
+        return PagedRelaySubscription(
             startDate: .now,
             filter: filter,
             relayService: self,
             subscriptionManager: subscriptionManager,
-            relayAddresses: await self.relayAddresses(for: currentUser)
+            relayAddresses: relays
         )
     }
     

--- a/Nos/Service/Relay/RelaySubscriptionManager.swift
+++ b/Nos/Service/Relay/RelaySubscriptionManager.swift
@@ -87,7 +87,7 @@ actor RelaySubscriptionManagerActor: RelaySubscriptionManager {
     /// do that in the future.
     @discardableResult
     func decrementSubscriptionCount(for subscriptionID: RelaySubscription.ID) async -> Bool {
-        if var subscription = subscription(from: subscriptionID) {
+        if let subscription = subscription(from: subscriptionID) {
             if subscription.referenceCount == 1 {
                 removeSubscription(with: subscriptionID)
                 return false
@@ -222,7 +222,7 @@ actor RelaySubscriptionManagerActor: RelaySubscriptionManager {
     }
     
     private func start(subscription: RelaySubscription) {
-        var subscription = subscription
+        let subscription = subscription
         subscription.subscriptionStartDate = .now
         if let socket = socket(for: subscription.relayAddress) {
             requestEvents(from: socket, subscription: subscription)

--- a/Nos/Views/Home/HomeFeedView.swift
+++ b/Nos/Views/Home/HomeFeedView.swift
@@ -56,7 +56,7 @@ struct HomeFeedView: View {
     var homeFeedFilter: Filter {
         var filter = Filter(kinds: [.text, .delete, .repost, .longFormContent])
         if selectedRelay == nil {
-            filter.authorKeys = user.followedKeys
+            filter.authorKeys = user.followedKeys.sorted()
         } else {
             filter.kinds += [.report]
         }

--- a/Nos/Views/Home/HomeFeedView.swift
+++ b/Nos/Views/Home/HomeFeedView.swift
@@ -205,6 +205,7 @@ struct HomeFeedView: View {
                             .foregroundStyle(Color.secondaryTxt)
                             .accessibilityLabel(Text(.localizable.filter))
                     }
+                    .frame(minWidth: 40, minHeight: 40)
                 }
             }
         }

--- a/Nos/Views/Home/HomeFeedView.swift
+++ b/Nos/Views/Home/HomeFeedView.swift
@@ -178,15 +178,6 @@ struct HomeFeedView: View {
             ToolbarItem(placement: .navigationBarLeading) {
                 SideMenuButton()
             }
-            RelayPickerToolbarButton(
-                selectedRelay: $selectedRelay,
-                isPresenting: $showRelayPicker,
-                defaultSelection: .localizable.allMyRelays
-            ) {
-                withAnimation {
-                    showRelayPicker.toggle()
-                }
-            }
             ToolbarItem(placement: .navigationBarTrailing) {
                 if isShowingStories {
                     Button {

--- a/Nos/Views/Home/HomeFeedView.swift
+++ b/Nos/Views/Home/HomeFeedView.swift
@@ -24,8 +24,9 @@ struct HomeFeedView: View {
     /// to get some data from relay. The amount of time is defined in `staticLoadTime`.
     @State private var showTimedLoadingIndicator = true
     
-    /// The amount of time the loading indicator will be shown when showTimedLoadingIndicator is set to true.
-    static let staticLoadTime = 2
+    /// The amount of time (in seconds) the loading indicator will be shown when showTimedLoadingIndicator is set to 
+    /// true.
+    static let staticLoadTime: Int = 2
 
     @ObservedObject var user: Author
 

--- a/Nos/Views/Home/HomeFeedView.swift
+++ b/Nos/Views/Home/HomeFeedView.swift
@@ -26,7 +26,7 @@ struct HomeFeedView: View {
     
     /// The amount of time (in seconds) the loading indicator will be shown when showTimedLoadingIndicator is set to 
     /// true.
-    static let staticLoadTime: Int = 2
+    static let staticLoadTime: TimeInterval = 2
 
     @ObservedObject var user: Author
 
@@ -143,7 +143,7 @@ struct HomeFeedView: View {
             if showTimedLoadingIndicator {
                 FullscreenProgressView(
                     isPresented: $showTimedLoadingIndicator,
-                    hideAfter: .now() + .seconds(Self.staticLoadTime)
+                    hideAfter: .now() + .seconds(Int(Self.staticLoadTime))
                 )
             } 
             

--- a/Nos/Views/Home/HomeFeedView.swift
+++ b/Nos/Views/Home/HomeFeedView.swift
@@ -243,7 +243,7 @@ struct HomeFeedView: View {
     
     func createTestData() {
         let user = previewData.alice
-        let addresses = Relay.allKnown
+        let addresses = Relay.recommended
         addresses.forEach { address in
             let relay = try? Relay.findOrCreate(by: address, context: previewData.previewContext)
             relay?.relayDescription = "A Nostr relay that aims to cultivate a healthy community."

--- a/Nos/Views/PagedNoteListView.swift
+++ b/Nos/Views/PagedNoteListView.swift
@@ -84,8 +84,17 @@ struct PagedNoteListView<Header: View, EmptyPlaceholder: View>: UIViewRepresenta
         return collectionView
     }
     
-    func updateUIView(_ collectionView: UICollectionView, context: Context) {}
-
+    func updateUIView(_ collectionView: UICollectionView, context: Context) {
+        if let dataSource = collectionView.dataSource as? PagedNoteDataSource<Header, EmptyPlaceholder> {
+            if relayFilter != dataSource.relayFilter || relay != dataSource.relay {
+                dataSource.subscribeToEvents(matching: relayFilter, from: relay)
+            }
+            if databaseFilter != dataSource.databaseFilter {
+                dataSource.updateFetchRequest(databaseFilter)
+            }
+        }
+    }
+    
     static func dismantleUIView(_ uiView: UICollectionView, coordinator: Coordinator<Header, EmptyPlaceholder>) {
         tearDownObservers(coordinator: coordinator)
     }
@@ -108,19 +117,6 @@ struct PagedNoteListView<Header: View, EmptyPlaceholder: View>: UIViewRepresenta
             }
             // scrolling to CGRect.zero does not work, so this seems to be the best we can do
             uiView?.scrollRectToVisible(CGRect(x: 0, y: 0, width: 1, height: 1), animated: true)
-        }
-
-        return collectionView
-    }
-    
-    func updateUIView(_ collectionView: UICollectionView, context: Context) {
-        if let dataSource = collectionView.dataSource as? PagedNoteDataSource<Header, EmptyPlaceholder> {
-            if relayFilter != dataSource.relayFilter || relay != dataSource.relay {
-                dataSource.subscribeToEvents(matching: relayFilter, from: relay)
-            }
-            if databaseFilter != dataSource.databaseFilter {
-                dataSource.updateFetchRequest(databaseFilter)
-            }
         }
     }
 

--- a/Nos/Views/PagedNoteListView.swift
+++ b/Nos/Views/PagedNoteListView.swift
@@ -25,6 +25,8 @@ struct PagedNoteListView<Header: View, EmptyPlaceholder: View>: UIViewRepresenta
     /// by the `databaseFilter`. 
     let relayFilter: Filter
     
+    let relay: Relay? 
+    
     let context: NSManagedObjectContext
 
     /// The tab in which this PagedNoteListView appears.
@@ -55,6 +57,7 @@ struct PagedNoteListView<Header: View, EmptyPlaceholder: View>: UIViewRepresenta
         let dataSource = context.coordinator.dataSource(
             databaseFilter: databaseFilter, 
             relayFilter: relayFilter,
+            relay: relay,
             collectionView: collectionView, 
             context: self.context,
             header: header,
@@ -89,7 +92,16 @@ struct PagedNoteListView<Header: View, EmptyPlaceholder: View>: UIViewRepresenta
         return collectionView
     }
     
-    func updateUIView(_ collectionView: UICollectionView, context: Context) {}
+    func updateUIView(_ collectionView: UICollectionView, context: Context) {
+        if let dataSource = collectionView.dataSource as? PagedNoteDataSource<Header, EmptyPlaceholder> {
+            if relayFilter != dataSource.relayFilter || relay != dataSource.relay {
+                dataSource.subscribeToEvents(matching: relayFilter, from: relay)
+            }
+            if databaseFilter != dataSource.databaseFilter {
+                dataSource.updateFetchRequest(databaseFilter)
+            }
+        }
+    }
 
     static func dismantleUIView(_ uiView: UITextView, coordinator: Coordinator<Header, EmptyPlaceholder>) {
         if let observer = coordinator.observer {
@@ -144,6 +156,7 @@ struct PagedNoteListView<Header: View, EmptyPlaceholder: View>: UIViewRepresenta
         func dataSource(
             databaseFilter: NSFetchRequest<Event>, 
             relayFilter: Filter,
+            relay: Relay?,
             collectionView: UICollectionView,
             context: NSManagedObjectContext,
             @ViewBuilder header: @escaping () -> CoordinatorHeader,
@@ -159,6 +172,7 @@ struct PagedNoteListView<Header: View, EmptyPlaceholder: View>: UIViewRepresenta
             let dataSource = PagedNoteDataSource(
                 databaseFilter: databaseFilter, 
                 relayFilter: relayFilter,
+                relay: relay,
                 collectionView: collectionView, 
                 context: context,
                 header: header,
@@ -171,7 +185,6 @@ struct PagedNoteListView<Header: View, EmptyPlaceholder: View>: UIViewRepresenta
         @objc func refreshData(_ sender: Any) {
             if let onRefresh {
                 dataSource?.updateFetchRequest(onRefresh())
-                collectionView?.reloadData()
             }
             
             if let refreshControl = sender as? UIRefreshControl {
@@ -193,7 +206,8 @@ extension Notification.Name {
     
     return PagedNoteListView(
         databaseFilter: previewData.alice.allPostsRequest(onlyRootPosts: false),
-        relayFilter: Filter(),
+        relayFilter: Filter(), 
+        relay: nil,
         context: previewData.previewContext,
         tab: .home,
         header: {

--- a/Nos/Views/Profile/ProfileView.swift
+++ b/Nos/Views/Profile/ProfileView.swift
@@ -75,7 +75,8 @@ struct ProfileView: View {
             VStack {
                 PagedNoteListView(
                     databaseFilter: selectedTab.databaseFilter(author: author),
-                    relayFilter: selectedTab.relayFilter(author: author),
+                    relayFilter: selectedTab.relayFilter(author: author), 
+                    relay: nil,
                     context: viewContext,
                     tab: .profile,
                     header: {

--- a/Nos/Views/RelayPicker.swift
+++ b/Nos/Views/RelayPicker.swift
@@ -31,7 +31,13 @@ struct RelayPicker: View {
                         .fixedSize(horizontal: false, vertical: true)
                 }
             }
-            .cornerRadius(15, corners: [.bottomLeft, .bottomRight])
+            .background(
+                Rectangle()
+                    .foregroundStyle(LinearGradient.cardBackground)
+                    .cornerRadius(20, corners: [.bottomLeft, .bottomRight])
+                    .shadow(radius: 15, y: 10)
+            ) 
+            .readabilityPadding()
             
             VStack(spacing: 0) {
                 // shadow effect at the top
@@ -41,25 +47,22 @@ struct RelayPicker: View {
                     .shadow(radius: 15, y: 10)
                 
                 ViewThatFits(in: .vertical) {
-                    pickerRows
+                    VStack {
+                        pickerRows
+                        Color.clear
+                            .contentShape(Rectangle())
+                            .frame(minHeight: 0)
+                            .onTapGesture { 
+                                isPresented = false
+                            }
+                    }
                     ScrollView {
                         pickerRows
                     }
                 }
             }
-            .background(
-                Rectangle()
-                    .foregroundStyle(LinearGradient.cardBackground)
-                    .cornerRadius(20, corners: [.bottomLeft, .bottomRight])
-                    .shadow(radius: 15, y: 10)
-            ) 
-            .readabilityPadding()
             .transition(.move(edge: .top))
             
-            Color.clear
-                .onTapGesture { 
-                    isPresented = false
-                }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .zIndex(99) // Fixes dismissal animation

--- a/Nos/Views/RelayPicker.swift
+++ b/Nos/Views/RelayPicker.swift
@@ -53,7 +53,9 @@ struct RelayPicker: View {
                             .contentShape(Rectangle())
                             .frame(minHeight: 0)
                             .onTapGesture { 
-                                isPresented = false
+                                withAnimation {
+                                    isPresented = false
+                                }
                             }
                     }
                     ScrollView {
@@ -61,9 +63,8 @@ struct RelayPicker: View {
                     }
                 }
             }
-            .transition(.move(edge: .top))
-            
         }
+        .transition(.move(edge: .top))
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .zIndex(99) // Fixes dismissal animation
     }

--- a/Nos/Views/RelayPicker.swift
+++ b/Nos/Views/RelayPicker.swift
@@ -18,27 +18,50 @@ struct RelayPicker: View {
     }
     
     var body: some View {
-        VStack {
-            ScrollView {
-                VStack(spacing: 0) {
-                    // TODO: scrolling
-                    RelayPickerRow(string: defaultSelection, selection: $selectedRelay)
-                    ForEach(relays) { relay in
-
-                        BeveledSeparator()
-                            .padding(.horizontal, 20)
-                        
-                        RelayPickerRow(relay: relay, selection: $selectedRelay)
-                            .fixedSize(horizontal: false, vertical: true)
+        VStack(spacing: 0) {
+            
+            let pickerRows = VStack(spacing: 0) {
+                RelayPickerRow(string: defaultSelection, selection: $selectedRelay)
+                ForEach(relays) { relay in
+                    
+                    BeveledSeparator()
+                        .padding(.horizontal, 20)
+                    
+                    RelayPickerRow(relay: relay, selection: $selectedRelay)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+            .cornerRadius(15, corners: [.bottomLeft, .bottomRight])
+            
+            VStack(spacing: 0) {
+                // shadow effect at the top
+                Rectangle()
+                    .frame(height: 1)
+                    .foregroundStyle(.clear)
+                    .shadow(radius: 15, y: 10)
+                
+                ViewThatFits(in: .vertical) {
+                    pickerRows
+                    ScrollView {
+                        pickerRows
                     }
                 }
-                .cornerRadius(15, corners: [.bottomLeft, .bottomRight])
             }
-            Spacer()
+            .background(
+                Rectangle()
+                    .foregroundStyle(LinearGradient.cardBackground)
+                    .cornerRadius(20, corners: [.bottomLeft, .bottomRight])
+                    .shadow(radius: 15, y: 10)
+            ) 
+            .readabilityPadding()
+            .transition(.move(edge: .top))
+            
+            Color.clear
+                .onTapGesture { 
+                    isPresented = false
+                }
         }
-        .background(LinearGradient.cardBackground) 
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .transition(.move(edge: .top))
         .zIndex(99) // Fixes dismissal animation
     }
 }
@@ -80,12 +103,29 @@ struct RelayPickerRow: View {
             selection = relay
         } label: {
             HStack {
-                Text(title)
-                    .foregroundColor(.primaryTxt)
-                    .font(.clarity(.bold))
-                    .lineLimit(1)
-                    .padding(.horizontal, 19)
-                    .padding(.vertical, 19)
+                VStack(spacing: 6) {
+                    HStack {
+                        Text(title)
+                            .foregroundColor(.primaryTxt)
+                            .font(.clarity(.bold))
+                            .lineLimit(1)
+                            .shadow(radius: 4, y: 4)
+                        Spacer()
+                    }
+                    
+                    if let description = relay?.relayDescription {
+                        HStack {
+                            Text(description)
+                                .font(.clarityRegular(.callout))
+                                .multilineTextAlignment(.leading)
+                                .foregroundColor(.secondaryTxt)
+                                .lineLimit(2)
+                            Spacer()
+                        }
+                    }
+                }
+                .padding(.horizontal, 14)
+                .padding(.vertical, 14)
                 Spacer()
                 if isSelected {
                     Image(systemName: "checkmark")
@@ -100,40 +140,54 @@ struct RelayPickerRow: View {
     }
 }
 
-struct RelayPicker_Previews: PreviewProvider {
+#Preview("Without ScrollView") {
 
-    static var previewData = PreviewData()
-    static var persistenceController = PersistenceController.preview
-    static var previewContext = persistenceController.container.viewContext
-    static var relayService = previewData.relayService
+    @State var selectedRelay: Relay?
+    var previewData = PreviewData()
     
-    static var user: Author {
-        let author = Author(context: previewContext)
-        author.hexadecimalPublicKey = KeyFixture.alice.publicKeyHex
-        createTestData(in: previewContext, user: author)
-        return author
-    }
-    
-    static func createTestData(in context: NSManagedObjectContext, user: Author) {
+    func createTestData() {
+        let user = previewData.alice
         let addresses = ["wss://nostr.com", "wss://nos.social", "wss://alongdomainnametoseewhathappens.com"]
         addresses.forEach { address in
-            let relay = try? Relay.findOrCreate(by: address, context: previewContext)
+            let relay = try? Relay.findOrCreate(by: address, context: previewData.previewContext)
+            relay?.relayDescription = "A Nostr relay that aims to cultivate a healthy community."
             relay?.addToAuthors(user)
         }
+    }
+    
+    return RelayPicker(
+        selectedRelay: $selectedRelay,
+        defaultSelection: String(localized: .localizable.allMyRelays),
+        author: previewData.alice,
+        isPresented: .constant(true)
+    )
+    .onAppear { createTestData() }
+    .inject(previewData: previewData)
+    .background(Color.appBg)
+}
 
-        try? previewContext.save()
+#Preview("With ScrollView") {
+
+    @State var selectedRelay: Relay?
+    var previewData = PreviewData()
+    
+    func createTestData() {
+        let user = previewData.alice
+        let addresses = Relay.allKnown
+        addresses.forEach { address in
+            let relay = try? Relay.findOrCreate(by: address, context: previewData.previewContext)
+            relay?.relayDescription = "A Nostr relay that aims to cultivate a healthy community."
+            relay?.addToAuthors(user)
+        }
     }
     
-    @State static var selectedRelay: Relay?
-    
-    static var previews: some View {
-        RelayPicker(
-            selectedRelay: $selectedRelay,
-            defaultSelection: String(localized: .localizable.allMyRelays),
-            author: user,
-            isPresented: .constant(true)
-        )
-        .environment(\.managedObjectContext, previewContext)
-        .background(Color.appBg)
-    }
+    return RelayPicker(
+        selectedRelay: $selectedRelay,
+        defaultSelection: String(localized: .localizable.allMyRelays),
+        author: previewData.alice,
+        isPresented: .constant(true)
+    )
+    .onAppear { createTestData() }
+    .inject(previewData: previewData)
+    .background(Color.appBg)
 }

--- a/Nos/Views/RelayPicker.swift
+++ b/Nos/Views/RelayPicker.swift
@@ -21,6 +21,12 @@ struct RelayPicker: View {
         VStack(spacing: 0) {
             
             let pickerRows = VStack(spacing: 0) {
+                // shadow effect at the top
+                Rectangle()
+                    .frame(height: 1)
+                    .foregroundStyle(.clear)
+                    .shadow(radius: 15, y: 10)
+                
                 RelayPickerRow(string: defaultSelection, selection: $selectedRelay)
                 ForEach(relays) { relay in
                     
@@ -40,12 +46,6 @@ struct RelayPicker: View {
             .readabilityPadding()
             
             VStack(spacing: 0) {
-                // shadow effect at the top
-                Rectangle()
-                    .frame(height: 1)
-                    .foregroundStyle(.clear)
-                    .shadow(radius: 15, y: 10)
-                
                 ViewThatFits(in: .vertical) {
                     VStack {
                         pickerRows


### PR DESCRIPTION
## Issues covered
#1291

## Description
This adds the `RelayPicker` back to the home feed. When you select a relay from the picker the feed will show all events from the given relay.

I had to modify `PagedNoteDatasource` a little so that it can make its requests to the correct relays. I also polished up the design of RelayPicker a bit to more closely match Figma (I referenced [this design](https://www.figma.com/design/s0qf4VmyQygydP8MIQazZc/Nos?node-id=231-6141&t=7cdTEpT5nwnjKZoN-1) in addition to the one linked in the ticket).

I didn't add the "Relays" header to the picker or the note "Filtering by an individual relay will show you ALL the content on that relay.". I'd like to either do that in a separate PR or in #1292. I'll check with Linda on that.

## How to test
1. Open the Home tab
2. Tap the filter button in the top right
3. Choose a relay
4. Verify that the events from that relay are displayed.

## Screenshots/Video

|Before|After|
|----|-----|
|![Simulator Screenshot - iPhone 15 - 2024-07-12 at 13 33 07](https://github.com/user-attachments/assets/493fcb29-2667-4d33-953b-0b4cd1e493dd)|![simulator_screenshot_855B29F1-C556-4A53-8739-E317BF68B840](https://github.com/user-attachments/assets/3e70319f-ab89-4c48-9c8f-d7a846025ab8)|
