### PR TITLE
Report large parse queue in Sentry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - Remove stories UI to improve performance.
+- Report error to Sentry when parse queue contains over 1000 events.
 
 ## [0.1.22] - 2024-07-26Z
 

--- a/Nos/Service/CrashReporting.swift
+++ b/Nos/Service/CrashReporting.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Logger
 import Sentry
 
 /// An abstraction of an external crash reporting service, like Sentry.io
@@ -45,10 +46,12 @@ class CrashReporting {
     }
 
     func report(_ error: Error) {
+        Log.info("Reporting error to Crash Reporting service: \(error.localizedDescription)")
         sentry.capture(error: error)
     }
     
     func report(_ errorMessage: String) {
+        Log.info("Reporting error to Crash Reporting service: \(errorMessage)")
         sentry.capture(message: errorMessage)
     }
     

--- a/Nos/Service/CrashReporting.swift
+++ b/Nos/Service/CrashReporting.swift
@@ -46,12 +46,12 @@ class CrashReporting {
     }
 
     func report(_ error: Error) {
-        Log.info("Reporting error to Crash Reporting service: \(error.localizedDescription)")
+        Log.error("Reporting error to Crash Reporting service: \(error.localizedDescription)")
         sentry.capture(error: error)
     }
     
     func report(_ errorMessage: String) {
-        Log.info("Reporting error to Crash Reporting service: \(errorMessage)")
+        Log.error("Reporting error to Crash Reporting service: \(errorMessage)")
         sentry.capture(message: errorMessage)
     }
     

--- a/Nos/Service/Relay/RelayService.swift
+++ b/Nos/Service/Relay/RelayService.swift
@@ -22,6 +22,7 @@ class RelayService: ObservableObject {
     
     @Dependency(\.persistenceController) var persistenceController
     @Dependency(\.analytics) private var analytics
+    @Dependency(\.crashReporting) private var crashReporting
     @MainActor @Dependency(\.currentUser) private var currentUser
     @Published var numberOfConnectedRelays: Int = 0
     
@@ -399,6 +400,9 @@ extension RelayService {
                     "\(remainingEventCount) events left in parse queue."
                 )
                 #endif
+                if remainingEventCount >= 1000 && remainingEventCount < 1030 {
+                    self.crashReporting.report("Parse queue is large: currently \(remainingEventCount) events")
+                }
                 try self.parseContext.saveIfNeeded()
                 try self.persistenceController.viewContext.saveIfNeeded()
             }

--- a/Nos/Service/Relay/RelayService.swift
+++ b/Nos/Service/Relay/RelayService.swift
@@ -401,7 +401,7 @@ extension RelayService {
                 )
                 #endif
                 if remainingEventCount >= 1000 && remainingEventCount < 1030 {
-                    self.crashReporting.report("Parse queue is large: currently \(remainingEventCount) events")
+                    self.crashReporting.report("Parse queue is large: currently 1000+ events")
                 }
                 try self.parseContext.saveIfNeeded()
                 try self.persistenceController.viewContext.saveIfNeeded()


### PR DESCRIPTION
## Issues covered
#1309

## Description
Just a little reporting in case the parse queue gets large for our users -- at least we'll know in Sentry.

## How to test
1. Navigate to Feed
2. Scroll a lot, really fast, and try to trigger the "large parse queue" error. It'll show up in the console something like this:

```
Parsed 30 events and saved 12 to database. 1107 events left in parse queue.
Parsed 30 events and saved 7 to database. 1091 events left in parse queue.
Parsed 30 events and saved 5 to database. 1061 events left in parse queue.
Parsed 30 events and saved 5 to database. 1031 events left in parse queue.
Parsed 30 events and saved 6 to database. 1003 events left in parse queue.
Reporting error to Crash Reporting service: Parse queue is large: currently 1003 events
```

I thought logging any error reporting to the console would be nice, so I added that to `CrashReporting`. And I set the range for parse queue to 1000-1029 to try to ensure we don't log it too often, since we process 30 events at a time.
