### PR TITLE
Update following list to newer bio cards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - Fixed the issue where tapping outside the New Post view caused it to disappear and all its text to be lost.
+- Updated the design of the cards in the Following list.
 - Remove stories UI to improve performance.
 - Report error to Sentry when parse queue contains over 1000 events.
 

--- a/Nos.xcodeproj/project.pbxproj
+++ b/Nos.xcodeproj/project.pbxproj
@@ -153,7 +153,7 @@
 		A303AF8329A9153A005DC8FC /* FollowButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = A303AF8229A9153A005DC8FC /* FollowButton.swift */; };
 		A32B6C7129A672BC00653FF5 /* CurrentUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = A34E439829A522F20057AFCB /* CurrentUser.swift */; };
 		A32B6C7329A6BE9B00653FF5 /* FollowsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A32B6C7229A6BE9B00653FF5 /* FollowsView.swift */; };
-		A32B6C7829A6C99200653FF5 /* FollowCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = A32B6C7729A6C99200653FF5 /* FollowCard.swift */; };
+		A32B6C7829A6C99200653FF5 /* MuteCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = A32B6C7729A6C99200653FF5 /* MuteCard.swift */; };
 		A336DD3C299FD78000A0CBA0 /* Filter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A336DD3B299FD78000A0CBA0 /* Filter.swift */; };
 		A34E439929A522F20057AFCB /* CurrentUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = A34E439829A522F20057AFCB /* CurrentUser.swift */; };
 		A351E1A229BA92240009B7F6 /* ProfileEditView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A351E1A129BA92240009B7F6 /* ProfileEditView.swift */; };
@@ -630,7 +630,7 @@
 		65D066982BD558690011C5CD /* DirectMessageWrapper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DirectMessageWrapper.swift; sourceTree = "<group>"; };
 		A303AF8229A9153A005DC8FC /* FollowButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FollowButton.swift; sourceTree = "<group>"; };
 		A32B6C7229A6BE9B00653FF5 /* FollowsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FollowsView.swift; sourceTree = "<group>"; };
-		A32B6C7729A6C99200653FF5 /* FollowCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FollowCard.swift; sourceTree = "<group>"; };
+		A32B6C7729A6C99200653FF5 /* MuteCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MuteCard.swift; sourceTree = "<group>"; };
 		A336DD3B299FD78000A0CBA0 /* Filter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Filter.swift; sourceTree = "<group>"; };
 		A34E439829A522F20057AFCB /* CurrentUser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentUser.swift; sourceTree = "<group>"; };
 		A351E1A129BA92240009B7F6 /* ProfileEditView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProfileEditView.swift; sourceTree = "<group>"; };
@@ -1550,7 +1550,6 @@
 				C9DFA96A299BEE2C006929C1 /* CompactNoteView.swift */,
 				5B0D99022A94090A0039F0C5 /* DoubleTapToPopModifier.swift */,
 				A303AF8229A9153A005DC8FC /* FollowButton.swift */,
-				A32B6C7729A6C99200653FF5 /* FollowCard.swift */,
 				A32B6C7229A6BE9B00653FF5 /* FollowsView.swift */,
 				C9B678E629F01A8500303F33 /* FullscreenProgressView.swift */,
 				C9CDBBA329A8FA2900C555C7 /* GoldenPostView.swift */,
@@ -1559,6 +1558,7 @@
 				2D4010A12AD87DF300F93AD4 /* KnownFollowersView.swift */,
 				C960C57029F3236200929990 /* LikeButton.swift */,
 				C905B0762A619E99009B8A78 /* LinkPreview.swift */,
+				A32B6C7729A6C99200653FF5 /* MuteCard.swift */,
 				5BFF66B52A58A8A000AA79DD /* MutesView.swift */,
 				C9E8C1142B081EBE002D46B0 /* NIP05View.swift */,
 				C9A0DADC29C689C900466635 /* NosNavigationBar.swift */,
@@ -1581,6 +1581,7 @@
 				C93EC2F029C337EB0012EE2A /* RelayPicker.swift */,
 				C97465332A3C95FE0031226F /* RelayPickerToolbarButton.swift */,
 				C9DEC069298965540078B43A /* RelayView.swift */,
+				5B6136372C2F408E00ADD9C3 /* RepliesLabel.swift */,
 				C9DFA970299BF8CD006929C1 /* RepliesView.swift */,
 				5BE281C62AE2CCD800880466 /* ReplyButton.swift */,
 				CD4908D329B92941007443DB /* ReportABugMailView.swift */,
@@ -1610,7 +1611,6 @@
 				C9032C2C2BAE31DA001F4EC6 /* Profile */,
 				5B79F5E92B97B5D7002DA9BE /* ProfileEdit */,
 				C905EA362A33620A006F1E99 /* UNS */,
-				5B6136372C2F408E00ADD9C3 /* RepliesLabel.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -2052,7 +2052,7 @@
 				C9A6C7472AD84263001F9500 /* UNSNamePicker.swift in Sources */,
 				C92E7F672C4EFF3D00B80638 /* WebSocketErrorEvent.swift in Sources */,
 				C93EC2F729C351470012EE2A /* Optional+Unwrap.swift in Sources */,
-				A32B6C7829A6C99200653FF5 /* FollowCard.swift in Sources */,
+				A32B6C7829A6C99200653FF5 /* MuteCard.swift in Sources */,
 				C92DF80829C25FA900400561 /* SquareImage.swift in Sources */,
 				5B29B58E2BEC392B008F6008 /* ActivityPubBadgeView.swift in Sources */,
 				C9DEBFD9298941000078B43A /* HomeFeedView.swift in Sources */,

--- a/Nos.xcodeproj/project.pbxproj
+++ b/Nos.xcodeproj/project.pbxproj
@@ -153,7 +153,7 @@
 		A303AF8329A9153A005DC8FC /* FollowButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = A303AF8229A9153A005DC8FC /* FollowButton.swift */; };
 		A32B6C7129A672BC00653FF5 /* CurrentUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = A34E439829A522F20057AFCB /* CurrentUser.swift */; };
 		A32B6C7329A6BE9B00653FF5 /* FollowsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A32B6C7229A6BE9B00653FF5 /* FollowsView.swift */; };
-		A32B6C7829A6C99200653FF5 /* MuteCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = A32B6C7729A6C99200653FF5 /* MuteCard.swift */; };
+		A32B6C7829A6C99200653FF5 /* CompactAuthorCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = A32B6C7729A6C99200653FF5 /* CompactAuthorCard.swift */; };
 		A336DD3C299FD78000A0CBA0 /* Filter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A336DD3B299FD78000A0CBA0 /* Filter.swift */; };
 		A34E439929A522F20057AFCB /* CurrentUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = A34E439829A522F20057AFCB /* CurrentUser.swift */; };
 		A351E1A229BA92240009B7F6 /* ProfileEditView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A351E1A129BA92240009B7F6 /* ProfileEditView.swift */; };
@@ -630,7 +630,7 @@
 		65D066982BD558690011C5CD /* DirectMessageWrapper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DirectMessageWrapper.swift; sourceTree = "<group>"; };
 		A303AF8229A9153A005DC8FC /* FollowButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FollowButton.swift; sourceTree = "<group>"; };
 		A32B6C7229A6BE9B00653FF5 /* FollowsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FollowsView.swift; sourceTree = "<group>"; };
-		A32B6C7729A6C99200653FF5 /* MuteCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MuteCard.swift; sourceTree = "<group>"; };
+		A32B6C7729A6C99200653FF5 /* CompactAuthorCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompactAuthorCard.swift; sourceTree = "<group>"; };
 		A336DD3B299FD78000A0CBA0 /* Filter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Filter.swift; sourceTree = "<group>"; };
 		A34E439829A522F20057AFCB /* CurrentUser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentUser.swift; sourceTree = "<group>"; };
 		A351E1A129BA92240009B7F6 /* ProfileEditView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProfileEditView.swift; sourceTree = "<group>"; };
@@ -1547,6 +1547,7 @@
 				CD2CF38D299E67F900332116 /* CardButtonStyle.swift */,
 				C9DFA968299BEC33006929C1 /* CardStyle.swift */,
 				65BD8DB82BDAF28200802039 /* CircularFollowButton.swift */,
+				A32B6C7729A6C99200653FF5 /* CompactAuthorCard.swift */,
 				C9DFA96A299BEE2C006929C1 /* CompactNoteView.swift */,
 				5B0D99022A94090A0039F0C5 /* DoubleTapToPopModifier.swift */,
 				A303AF8229A9153A005DC8FC /* FollowButton.swift */,
@@ -1558,7 +1559,6 @@
 				2D4010A12AD87DF300F93AD4 /* KnownFollowersView.swift */,
 				C960C57029F3236200929990 /* LikeButton.swift */,
 				C905B0762A619E99009B8A78 /* LinkPreview.swift */,
-				A32B6C7729A6C99200653FF5 /* MuteCard.swift */,
 				5BFF66B52A58A8A000AA79DD /* MutesView.swift */,
 				C9E8C1142B081EBE002D46B0 /* NIP05View.swift */,
 				C9A0DADC29C689C900466635 /* NosNavigationBar.swift */,
@@ -2052,7 +2052,7 @@
 				C9A6C7472AD84263001F9500 /* UNSNamePicker.swift in Sources */,
 				C92E7F672C4EFF3D00B80638 /* WebSocketErrorEvent.swift in Sources */,
 				C93EC2F729C351470012EE2A /* Optional+Unwrap.swift in Sources */,
-				A32B6C7829A6C99200653FF5 /* MuteCard.swift in Sources */,
+				A32B6C7829A6C99200653FF5 /* CompactAuthorCard.swift in Sources */,
 				C92DF80829C25FA900400561 /* SquareImage.swift in Sources */,
 				5B29B58E2BEC392B008F6008 /* ActivityPubBadgeView.swift in Sources */,
 				C9DEBFD9298941000078B43A /* HomeFeedView.swift in Sources */,

--- a/Nos/Views/CompactAuthorCard.swift
+++ b/Nos/Views/CompactAuthorCard.swift
@@ -1,11 +1,10 @@
 import SwiftUI
 
-/// This view displays the information we have for an message suitable for being used in a list or grid.
-///
-/// Use this view inside MessageButton to have nice borders.
-struct MuteCard: View {
+/// Displays the name and photo of an author in a compact view.
+struct CompactAuthorCard: View {
 
-    @ObservedObject var author: Author
+    /// The author to display.
+    let author: Author
 
     @EnvironmentObject private var router: Router
     @EnvironmentObject private var relayService: RelayService

--- a/Nos/Views/FollowsView.swift
+++ b/Nos/Views/FollowsView.swift
@@ -49,6 +49,7 @@ struct FollowsView: View {
             }
             .padding(.vertical, 12)
         }
+        .background(Color.appBg)
         .nosNavigationBar(title: title)
     }
 }

--- a/Nos/Views/MuteCard.swift
+++ b/Nos/Views/MuteCard.swift
@@ -3,14 +3,11 @@ import SwiftUI
 /// This view displays the information we have for an message suitable for being used in a list or grid.
 ///
 /// Use this view inside MessageButton to have nice borders.
-struct FollowCard: View {
+struct MuteCard: View {
 
     @ObservedObject var author: Author
-    
-    var style = CardStyle.compact
 
     @EnvironmentObject private var router: Router
-    @Environment(CurrentUser.self) private var currentUser
     @EnvironmentObject private var relayService: RelayService
     
     @State private var relaySubscriptions = SubscriptionCancellables()
@@ -21,7 +18,7 @@ struct FollowCard: View {
                 Button {
                     router.push(author)
                 } label: {
-                    HStack(alignment: .center) {
+                    HStack {
                         AvatarView(imageUrl: author.profilePhotoURL, size: 24)
                         Text(author.safeName)
                             .lineLimit(1)
@@ -29,19 +26,8 @@ struct FollowCard: View {
                             .foregroundColor(Color.primaryTxt)
                             .multilineTextAlignment(.leading)
                             .frame(maxWidth: .infinity, alignment: .leading)
-                        if author.muted {
-                            Text(.localizable.muted)
-                                .font(.subheadline)
-                                .foregroundColor(Color.secondaryTxt)
-                        }
-                        Spacer()
-                        if let currentUser = currentUser.author {
-                            FollowButton(currentUserAuthor: currentUser, author: author)
-                                .padding(10)
-                        }
                     }
                 }
-                // TODO: Put MessageOptionsButton back here eventually
             }
             .padding(10)
             BeveledSeparator()
@@ -54,7 +40,7 @@ struct FollowCard: View {
             )
         )
         .listRowInsets(EdgeInsets())
-        .cornerRadius(cornerRadius)
+        .cornerRadius(15)
         .onAppear {
             Task(priority: .userInitiated) { 
                 let subscription = await relayService.requestMetadata(
@@ -66,15 +52,6 @@ struct FollowCard: View {
         }
         .onDisappear {
             relaySubscriptions.removeAll()
-        }
-    }
-
-    var cornerRadius: CGFloat {
-        switch style {
-        case .golden:
-            return 15
-        case .compact:
-            return 15
         }
     }
 }

--- a/Nos/Views/MutesView.swift
+++ b/Nos/Views/MutesView.swift
@@ -14,7 +14,7 @@ struct MutesView: View {
         ScrollView(.vertical) {
             LazyVStack {
                 ForEach(authors) { author in
-                    MuteCard(author: author)
+                    CompactAuthorCard(author: author)
                         .padding(.horizontal)
                         .readabilityPadding()
                 }

--- a/Nos/Views/MutesView.swift
+++ b/Nos/Views/MutesView.swift
@@ -14,7 +14,7 @@ struct MutesView: View {
         ScrollView(.vertical) {
             LazyVStack {
                 ForEach(authors) { author in
-                    FollowCard(author: author)
+                    MuteCard(author: author)
                         .padding(.horizontal)
                         .readabilityPadding()
                 }


### PR DESCRIPTION
## Issues covered
#1269

## Description
Updates the following list to the newer bio card design. Also updates the mute list design since it was shared with the old follow card.

## How to test
1. Navigate to a profile
2. Tap the ## following button
3. Observe the new design
4. Navigate to the profile tab (your profile)
5. Tap the three-dot button in the upper right
6. Tap Muted Users
7. Observe the updated design

## Screenshots/Video
| Before | After |
|--------|--------|
| ![Simulator Screenshot - iPhone 15 Pro - 2024-07-30 at 17 25 21](https://github.com/user-attachments/assets/c089d5b3-e7f1-4d33-a008-92393b96d322) | ![Simulator Screenshot - iPhone 15 Pro - 2024-07-30 at 17 20 32](https://github.com/user-attachments/assets/fdbcd96e-3550-4146-af3d-2d0eee38a9ba) |
| ![Simulator Screenshot - iPhone 15 Pro - 2024-07-30 at 17 25 47](https://github.com/user-attachments/assets/c22a7fda-a8fe-44e8-91e4-cafd1190ab07) | ![Simulator Screenshot - iPhone 15 Pro - 2024-07-30 at 17 18 02](https://github.com/user-attachments/assets/394b561c-929f-402e-acf4-329933e62254) | 