### PR TITLE
Disable "Post" button while media is uploading #1347

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Disable the Post button while images are still uploading. Thanks @vien-eaker!
 - Improved app performance on first login by requesting fewer events from relays.
 
 ## [0.1.23] - 2024-07-31Z

--- a/Nos/Views/New Note/NewNoteView.swift
+++ b/Nos/Views/New Note/NewNoteView.swift
@@ -146,7 +146,7 @@ struct NewNoteView: View {
                 },
                 trailing: ActionButton(title: .localizable.post, action: postAction)
                     .frame(height: 22)
-                    .disabled(text.string.isEmpty)
+                    .disabled(text.string.isEmpty || isUploadingImage)
                     .padding(.bottom, 3)
             )
             .onAppear {


### PR DESCRIPTION
## Issues covered
fix bug : [1347](https://github.com/planetary-social/nos/issues/1347)

## Description
 I found that the isUploadingImage flag is set to true during image uploads. I have included this flag in the disable condition of the Post button.

## How to test
1. Navigate to Post then input message then upload image.
2. While Image uploading tap on Post button. Post button is disable.

## Screenshots/Video
Before fixed : https://github.com/user-attachments/assets/9c556393-4b68-4e2d-891b-0b68ea2bcfc4

After fixed : https://github.com/user-attachments/assets/d0cddb68-fcfe-4319-9601-990b0ab764c3