### PR TITLE
Fix Published Reply event which wasn't being sent

### DIFF
--- a/Nos/Views/New Note/NewNoteView.swift
+++ b/Nos/Views/New Note/NewNoteView.swift
@@ -252,7 +252,11 @@ struct NewNoteView: View {
             } else {
                 try await relayService.publishToAll(event: jsonEvent, signingKey: keyPair, context: viewContext)
             }
-            analytics.published(note: jsonEvent)
+            if let replyToNote {
+                analytics.published(reply: jsonEvent)
+            } else {
+                analytics.published(note: jsonEvent)
+            }
             text = EditableNoteText()
         } catch {
             Log.error("Error when posting: \(error.localizedDescription)")

--- a/Nos/Views/New Note/NewNoteView.swift
+++ b/Nos/Views/New Note/NewNoteView.swift
@@ -252,7 +252,7 @@ struct NewNoteView: View {
             } else {
                 try await relayService.publishToAll(event: jsonEvent, signingKey: keyPair, context: viewContext)
             }
-            if let replyToNote {
+            if replyToNote != nil {
                 analytics.published(reply: jsonEvent)
             } else {
                 analytics.published(note: jsonEvent)


### PR DESCRIPTION
## Issues covered
[#1250](https://github.com/planetary-social/nos/issues/1250)

## Description
I forget why I fixed this. I think Linda mentioned it in a meeting and I just made the change while we were talking about it.

## How to test
1. Post a reply
2. Look in the logs for the "Published Reply" analytics event.