### PR TITLE
Fix duplicate authors in db

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Fixed an issue where Profile views would sometimes not display any notes.
 - Add impersonation flag category and better NIP-56 mapping.
 - Add a Tap to Refresh button in empty profiles.
 - Support nostr:naddr links to text and long-form content notes.

--- a/Nos/Service/Relay/RelayService.swift
+++ b/Nos/Service/Relay/RelayService.swift
@@ -20,6 +20,7 @@ class RelayService: ObservableObject {
     private var processingQueue = DispatchQueue(label: "RelayService-processing", qos: .userInitiated)
     private var parseQueue = ParseQueue()
     
+    @Dependency(\.persistenceController) var persistenceController
     @Dependency(\.analytics) private var analytics
     @MainActor @Dependency(\.currentUser) private var currentUser
     @Published var numberOfConnectedRelays: Int = 0
@@ -400,6 +401,7 @@ extension RelayService {
                 )
                 #endif
                 try self.parseContext.saveIfNeeded()
+                try self.persistenceController.viewContext.saveIfNeeded()
             }
             return true
         }


### PR DESCRIPTION
## Issues covered
#1317

## Description
I found out there were duplicate authors in the `viewContext`, and the `ProfileView` would sometimes display one without any associated data instead of the one with data we had parsed. I think Core Data merges them when we save the `viewContext`, but we weren't doing that all that often. This updates the `RelayService` to save the `viewContext` whenever it is done parsing a batch of events. I also added a call in `CurrentUser.setUp`.

I'm a little worried about the performance implications of saving the viewContext so often, but in my anecdotal testing it seemed ok.

## How to test
1. Launch Nos (bonus points if you do a fresh install)
2. Tap profiles on the Discover and Home tabs, make sure some notes are displayed.