### PR TITLE
(Re-)fix paging

### DIFF
--- a/Nos/Controller/PagedNoteDataSource.swift
+++ b/Nos/Controller/PagedNoteDataSource.swift
@@ -209,7 +209,7 @@ class PagedNoteDataSource<Header: View, EmptyPlaceholder: View>: NSObject, UICol
             startAggressivePaging()
             return
         } else if indexPath.row.isMultiple(of: pageSize / 2) {
-            pager?.loadMore()
+            Task { await pager?.loadMore() }
         } 
     }
     
@@ -242,7 +242,7 @@ class PagedNoteDataSource<Header: View, EmptyPlaceholder: View>: NSObject, UICol
 
                 if self.largestLoadedRowIndex > lastPageStartIndex {
                     // we are still on the last page of results, keep loading
-                    self.pager?.loadMore()
+                    Task { await self.pager?.loadMore() }
                 } else {
                     // we've loaded enough, go back to normal paging
                     self.stopAggressivePaging()

--- a/Nos/Models/RelaySubscription.swift
+++ b/Nos/Models/RelaySubscription.swift
@@ -1,8 +1,9 @@
 import Foundation
 import Logger
+import Combine
 
 /// Models a request to a relay for Nostr Events. 
-struct RelaySubscription: Identifiable, Hashable {
+class RelaySubscription: Identifiable, Hashable {
     
     var id: String 
     
@@ -14,15 +15,15 @@ struct RelaySubscription: Identifiable, Hashable {
     /// The date this Filter was opened as a subscription on relays. Used to close stale subscriptions
     var subscriptionStartDate: Date?
     
-    /// The oldest creation date on an event processed by this filter. Used for pagination.
-    var oldestEventCreationDate: Date?
-    
     /// The number of events that have been returned for this subscription
     var receivedEventCount = 0
     
     /// The number of objects using this filter. This is incremented and decremented by the RelayService to determine
     /// when a filter can be closed.
     var referenceCount: Int = 0
+    
+    /// An observable stream of events that should emit every event downloaded on this subscription 
+    let events: PassthroughSubject<JSONEvent, Never> = PassthroughSubject<JSONEvent, Never>()
     
     var isActive: Bool {
         subscriptionStartDate != nil
@@ -38,7 +39,6 @@ struct RelaySubscription: Identifiable, Hashable {
         filter: Filter, 
         relayAddress: URL, 
         subscriptionStartDate: Date? = nil, 
-        oldestEventCreationDate: Date? = nil, 
         referenceCount: Int = 0
     ) {
         self.filter = filter
@@ -46,7 +46,24 @@ struct RelaySubscription: Identifiable, Hashable {
         // Compute a unique ID but predictable ID. The sha256 cuts the length down to an acceptable size.
         self.id = (filter.id + "-" + relayAddress.absoluteString).data(using: .utf8)?.sha256 ?? "error"
         self.subscriptionStartDate = subscriptionStartDate
-        self.oldestEventCreationDate = oldestEventCreationDate
         self.referenceCount = referenceCount
+    }
+    
+    static func == (lhs: RelaySubscription, rhs: RelaySubscription) -> Bool {
+        lhs.id == rhs.id &&
+        lhs.filter == rhs.filter &&
+        lhs.relayAddress == rhs.relayAddress &&
+        lhs.subscriptionStartDate == rhs.subscriptionStartDate &&
+        lhs.referenceCount == rhs.referenceCount &&
+        lhs.isActive == rhs.isActive
+    }
+    
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
+        hasher.combine(filter)
+        hasher.combine(relayAddress)
+        hasher.combine(subscriptionStartDate)
+        hasher.combine(referenceCount)
+        hasher.combine(isActive)
     }
 }

--- a/Nos/Service/MockRelaySubscriptionManager.swift
+++ b/Nos/Service/MockRelaySubscriptionManager.swift
@@ -43,9 +43,9 @@ class MockRelaySubscriptionManager: RelaySubscriptionManager {
     }
 
     var queueSubscriptionFilter: Filter?
-    func queueSubscription(with filter: Filter, to relayAddress: URL) async -> RelaySubscription.ID {
+    func queueSubscription(with filter: Filter, to relayAddress: URL) async -> RelaySubscription {
         queueSubscriptionFilter = filter
-        return RelaySubscription.ID()
+        return RelaySubscription(filter: filter, relayAddress: relayAddress)
     }
 
     func remove(_ socket: any WebSocketClient) async {

--- a/Nos/Service/Relay/Filter.swift
+++ b/Nos/Service/Relay/Filter.swift
@@ -5,7 +5,7 @@ import Foundation
 struct Filter: Hashable, Identifiable {
     
     /// List of author identifiers the Filter should be constrained to.
-    var authorKeys: [RawAuthorID]
+    let authorKeys: [RawAuthorID]
 
     /// List of event identifiers the Filter should be constrained to.
     let eventIDs: [RawEventID]

--- a/Nos/Service/Relay/Filter.swift
+++ b/Nos/Service/Relay/Filter.swift
@@ -5,13 +5,13 @@ import Foundation
 struct Filter: Hashable, Identifiable {
     
     /// List of author identifiers the Filter should be constrained to.
-    let authorKeys: [RawAuthorID]
+    var authorKeys: [RawAuthorID]
 
     /// List of event identifiers the Filter should be constrained to.
     let eventIDs: [RawEventID]
 
     /// List of Note kinds to filter
-    let kinds: [EventKind]
+    var kinds: [EventKind]
 
     /// An array of replaceable identifiers, or `"d"` tags, to match.
     let dTags: [RawReplaceableID]
@@ -74,7 +74,7 @@ struct Filter: Hashable, Identifiable {
         until: Date? = nil,
         keepSubscriptionOpen: Bool = false
     ) {
-        self.authorKeys = authorKeys.sorted(by: { $0 > $1 })
+        self.authorKeys = authorKeys.sorted()
         self.eventIDs = eventIDs
         self.kinds = kinds.sorted(by: { $0.rawValue > $1.rawValue })
         self.dTags = dTags

--- a/Nos/Service/Relay/Filter.swift
+++ b/Nos/Service/Relay/Filter.swift
@@ -11,7 +11,7 @@ struct Filter: Hashable, Identifiable {
     let eventIDs: [RawEventID]
 
     /// List of Note kinds to filter
-    var kinds: [EventKind]
+    let kinds: [EventKind]
 
     /// An array of replaceable identifiers, or `"d"` tags, to match.
     let dTags: [RawReplaceableID]

--- a/Nos/Service/Relay/PagedRelaySubscription.swift
+++ b/Nos/Service/Relay/PagedRelaySubscription.swift
@@ -1,9 +1,11 @@
 import Foundation
 import Logger
+import Combine
 
 /// This class manages a Filter and fetches events in reverse-chronological order as `loadMore()` is called. This
 /// can be used to paginate a list of events. The underlying relay subscriptions will be deallocated when this object
-/// goes out of scope. 
+/// goes out of scope.  
+@RelaySubscriptionManagerActor
 class PagedRelaySubscription {
     let startDate: Date
     let filter: Filter
@@ -17,6 +19,14 @@ class PagedRelaySubscription {
     /// A set of subscriptions always listening for new events published after the `startDate`.
     private var newEventsSubscriptionIDs = Set<RelaySubscription.ID>()
     
+    /// The relays we are fetching events from
+    private var relayAddresses: Set<URL>
+    
+    /// The oldest event each relay has returned. Used to load the next page.
+    private var oldestEventByRelay = [URL: Date]()
+    
+    private var cancellables = [AnyCancellable]()
+    
     init(
         startDate: Date, 
         filter: Filter, 
@@ -28,6 +38,7 @@ class PagedRelaySubscription {
         self.filter = filter
         self.relayService = relayService
         self.subscriptionManager = subscriptionManager
+        self.relayAddresses = relayAddresses
         Task {
             // We keep two sets of subscriptions. One is always listening for new events and the other fetches 
             // progressively older events as we page down.
@@ -35,17 +46,16 @@ class PagedRelaySubscription {
             pagedEventsFilter.until = startDate
             pagedEventsFilter.keepSubscriptionOpen = false
             var newEventsFilter = filter
+            
             newEventsFilter.since = startDate
             newEventsFilter.keepSubscriptionOpen = true
             newEventsFilter.limit = nil
             for relayAddress in relayAddresses {
                 newEventsSubscriptionIDs.insert(
-                    await subscriptionManager.queueSubscription(with: filter, to: relayAddress)
-                )
-                pagedSubscriptionIDs.insert(
-                    await subscriptionManager.queueSubscription(with: pagedEventsFilter, to: relayAddress)
+                    await subscriptionManager.queueSubscription(with: filter, to: relayAddress).id
                 )
             }
+            loadMore()
         }
     }
     
@@ -63,33 +73,48 @@ class PagedRelaySubscription {
     /// `Filter` and updating all its managed subscriptions.
     func loadMore() {
         Task { [self] in
-            var newUntilDates = [URL: Date]()
-            var subscriptionsToRemove = Set<RelaySubscription.ID>()
-            
+            // Remove old subscriptions
             for subscriptionID in pagedSubscriptionIDs {
-                if let subscription = await subscriptionManager.subscription(from: subscriptionID),
-                    let newDate = subscription.oldestEventCreationDate {
-                    
-                    guard newDate != subscription.filter.until else {
-                        // Optimization. Don't close and reopen an identical filter.
-                        continue
-                    }
-                          
-                    newUntilDates[subscription.relayAddress] = newDate
-                    relayService.decrementSubscriptionCount(for: subscriptionID)
-                    subscriptionsToRemove.insert(subscription.id)
-                }
+                relayService.decrementSubscriptionCount(for: subscriptionID)
             }
+            pagedSubscriptionIDs.removeAll()
+            cancellables.removeAll()
             
-            pagedSubscriptionIDs.subtract(subscriptionsToRemove)            
-            
-            for (relayAddress, until) in newUntilDates {
-                var newEventsFilter = self.filter
-                newEventsFilter.until = until
-                pagedSubscriptionIDs.insert(
-                    await subscriptionManager.queueSubscription(with: newEventsFilter, to: relayAddress)
+            // Open new subscriptions
+            for relayAddress in relayAddresses {
+                let newPageStartDate = oldestEventByRelay[relayAddress] ?? startDate
+                var newPageFilter = self.filter
+                newPageFilter.until = newPageStartDate
+                newPageFilter.keepSubscriptionOpen = false
+                
+                let pagedEventSubscription = await subscriptionManager.queueSubscription(
+                    with: newPageFilter, 
+                    to: relayAddress
                 )
+                
+                pagedEventSubscription.events
+                    .sink { [weak self] jsonEvent in
+                        Task {
+                            await self?.track(event: jsonEvent, from: relayAddress)
+                        }
+                    }
+                    .store(in: &cancellables)
+                
+                pagedSubscriptionIDs.insert(pagedEventSubscription.id)
             }
+        }
+    }
+    
+    func updateOldestEvent(for relay: URL, to date: Date) {
+        oldestEventByRelay[relay] = date
+    }
+    
+    nonisolated func track(event: JSONEvent, from relay: URL) async {
+        if let oldestSeen = await oldestEventByRelay[relay],
+            event.createdDate < oldestSeen {
+            await updateOldestEvent(for: relay, to: event.createdDate)
+        } else {
+            await updateOldestEvent(for: relay, to: event.createdDate)
         }
     }
 }

--- a/Nos/Service/Relay/PagedRelaySubscription.swift
+++ b/Nos/Service/Relay/PagedRelaySubscription.swift
@@ -101,6 +101,8 @@ class PagedRelaySubscription {
                     .store(in: &cancellables)
                 
                 pagedSubscriptionIDs.insert(pagedEventSubscription.id)
+                
+                await subscriptionManager.processSubscriptionQueue()
             }
         }
     }
@@ -110,9 +112,10 @@ class PagedRelaySubscription {
     }
     
     nonisolated func track(event: JSONEvent, from relay: URL) async {
-        if let oldestSeen = await oldestEventByRelay[relay],
-            event.createdDate < oldestSeen {
-            await updateOldestEvent(for: relay, to: event.createdDate)
+        if let oldestSeen = await oldestEventByRelay[relay] {
+            if event.createdDate < oldestSeen {
+                await updateOldestEvent(for: relay, to: event.createdDate)
+            }
         } else {
             await updateOldestEvent(for: relay, to: event.createdDate)
         }

--- a/Nos/Service/Relay/PagedRelaySubscription.swift
+++ b/Nos/Service/Relay/PagedRelaySubscription.swift
@@ -20,7 +20,7 @@ class PagedRelaySubscription {
     private var newEventsSubscriptionIDs = Set<RelaySubscription.ID>()
     
     /// The relays we are fetching events from
-    private var relayAddresses: Set<URL>
+    private let relayAddresses: Set<URL>
     
     /// The oldest event each relay has returned. Used to load the next page.
     private var oldestEventByRelay = [URL: Date]()

--- a/Nos/Service/Relay/RelayService.swift
+++ b/Nos/Service/Relay/RelayService.swift
@@ -170,7 +170,7 @@ extension RelayService {
         }
         var subscriptionIDs = [RelaySubscription.ID]()
         for relay in relayAddresses {
-            subscriptionIDs.append(await subscriptionManager.queueSubscription(with: filter, to: relay))
+            subscriptionIDs.append(await subscriptionManager.queueSubscription(with: filter, to: relay).id)
         }
         
         // Fire off REQs in the background
@@ -182,13 +182,28 @@ extension RelayService {
     /// Asks the relay to download a page of events matching the given `filter` from relays and save them to Core Data.
     /// You can cause the service to download the next page by calling `loadMore()` on the returned subscription object.
     /// The subscription will be cancelled when the returned subscription object is deallocated.
-    func subscribeToPagedEvents(matching filter: Filter) async -> PagedRelaySubscription {
-        PagedRelaySubscription(
+    /// - Parameters:
+    ///   - filter: an object describing the set of events that should be downloaded.
+    ///   - specificRelay: a specific relay to download events from. If `nil` the user's relay list will be used.
+    /// - Returns: A handle that can be used to load more pages of events. It will close the relay subscriptions
+    ///     when deallocated.
+    func subscribeToPagedEvents(
+        matching filter: Filter, 
+        from specificRelay: URL? = nil
+    ) async -> PagedRelaySubscription {
+        var relays = Set<URL>()
+        if let specificRelay {
+            relays.insert(specificRelay)
+        } else {
+            relays = await self.relayAddresses(for: currentUser)
+        }
+        
+        return await PagedRelaySubscription(
             startDate: .now,
             filter: filter,
             relayService: self,
             subscriptionManager: subscriptionManager,
-            relayAddresses: await self.relayAddresses(for: currentUser)
+            relayAddresses: relays
         )
     }
     
@@ -325,6 +340,7 @@ extension RelayService {
         if let subID = responseArray[1] as? String,
             let subscription = await subscriptionManager.subscription(from: subID),
             subscription.closesAfterResponse {
+            Log.debug("\(socket.host) has finished responding on \(subID). Closing subscription.")
             // This is a one-off request. Close it.
             await sendClose(from: socket, subscriptionID: subID)
         }
@@ -351,17 +367,9 @@ extension RelayService {
             let jsonEvent = try JSONDecoder().decode(JSONEvent.self, from: jsonData)
             await self.parseQueue.push(jsonEvent, from: socket)
             
-            if var subscription = await subscriptionManager.subscription(from: subscriptionID) {
-                if let oldestSeen = subscription.oldestEventCreationDate,
-                    jsonEvent.createdDate < oldestSeen {
-                    subscription.oldestEventCreationDate = jsonEvent.createdDate
-                    subscription.receivedEventCount += 1
-                    await subscriptionManager.updateSubscriptions(with: subscription)
-                } else {
-                    subscription.oldestEventCreationDate = jsonEvent.createdDate
-                    subscription.receivedEventCount += 1
-                    await subscriptionManager.updateSubscriptions(with: subscription)
-                }
+            if let subscription = await subscriptionManager.subscription(from: subscriptionID) {
+                subscription.receivedEventCount += 1
+                subscription.events.send(jsonEvent)
                 if subscription.closesAfterResponse {
                     Log.debug("detected subscription with id \(subscription.id) has been fulfilled. Closing.")
                     await subscriptionManager.forceCloseSubscriptionCount(for: subscription.id)

--- a/Nos/Service/Relay/RelaySubscriptionManager.swift
+++ b/Nos/Service/Relay/RelaySubscriptionManager.swift
@@ -14,7 +14,7 @@ protocol RelaySubscriptionManager {
     func forceCloseSubscriptionCount(for subscriptionID: RelaySubscription.ID) async
     func markHealthy(socket: WebSocket) async
     func processSubscriptionQueue() async
-    func queueSubscription(with filter: Filter, to relayAddress: URL) async -> RelaySubscription.ID
+    func queueSubscription(with filter: Filter, to relayAddress: URL) async -> RelaySubscription
     func remove(_ socket: WebSocketClient) async
     func requestEvents(from socket: WebSocketClient, subscription: RelaySubscription) async
     func socket(for address: String) async -> WebSocket?
@@ -22,11 +22,14 @@ protocol RelaySubscriptionManager {
     func staleSubscriptions() async -> [RelaySubscription]
     func subscription(from subscriptionID: RelaySubscription.ID) async -> RelaySubscription?
     func trackError(socket: WebSocket) async
-    func updateSubscriptions(with newValue: RelaySubscription) async
 }
 
 /// An actor that manages state for a `RelayService` including lists of open sockets and subscriptions.
+@globalActor
 actor RelaySubscriptionManagerActor: RelaySubscriptionManager {
+    
+    static let shared = RelaySubscriptionManagerActor()
+    
     // MARK: - Public Properties
     
     var all = [RelaySubscription]()
@@ -64,14 +67,6 @@ actor RelaySubscriptionManagerActor: RelaySubscriptionManager {
         }
     }
     
-    func updateSubscriptions(with newValue: RelaySubscription) {
-        if let subscriptionIndex = self.all.firstIndex(where: { $0.id == newValue.id }) {
-            all[subscriptionIndex] = newValue
-        } else {
-            all.append(newValue)
-        }
-    }
-    
     private func removeSubscription(with subscriptionID: RelaySubscription.ID) {
         if let subscriptionIndex = self.all.firstIndex(
             where: { $0.id == subscriptionID }
@@ -92,13 +87,12 @@ actor RelaySubscriptionManagerActor: RelaySubscriptionManager {
     /// do that in the future.
     @discardableResult
     func decrementSubscriptionCount(for subscriptionID: RelaySubscription.ID) async -> Bool {
-        if var subscription = subscription(from: subscriptionID) {
+        if let subscription = subscription(from: subscriptionID) {
             if subscription.referenceCount == 1 {
                 removeSubscription(with: subscriptionID)
                 return false
             } else {
                 subscription.referenceCount -= 1
-                updateSubscriptions(with: subscription)
                 return true
             }
         }
@@ -221,24 +215,24 @@ actor RelaySubscriptionManagerActor: RelaySubscriptionManager {
         #endif
     }
     
-    func queueSubscription(with filter: Filter, to relayAddress: URL) async -> RelaySubscription.ID {
+    func queueSubscription(with filter: Filter, to relayAddress: URL) async -> RelaySubscription {
         var subscription = RelaySubscription(filter: filter, relayAddress: relayAddress)
         
         if let existingSubscription = self.subscription(from: subscription.id) {
             // dedup
             subscription = existingSubscription
+        } else {
+            all.append(subscription)
         }
         
         subscription.referenceCount += 1
-        updateSubscriptions(with: subscription)
         
-        return subscription.id
+        return subscription
     }
     
     private func start(subscription: RelaySubscription) {
-        var subscription = subscription
+        let subscription = subscription
         subscription.subscriptionStartDate = .now
-        updateSubscriptions(with: subscription)
         if let socket = socket(for: subscription.relayAddress) {
             requestEvents(from: socket, subscription: subscription)
         }


### PR DESCRIPTION
## Issues covered
#1246

## Description
It turns out that the bugs with paging I addressed in #1298 were actually caused by #1277. Basically the `PagedRelaySubscription` was storing the `oldestEventCreationDate` in each `RelaySubscription`. This date tells the pager what the oldest event we have fetched is so that we can fetch older stuff and continue paging. However now that we are aggressively clearing out subscriptions when they send EOSE (which is great) we were losing the  `oldestEventCreationDate`. I described the issue and my fix in more detail [here](https://github.com/planetary-social/nos/pull/1298#issuecomment-2229213480).

This code was already reviewed and approved in #1298, then it was reverted in #1314, and now I'm bringing it back.

## How to test
Try out paging in the home feed and profile views and make sure you don't see any other bugs.