### PR TITLE
Add analytics for search on Discover

### DIFF
--- a/Nos/Controller/SearchController.swift
+++ b/Nos/Controller/SearchController.swift
@@ -246,20 +246,20 @@ class SearchController: ObservableObject {
         if trimmedQuery.contains("@") {
             Task(priority: .userInitiated) {
                 if let publicKeyHex = await relayService.retrievePublicKeyFromUsername(trimmedQuery) {
-                    analytics.displayedAuthorFromDiscoverSearch(resultsCount: 1)
                     Task { @MainActor in
+                        analytics.displayedAuthorFromDiscoverSearch(resultsCount: 1)
                         router.pushAuthor(id: publicKeyHex)
                     }
                 }
             }
         } else if let author = author(fromPublicKey: trimmedQuery) {
-            analytics.displayedAuthorFromDiscoverSearch(resultsCount: 1)
             Task { @MainActor in
+                analytics.displayedAuthorFromDiscoverSearch(resultsCount: 1)
                 router.push(author)
             }
         } else if let note = note(fromPublicKey: trimmedQuery) {
-            analytics.displayedNoteFromDiscoverSearch()
             Task { @MainActor in
+                analytics.displayedNoteFromDiscoverSearch()
                 router.push(note)
             }
         } else {

--- a/Nos/Controller/SearchController.swift
+++ b/Nos/Controller/SearchController.swift
@@ -245,18 +245,20 @@ class SearchController: ObservableObject {
         let trimmedQuery = query.lowercased().trimmingCharacters(in: .whitespacesAndNewlines)
         if trimmedQuery.contains("@") {
             Task(priority: .userInitiated) {
-                if let publicKeyHex =
-                    await relayService.retrievePublicKeyFromUsername(trimmedQuery) {
+                if let publicKeyHex = await relayService.retrievePublicKeyFromUsername(trimmedQuery) {
+                    analytics.displayedAuthorFromDiscoverSearch(resultsCount: 1)
                     Task { @MainActor in
                         router.pushAuthor(id: publicKeyHex)
                     }
                 }
             }
         } else if let author = author(fromPublicKey: trimmedQuery) {
+            analytics.displayedAuthorFromDiscoverSearch(resultsCount: 1)
             Task { @MainActor in
                 router.push(author)
             }
         } else if let note = note(fromPublicKey: trimmedQuery) {
+            analytics.displayedNoteFromDiscoverSearch()
             Task { @MainActor in
                 router.push(note)
             }

--- a/Nos/Controller/SearchController.swift
+++ b/Nos/Controller/SearchController.swift
@@ -41,7 +41,8 @@ class SearchController: ObservableObject {
     @Dependency(\.persistenceController) private var persistenceController
     @Dependency(\.unsAPI) var unsAPI
     @Dependency(\.currentUser) var currentUser
-    
+    @Dependency(\.analytics) private var analytics
+
     private var cancellables = [AnyCancellable]()
     private var searchSubscriptions = SubscriptionCancellables()
 
@@ -69,6 +70,10 @@ class SearchController: ObservableObject {
             .filter { !$0.isEmpty }
             .compactMap { [weak self] query in
                 guard let self else { return nil }
+                if self.state == .noQuery {
+                    // User is starting a new search
+                    analytics.searchedDiscover()
+                }
                 self.authorResults = self.authors(named: query)
                 if self.authorResults.isEmpty {
                     // if we had `results` before and don't now, we're `empty`

--- a/Nos/Service/Analytics.swift
+++ b/Nos/Service/Analytics.swift
@@ -144,7 +144,7 @@ class Analytics {
         postHog?.capture(eventName, properties: properties)
     }
 
-    /// Tracks when the user performs a search on the Discover screen.
+    /// Tracks when the user submits a search on the Discover screen.
     func searchedDiscover() {
         track("Searched Discover")
     }

--- a/Nos/Service/Analytics.swift
+++ b/Nos/Service/Analytics.swift
@@ -143,7 +143,12 @@ class Analytics {
         }
         postHog?.capture(eventName, properties: properties)
     }
-    
+
+    /// Tracks when the user performs a search on the Discover screen.
+    func searchedDiscover() {
+        track("Searched Discover")
+    }
+
     // MARK: - Relays
     
     func rateLimited(by socket: WebSocket, requestCount: Int) {

--- a/Nos/Service/Analytics.swift
+++ b/Nos/Service/Analytics.swift
@@ -149,6 +149,14 @@ class Analytics {
         track("Searched Discover")
     }
 
+    /// Tracks when the user taps on a search result on the Discover screen.
+    func displayedAuthorFromDiscoverSearch(resultsCount: Int) {
+        track(
+            "Displayed Author from Discover Search",
+            properties: ["Number of results": resultsCount]
+        )
+    }
+
     // MARK: - Relays
     
     func rateLimited(by socket: WebSocket, requestCount: Int) {

--- a/Nos/Service/Analytics.swift
+++ b/Nos/Service/Analytics.swift
@@ -146,13 +146,13 @@ class Analytics {
 
     /// Tracks when the user submits a search on the Discover screen.
     func searchedDiscover() {
-        track("Searched Discover")
+        track("Discover Search Started")
     }
 
     /// Tracks when the user taps on a search result on the Discover screen.
     func displayedAuthorFromDiscoverSearch(resultsCount: Int) {
         track(
-            "Displayed Author from Discover Search",
+            "Discover Search Displayed Author",
             properties: ["Number of results": resultsCount]
         )
     }
@@ -160,7 +160,7 @@ class Analytics {
     /// Tracks when the user navigates to a note from the Discover search screen.
     func displayedNoteFromDiscoverSearch() {
         track(
-            "Displayed Note from Discover Search"
+            "Discover Search Displayed Note"
         )
     }
 

--- a/Nos/Service/Analytics.swift
+++ b/Nos/Service/Analytics.swift
@@ -157,6 +157,13 @@ class Analytics {
         )
     }
 
+    /// Tracks when the user navigates to a note from the Discover search screen.
+    func displayedNoteFromDiscoverSearch() {
+        track(
+            "Displayed Note from Discover Search"
+        )
+    }
+
     // MARK: - Relays
     
     func rateLimited(by socket: WebSocket, requestCount: Int) {

--- a/Nos/Views/Discover/DiscoverContentsView.swift
+++ b/Nos/Views/Discover/DiscoverContentsView.swift
@@ -11,6 +11,7 @@ struct DiscoverContentsView: View {
 
     @Dependency(\.relayService) private var relayService
     @Dependency(\.crashReporting) private var crashReporting
+    @Dependency(\.analytics) private var analytics
 
     /// The IDs of the authors we will display when we aren't searching.
     @State private var featuredAuthorIDs = [RawAuthorID]()
@@ -50,6 +51,10 @@ struct DiscoverContentsView: View {
                             LazyVStack {
                                 ForEach(searchController.authorResults) { author in
                                     AuthorCard(author: author) {
+                                        let resultsCount = searchController.authorResults.count
+                                        analytics.displayedAuthorFromDiscoverSearch(
+                                            resultsCount: resultsCount
+                                        )
                                         router.push(author)
                                     }
                                     .padding(.horizontal, 15)

--- a/Nos/Views/Discover/DiscoverTab.swift
+++ b/Nos/Views/Discover/DiscoverTab.swift
@@ -37,7 +37,6 @@ struct DiscoverTab: View {
             )
             .autocorrectionDisabled()
             .onSubmit(of: .search) {
-                analytics.searchedDiscover()
                 searchController.submitSearch(query: searchController.query)
             }
             .background(Color.appBg)

--- a/Nos/Views/Discover/DiscoverTab.swift
+++ b/Nos/Views/Discover/DiscoverTab.swift
@@ -37,6 +37,7 @@ struct DiscoverTab: View {
             )
             .autocorrectionDisabled()
             .onSubmit(of: .search) {
+                analytics.searchedDiscover()
                 searchController.submitSearch(query: searchController.query)
             }
             .background(Color.appBg)


### PR DESCRIPTION
## Issues covered
#1304

## Description
This adds two new events to track search actions in the Discover screen. As recommended in https://github.com/planetary-social/nos/issues/1304#issuecomment-2229191372 I'm tracking the number of search results when the user taps on a search result (an author).

## How to test
1. Navigate to Discover
2. Search for something, maybe "Jo" and tap submit (if on an iPhone/iPad) or just enter (if on a Mac)
3. Tap on a search result, "Johanna" in my case
4. On posthog, you should see an event for action performed in step 2, and another one for action performed in step 3 (this time, with a property indicating the number of search results, 6 in my case)
