### PR TITLE
Fetch all reports from a relay when viewing a single relay

### DIFF
--- a/Nos/Views/Home/HomeFeedView.swift
+++ b/Nos/Views/Home/HomeFeedView.swift
@@ -55,12 +55,10 @@ struct HomeFeedView: View {
     }
     
     var homeFeedFilter: Filter {
-        var filter = Filter(kinds: [.text, .delete, .repost, .longFormContent])
+        var filter = Filter(kinds: [.text, .delete, .repost, .longFormContent, .report])
         if selectedRelay == nil {
             filter.authorKeys = user.followedKeys.sorted()
-        } else {
-            filter.kinds += [.report]
-        }
+        } 
         return filter
     }
     


### PR DESCRIPTION
## Issues covered
Small follow up to #1291

## Description
This is a little bug I wrote in my last PR. Not sure why I thought we shouldn't get report when filtering by a single relay, but we should.