### PR TITLE
Fix publishing to a single relay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Fixed a bug where publishing a note to one relay would publish to all relays
+- Fixed a bug where publishing a note to one relay would publish to all relays.
 - Fix a bug where multiple connections could be opened with the same relay.
 - Fixed an issue where Profile views would sometimes not display any notes.
 - Add impersonation flag category and better NIP-56 mapping.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Fixed a bug where publishing a note to one relay would publish to all relays
 - Fix a bug where multiple connections could be opened with the same relay.
 - Fixed an issue where Profile views would sometimes not display any notes.
 - Add impersonation flag category and better NIP-56 mapping.

--- a/Nos/Service/Relay/RelayService.swift
+++ b/Nos/Service/Relay/RelayService.swift
@@ -582,7 +582,7 @@ extension RelayService {
         signingKey: KeyPair,
         context: NSManagedObjectContext
     ) async throws {
-        let signedEvent = try await signAndSave(event: event, signingKey: signingKey, in: context)
+        let signedEvent = try await signAndSave(event: event, signingKey: signingKey, relayURLs: relayURLs, in: context)
         for relayURL in relayURLs {
             if let socket = await socket(from: relayURL) {
                 try await publish(from: socket, jsonEvent: signedEvent)

--- a/Nos/Service/Relay/RelayService.swift
+++ b/Nos/Service/Relay/RelayService.swift
@@ -635,7 +635,7 @@ extension RelayService {
                 Log.error("Could not parse new event \(jsonEvent)")
                 throw RelayError.parseError
             }
-            var relays: [Relay]
+            let relays: [Relay]
             if let relayURLs {
                 relays = try relayURLs.map { try Relay.findOrCreate(by: $0.absoluteString, context: context) }
             } else {

--- a/Nos/Service/Relay/RelayService.swift
+++ b/Nos/Service/Relay/RelayService.swift
@@ -611,7 +611,7 @@ extension RelayService {
             signedEvent = event
             
         case .some(let keyPair):
-            signedEvent = try await signAndSave(event: event, signingKey: keyPair, in: context)
+            signedEvent = try await signAndSave(event: event, signingKey: keyPair, relayURLs: [relayURL], in: context)
         }
         
         await openSocket(to: relayURL, andSend: try signedEvent.buildPublishRequest())
@@ -620,6 +620,7 @@ extension RelayService {
     private func signAndSave(
         event: JSONEvent,
         signingKey: KeyPair,
+        relayURLs: [URL]? = nil,
         in context: NSManagedObjectContext
     ) async throws -> JSONEvent {
         var jsonEvent = event
@@ -634,7 +635,12 @@ extension RelayService {
                 Log.error("Could not parse new event \(jsonEvent)")
                 throw RelayError.parseError
             }
-            let relays = try context.fetch(Relay.relays(for: event.author!))
+            var relays: [Relay]
+            if let relayURLs {
+                relays = try relayURLs.map { try Relay.findOrCreate(by: $0.absoluteString, context: context) }
+            } else {
+                relays = try context.fetch(Relay.relays(for: event.author!))
+            }
             event.shouldBePublishedTo = Set(relays)
             try context.save()
         }


### PR DESCRIPTION
## Issues covered
#1322

## Description
This was pretty simple. We were putting all the user's relays in the `shouldBePublishedTo` list instead of just the one they wanted to publish to.

## How to test

1. Open the note composer
2. Choose a relay from the selector at the top
3. Publish your note
4. Wait 1-2 minutes
5. Look for your notes on other relays (I do this using `nak` but you could use an app like Nostrudel.ninja)