### PR TITLE
Turn off automatic screen captures in PostHog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Removed analytics events sent each time the user navigate to a new screen.
+- Disabled automatically generated analytics events that were sent each time the user navigated to a new screen.
 - Show “New notes available” notification on Feed when there are new notes to display.
 - Disable the Post button while images are still uploading. Thanks @vien-eaker!
 - Improved app performance on first login by requesting fewer events from relays.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Removed analytics events sent each time the user navigate to a new screen.
 - Show “New notes available” notification on Feed when there are new notes to display.
 - Disable the Post button while images are still uploading. Thanks @vien-eaker!
 - Improved app performance on first login by requesting fewer events from relays.

--- a/Nos/Service/Analytics.swift
+++ b/Nos/Service/Analytics.swift
@@ -16,7 +16,7 @@ class Analytics {
             let configuration = PostHogConfig(apiKey: apiKey, host: "https://posthog.planetary.tools")
 
             configuration.captureApplicationLifecycleEvents = true
-            configuration.captureScreenViews = true
+            configuration.captureScreenViews = false
             // TODO: write screen views to log
 
             PostHogSDK.shared.setup(configuration)


### PR DESCRIPTION
## Issues covered
#1385 

## Description
This PR disables the automatic screen event capture in PostHog, as it isn’t useful for Swift, and clutters PostHog with unnecessary events.
Relevant discussion https://planetary-app.slack.com/archives/C04PLR5QFQQ/p1722972656748709 

## How to test
1. Use the app
2. Open PostHog
3. See that is not cluttered anymore

## Screenshots/Video
![Captura de pantalla 2024-08-06 a la(s) 4 28 21 p  m](https://github.com/user-attachments/assets/1757d7f1-cf08-4da4-bf43-37183060593a)

