### PR TITLE
Lower concurrent queue limit in RelaySubscriptionManager

### DIFF
--- a/Nos/Service/Analytics.swift
+++ b/Nos/Service/Analytics.swift
@@ -172,8 +172,14 @@ class Analytics {
     
     // MARK: - Relays
     
-    func rateLimited(by socket: WebSocket) {
-        track("Rate Limited", properties: ["relay": socket.request.url?.absoluteString ?? "null"])
+    func rateLimited(by socket: WebSocket, requestCount: Int) {
+        track(
+            "Rate Limited", 
+            properties: [
+                "relay": socket.request.url?.absoluteString ?? "null",
+                "count": requestCount,
+            ]
+        )
     }
     
     func badRequest(from socket: WebSocket, message: String) {

--- a/Nos/Service/Relay/RelaySubscriptionManager.swift
+++ b/Nos/Service/Relay/RelaySubscriptionManager.swift
@@ -204,11 +204,9 @@ actor RelaySubscriptionManagerActor: RelaySubscriptionManager {
         // Print number of waiting subscriptions for each relay
         if all.count > active.count {
             var waitingSubscriptionsByRelay = [URL: Int]()
-            for subscription in all {
-                if subscription.subscriptionStartDate == nil {
-                    let count = waitingSubscriptionsByRelay[subscription.relayAddress] ?? 0
-                    waitingSubscriptionsByRelay[subscription.relayAddress] = count + 1
-                }
+            for subscription in all where subscription.subscriptionStartDate == nil {
+                let count = waitingSubscriptionsByRelay[subscription.relayAddress] ?? 0
+                waitingSubscriptionsByRelay[subscription.relayAddress] = count + 1
             }
             for (relayAddress, count) in waitingSubscriptionsByRelay {
                 Log.debug("\(relayAddress) has \(count) subscriptions waiting in queue.")

--- a/Nos/Service/Relay/RelaySubscriptionManager.swift
+++ b/Nos/Service/Relay/RelaySubscriptionManager.swift
@@ -41,7 +41,7 @@ actor RelaySubscriptionManagerActor: RelaySubscriptionManager {
     }
 
     /// Limit of the number of active subscriptions in a single relay
-    private let queueLimit = 25
+    private let queueLimit = 10
 
     // MARK: - Protocol conformance
     
@@ -201,10 +201,18 @@ actor RelaySubscriptionManagerActor: RelaySubscriptionManager {
         }
         
         #if DEBUG
-        let allCount = all.count
-        let activeCount = active.count
-        if allCount > activeCount {
-            Log.debug("\(allCount - activeCount) subscriptions waiting in queue.")
+        // Print number of waiting subscriptions for each relay
+        if all.count > active.count {
+            var waitingSubscriptionsByRelay = [URL: Int]()
+            for subscription in all {
+                if subscription.subscriptionStartDate == nil {
+                    let count = waitingSubscriptionsByRelay[subscription.relayAddress] ?? 0
+                    waitingSubscriptionsByRelay[subscription.relayAddress] = count + 1
+                }
+            }
+            for (relayAddress, count) in waitingSubscriptionsByRelay {
+                Log.debug("\(relayAddress) has \(count) subscriptions waiting in queue.")
+            }
         }
         #endif
     }


### PR DESCRIPTION
## Issues covered
Fixes https://github.com/planetary-social/nos/issues/1246#issuecomment-2233325737

## Description
This lowers the max number of concurrent requests we have open with a given relay from 25 to 10. 

While I was at it I added analytics for the "too many concurrent REQs" messages that relays send us so we can see how often this happens in production. We were already doing this for another type of rate limit, but I think the error message is different depending on the relay implementation.

I also improved the debug logging for when subscriptions are waiting in the queue. Before it could be deceptive there could be 100 subscriptions in the queue, but those 100 subscriptions could all be for 1 or 2 unhealthy relays, when all the other relays are working fine. So now we break the number down by relay.

## How to test
Scroll around a lot and verify that things load quickly and you don't see "Rate Limited" or "too many concurrent REQs" or other "Notice from relay" messages in the logs indicating that we have too many subscriptions open at once.