### PR TITLE
Disable tapping/clicking to dismiss New Post view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Fixed the issue where tapping outside the New Post view caused it to disappear and all its text to be lost.
 - Remove stories UI to improve performance.
 
 ## [0.1.22] - 2024-07-26Z

--- a/Nos/Views/AppView.swift
+++ b/Nos/Views/AppView.swift
@@ -136,6 +136,7 @@ struct AppView: View {
                 .sheet(isPresented: $showNewPost, content: {
                     NewNoteView(initialContents: newPostContents, isPresented: $showNewPost)
                         .environment(currentUser)
+                        .interactiveDismissDisabled()
                 })
                 
                 SideMenu(

--- a/Nos/Views/RepliesView.swift
+++ b/Nos/Views/RepliesView.swift
@@ -115,6 +115,7 @@ struct RepliesView: View {
                         .sheet(isPresented: $showReplyComposer, content: {
                             NewNoteView(replyTo: note, isPresented: $showReplyComposer)
                                 .environment(currentUser)
+                                .interactiveDismissDisabled()
                         })
                         
                         ForEach(directReplies.reversed()) { event in


### PR DESCRIPTION
## Issues covered
#1357 

## Description
Now when you tap or click outside of the New Post view, it does not get dismissed. This prevents accidental dismissals which have caused at least one user to lose all the text they had typed into the New Post view.

## How to test
1. Tap the Post button on iPad or Mac
2. Tap outside of the New Post view
3. Observe that it does not get dismissed

## Screenshots/Video
Post screenshots or video showing your changes, ideally showing how the app worked before and after these changes. Delete this section if this PR contains no visual changes.
