### PR TITLE
Keep fewer subscriptions open and close them immediately on EOSE

### DIFF
--- a/Nos/Controller/PersistenceController.swift
+++ b/Nos/Controller/PersistenceController.swift
@@ -46,7 +46,7 @@ class PersistenceController {
     private var model: NSManagedObjectModel
     private var inMemory: Bool
 
-    init(containerName: String = "Nos", inMemory: Bool = false, erase: Bool = true) {
+    init(containerName: String = "Nos", inMemory: Bool = false, erase: Bool = false) {
         self.inMemory = inMemory
         let modelURL = Bundle.current.url(forResource: "Nos", withExtension: "momd")!
         model = NSManagedObjectModel(contentsOf: modelURL)!

--- a/Nos/Controller/PersistenceController.swift
+++ b/Nos/Controller/PersistenceController.swift
@@ -46,7 +46,7 @@ class PersistenceController {
     private var model: NSManagedObjectModel
     private var inMemory: Bool
 
-    init(containerName: String = "Nos", inMemory: Bool = false, erase: Bool = false) {
+    init(containerName: String = "Nos", inMemory: Bool = false, erase: Bool = true) {
         self.inMemory = inMemory
         let modelURL = Bundle.current.url(forResource: "Nos", withExtension: "momd")!
         model = NSManagedObjectModel(contentsOf: modelURL)!

--- a/Nos/Service/CurrentUser.swift
+++ b/Nos/Service/CurrentUser.swift
@@ -194,7 +194,7 @@ import Dependencies
             kinds: [.contactList],
             limit: 2, // small hack to make sure this filter doesn't get closed for being stale
             since: author.lastUpdatedContactList,
-            keepSubscriptionOpen: true
+            keepSubscriptionOpen: false
         )
         subscriptions.append(
             await relayService.fetchEvents(matching: contactFilter)

--- a/Nos/Service/CurrentUser.swift
+++ b/Nos/Service/CurrentUser.swift
@@ -193,8 +193,7 @@ import Dependencies
             authorKeys: [key],
             kinds: [.contactList],
             limit: 2, // small hack to make sure this filter doesn't get closed for being stale
-            since: author.lastUpdatedContactList,
-            keepSubscriptionOpen: false
+            since: author.lastUpdatedContactList
         )
         subscriptions.append(
             await relayService.fetchEvents(matching: contactFilter)

--- a/Nos/Service/PushNotificationService.swift
+++ b/Nos/Service/PushNotificationService.swift
@@ -96,9 +96,10 @@ import Combine
         }
         
         let userMentionsFilter = Filter(
-            kinds: [.text, .longFormContent, .like], 
+            kinds: [.text], 
             pTags: [authorKey], 
-            limit: 50
+            limit: 50,
+            keepSubscriptionOpen: true
         )
         relaySubscription = await relayService.fetchEvents(
             matching: userMentionsFilter

--- a/Nos/Service/PushNotificationService.swift
+++ b/Nos/Service/PushNotificationService.swift
@@ -98,8 +98,7 @@ import Combine
         let userMentionsFilter = Filter(
             kinds: [.text, .longFormContent, .like], 
             pTags: [authorKey], 
-            limit: 50,
-            keepSubscriptionOpen: true
+            limit: 50
         )
         relaySubscription = await relayService.fetchEvents(
             matching: userMentionsFilter

--- a/Nos/Service/Relay/PagedRelaySubscription.swift
+++ b/Nos/Service/Relay/PagedRelaySubscription.swift
@@ -33,8 +33,10 @@ class PagedRelaySubscription {
             // progressively older events as we page down.
             var pagedEventsFilter = filter
             pagedEventsFilter.until = startDate
+            pagedEventsFilter.keepSubscriptionOpen = false
             var newEventsFilter = filter
             newEventsFilter.since = startDate
+            newEventsFilter.keepSubscriptionOpen = true
             for relayAddress in relayAddresses {
                 newEventsSubscriptionIDs.insert(
                     await subscriptionManager.queueSubscription(with: filter, to: relayAddress)

--- a/Nos/Service/Relay/RelayService.swift
+++ b/Nos/Service/Relay/RelayService.swift
@@ -795,7 +795,7 @@ extension RelayService {
         }
         
         for subscription in await subscriptionManager.active() where subscription.relayAddress == client.url {
-            await subscriptionManager.requestEvents(from: client, subscription: subscription)
+            await subscriptionManager.requestEvents (from: client, subscription: subscription)
         }
     }
 }
@@ -809,21 +809,21 @@ extension RelayService: WebSocketDelegate {
         
         Task {
             switch event {
-            case .connected:
+            case .connected, .viabilityChanged(true):
                 await handleConnection(from: client)
             case .disconnected(let reason, let code):
                 await subscriptionManager.remove(socket)
-                print("websocket is disconnected: \(reason) with code: \(code)")
+            case .peerClosed:
+                await subscriptionManager.remove(socket)
             case .text(let string):
                 await parseResponse(string, socket)
             case .binary:
                 break
-            case .ping, .pong, .viabilityChanged, .reconnectSuggested, .peerClosed:
+            case .ping, .pong, .viabilityChanged, .reconnectSuggested:
                 break
             case .cancelled:
                 await subscriptionManager.trackError(socket: socket)
                 await subscriptionManager.remove(socket)
-                print("websocket is cancelled")
             case .error(let error):
                 await subscriptionManager.trackError(socket: socket)
                 await subscriptionManager.remove(socket)

--- a/Nos/Service/Relay/RelayService.swift
+++ b/Nos/Service/Relay/RelayService.swift
@@ -359,7 +359,7 @@ extension RelayService {
             let jsonEvent = try JSONDecoder().decode(JSONEvent.self, from: jsonData)
             await self.parseQueue.push(jsonEvent, from: socket)
             
-            if var subscription = await subscriptionManager.subscription(from: subscriptionID) {
+            if let subscription = await subscriptionManager.subscription(from: subscriptionID) {
                 subscription.receivedEventCount += 1
                 subscription.events.send(jsonEvent)
                 if subscription.closesAfterResponse {
@@ -795,7 +795,7 @@ extension RelayService {
         }
         
         for subscription in await subscriptionManager.active() where subscription.relayAddress == client.url {
-            await subscriptionManager.requestEvents (from: client, subscription: subscription)
+            await subscriptionManager.requestEvents(from: client, subscription: subscription)
         }
     }
 }
@@ -811,7 +811,7 @@ extension RelayService: WebSocketDelegate {
             switch event {
             case .connected, .viabilityChanged(true):
                 await handleConnection(from: client)
-            case .disconnected(let reason, let code):
+            case .disconnected:
                 await subscriptionManager.remove(socket)
             case .peerClosed:
                 await subscriptionManager.remove(socket)

--- a/Nos/Service/Relay/RelaySubscriptionManager.swift
+++ b/Nos/Service/Relay/RelaySubscriptionManager.swift
@@ -109,7 +109,7 @@ actor RelaySubscriptionManagerActor: RelaySubscriptionManager {
     func staleSubscriptions() async -> [RelaySubscription] {
         var staleSubscriptions = [RelaySubscription]()
         for subscription in active {
-            if !subscription.closesAfterResponse, 
+            if subscription.closesAfterResponse, 
                 let filterStartedAt = subscription.subscriptionStartDate,
                 filterStartedAt.distance(to: .now) > 10 {
                 staleSubscriptions.append(subscription)

--- a/Nos/Service/Relay/RelaySubscriptionManager.swift
+++ b/Nos/Service/Relay/RelaySubscriptionManager.swift
@@ -144,6 +144,9 @@ actor RelaySubscriptionManagerActor: RelaySubscriptionManager {
         if let index = sockets.firstIndex(where: { $0 === socket }) {
             sockets.remove(at: index)
         }
+        all.removeAll { subscription in
+            subscription.relayAddress == socket.url
+        }
     }
     
     func socket(for address: String) -> WebSocket? {

--- a/Nos/Views/Home/HomeFeedView.swift
+++ b/Nos/Views/Home/HomeFeedView.swift
@@ -51,8 +51,7 @@ struct HomeFeedView: View {
             let textFilter = Filter(
                 authorKeys: followedKeys, 
                 kinds: [.text, .delete, .repost, .longFormContent, .report], 
-                since: storiesCutoffDate,
-                keepSubscriptionOpen: true
+                since: storiesCutoffDate
             )
             let textSubs = await relayService.fetchEvents(matching: textFilter)
             relaySubscriptions.append(textSubs)
@@ -63,10 +62,7 @@ struct HomeFeedView: View {
         ZStack {
             let homeFeedFilter = Filter(
                 authorKeys: user.followedKeys, 
-                kinds: [.text, .delete, .repost, .longFormContent, .report], 
-                limit: 100, 
-                since: nil,
-                keepSubscriptionOpen: true
+                kinds: [.text, .delete, .repost, .longFormContent, .report]
             )
             PagedNoteListView(
                 databaseFilter: Event.homeFeed(for: user, before: lastRefreshDate), 

--- a/Nos/Views/NotificationsView.swift
+++ b/Nos/Views/NotificationsView.swift
@@ -41,7 +41,7 @@ struct NotificationsView: View {
             kinds: [.text], 
             pTags: [currentUserKey], 
             limit: 100,
-            keepSubscriptionOpen: true
+            keepSubscriptionOpen: false
         )
         let subscriptions = await relayService.fetchEvents(matching: filter)
         relaySubscriptions.append(subscriptions)

--- a/Nos/Views/Profile/ProfileFeedType.swift
+++ b/Nos/Views/Profile/ProfileFeedType.swift
@@ -18,10 +18,6 @@ enum ProfileFeedType {
             kinds = [.text, .delete]
         }
         
-        return Filter(
-            authorKeys: [author.hexadecimalPublicKey ?? "error"],
-            kinds: kinds,
-            keepSubscriptionOpen: true
-        )
+        return Filter(authorKeys: [author.hexadecimalPublicKey ?? "error"], kinds: kinds)
     }
 }


### PR DESCRIPTION
## Issues covered
Related to #1246, these are changes that take advantage of improvements made while testing #1277

## Description
This fixes a bug in the RelayService where we weren't closing subscriptions immediately upon receiving "EOSE" (end of stored events) from a relay. It has been around for a while but wasn't really causing problems until we added code to limit the number of concurrent subscriptions, and started opening more subscriptions when browsing the feed in #1277.

This also modifies a few `Filters` that we don't need to keep open indefinitely.

## How to test
Generally smoke test the app and look for "X subscriptions waiting in queue." messages in the logs. There should be almost none.