### PR TITLE
Fix empty home feed on first launch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Fixed a bug where the home feed would be empty on first launch.
+
 ## [0.1.22] - 2024-07-26Z
 
 - Added a filter button to the Home tab that lets you browse all notes on a specific relay.

--- a/Nos/Views/Home/HomeFeedView.swift
+++ b/Nos/Views/Home/HomeFeedView.swift
@@ -28,7 +28,7 @@ struct HomeFeedView: View {
     /// true.
     static let staticLoadTime: TimeInterval = 2
 
-    @ObservedObject var user: Author
+    let user: Author
 
     @State private var stories: [Author] = []
     @State private var selectedStoryAuthor: Author?


### PR DESCRIPTION
## Issues covered
#1338

## Description
The issue was that downloading the user's contact list was not triggering a view update. We fixed it by using the new @Observable annotation on Author instead of the old @ObservableObject annotation which can't detect changes deeper in the object graph.

## How to test
1. Try to reproduce the bug with the steps in the ticket.
2. Try following people and doing other things to update your user and make sure it doesn't mess with the home feed scroll position or paging.