### PR TITLE
Fix CHANGELOG: move a reverted then restored feature to the right place

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Added a filter button to the Home tab that lets you browse all notes on a specific relay.
 - Improved the search experience with fast local searches.
 - Fixed the issue where tapping the Search button caused search results to disappear.
 - Fixed an issue with naddr links.
@@ -19,7 +20,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix a bug where multiple connections could be opened with the same relay.
 - Fixed an issue where Profile views would sometimes not display any notes.
 - Add impersonation flag category and better NIP-56 mapping.
-- Added a filter button to the Home tab that lets you browse all notes on a specific relay.
 - Add a Tap to Refresh button in empty profiles.
 - Support nostr:naddr links to text and long-form content notes.
 - Update the reply count shown below each note in a Feed.


### PR DESCRIPTION
## Issues covered
None

## Description
Like it says in the title. Fix CHANGELOG: move a reverted then restored feature to the right place