### PR TITLE
#1371: add push notifications for profile zaps, add zaps to Notifications view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed a bug where the cursor could jump around when composing a note.
 - Fixed a bug where mentions could be duplicated when typing in the middle of one.
 - Re-enabled autocomplete when composing a note.
+- Added push notifications for zaps.
+- Added zaps to the Notifications view.
 
 ## [0.1.23] - 2024-07-31Z
 

--- a/Nos.xcodeproj/project.pbxproj
+++ b/Nos.xcodeproj/project.pbxproj
@@ -101,6 +101,11 @@
 		3FFB1D9729A6BBEC002A755D /* Collection+SafeSubscript.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FFB1D9529A6BBEC002A755D /* Collection+SafeSubscript.swift */; };
 		3FFB1D9C29A7DF9D002A755D /* StackedAvatarsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FFB1D9B29A7DF9D002A755D /* StackedAvatarsView.swift */; };
 		3FFF3BD029A9645F00DD0B72 /* AuthorReference+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F43C47529A9625700E896A0 /* AuthorReference+CoreDataClass.swift */; };
+		509532DF2C62360500E0BACA /* NotificationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 509532DE2C62360500E0BACA /* NotificationTests.swift */; };
+		509533002C62535400E0BACA /* zap_request.json in Resources */ = {isa = PBXBuildFile; fileRef = 509532FF2C62535400E0BACA /* zap_request.json */; };
+		5095330B2C625B5D00E0BACA /* zap_request_one_sat.json in Resources */ = {isa = PBXBuildFile; fileRef = 509533092C625B5D00E0BACA /* zap_request_one_sat.json */; };
+		5095330C2C625B5D00E0BACA /* zap_request_no_amount.json in Resources */ = {isa = PBXBuildFile; fileRef = 5095330A2C625B5D00E0BACA /* zap_request_no_amount.json */; };
+		50F695072C6392C4000E4C74 /* zap_receipt.json in Resources */ = {isa = PBXBuildFile; fileRef = 50F695062C6392C4000E4C74 /* zap_receipt.json */; };
 		5B098DBC2BDAF6CB00500A1B /* NoteParserTests+NIP08.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B098DBB2BDAF6CB00500A1B /* NoteParserTests+NIP08.swift */; };
 		5B098DC62BDAF73500500A1B /* AttributedString+Links.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B098DC52BDAF73500500A1B /* AttributedString+Links.swift */; };
 		5B098DC72BDAF77400500A1B /* AttributedString+Links.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B098DC52BDAF73500500A1B /* AttributedString+Links.swift */; };
@@ -584,6 +589,11 @@
 		3FFB1D9229A6BBCE002A755D /* EventReference+CoreDataClass.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "EventReference+CoreDataClass.swift"; sourceTree = "<group>"; };
 		3FFB1D9529A6BBEC002A755D /* Collection+SafeSubscript.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Collection+SafeSubscript.swift"; sourceTree = "<group>"; };
 		3FFB1D9B29A7DF9D002A755D /* StackedAvatarsView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StackedAvatarsView.swift; sourceTree = "<group>"; };
+		509532DE2C62360500E0BACA /* NotificationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationTests.swift; sourceTree = "<group>"; };
+		509532FF2C62535400E0BACA /* zap_request.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = zap_request.json; sourceTree = "<group>"; };
+		509533092C625B5D00E0BACA /* zap_request_one_sat.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = zap_request_one_sat.json; sourceTree = "<group>"; };
+		5095330A2C625B5D00E0BACA /* zap_request_no_amount.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = zap_request_no_amount.json; sourceTree = "<group>"; };
+		50F695062C6392C4000E4C74 /* zap_receipt.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = zap_receipt.json; sourceTree = "<group>"; };
 		5B098DBB2BDAF6CB00500A1B /* NoteParserTests+NIP08.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NoteParserTests+NIP08.swift"; sourceTree = "<group>"; };
 		5B098DC52BDAF73500500A1B /* AttributedString+Links.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AttributedString+Links.swift"; sourceTree = "<group>"; };
 		5B098DC82BDAF7CF00500A1B /* NoteParserTests+NIP27.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NoteParserTests+NIP27.swift"; sourceTree = "<group>"; };
@@ -994,6 +1004,7 @@
 				03ED93462C46C48400C8D443 /* JSONEventTests.swift */,
 				035729A52BE4167E005FEE85 /* KeyPairTests.swift */,
 				035729A62BE4167E005FEE85 /* NoteParserTests.swift */,
+				509532DE2C62360500E0BACA /* NotificationTests.swift */,
 				03A3AA3A2C5028FF008FE153 /* PublicKeyTests.swift */,
 				035729A72BE4167E005FEE85 /* ReportTests.swift */,
 				035729A82BE4167E005FEE85 /* SHA256KeyTests.swift */,
@@ -1449,6 +1460,10 @@
 				C94B2D172B17F5EC002104B6 /* sample_repost.json */,
 				0350F12A2C0A49D40024CC15 /* text_note.json */,
 				039C961E2C480F4100A8EB39 /* unsupported_kinds.json */,
+				509532FF2C62535400E0BACA /* zap_request.json */,
+				5095330A2C625B5D00E0BACA /* zap_request_no_amount.json */,
+				509533092C625B5D00E0BACA /* zap_request_one_sat.json */,
+				50F695062C6392C4000E4C74 /* zap_receipt.json */,
 				C9ADB134299288230075E7F8 /* KeyFixture.swift */,
 				C90B16B72AFED96300CB4B85 /* URLExtensionTests.swift */,
 			);
@@ -1847,6 +1862,7 @@
 				C987F84529BA951E00B44E7A /* ClarityCity-ExtraBoldItalic.otf in Resources */,
 				C987F84329BA951E00B44E7A /* ClarityCity-Black.otf in Resources */,
 				C9BD91892B61BBEF00FDA083 /* bad_contact_list.json in Resources */,
+				50F695072C6392C4000E4C74 /* zap_receipt.json in Resources */,
 				039C96292C48321E00A8EB39 /* long_form_data.json in Resources */,
 				C987F85329BA951E00B44E7A /* ClarityCity-Regular.otf in Resources */,
 				C987F84729BA951E00B44E7A /* ClarityCity-Light.otf in Resources */,
@@ -1854,12 +1870,14 @@
 				C987F85129BA951E00B44E7A /* ClarityCity-ExtraLightItalic.otf in Resources */,
 				C987F84D29BA951E00B44E7A /* ClarityCity-ThinItalic.otf in Resources */,
 				03B4E6A22C125CA1006E5F59 /* nostr_build_nip96_upload_response.json in Resources */,
+				5095330C2C625B5D00E0BACA /* zap_request_no_amount.json in Resources */,
 				C987F84F29BA951E00B44E7A /* ClarityCity-RegularItalic.otf in Resources */,
 				CD27177629A7C8B200AE8888 /* sample_replies.json in Resources */,
 				C987F83B29BA951E00B44E7A /* ClarityCity-BoldItalic.otf in Resources */,
 				C987F84129BA951E00B44E7A /* ClarityCity-SemiBoldItalic.otf in Resources */,
 				C987F83529BA951E00B44E7A /* ClarityCity-LightItalic.otf in Resources */,
 				3AEABEFD2B2BF84C001BC933 /* Localizable.xcstrings in Resources */,
+				5095330B2C625B5D00E0BACA /* zap_request_one_sat.json in Resources */,
 				0350F12B2C0A49D40024CC15 /* text_note.json in Resources */,
 				C987F85529BA951E00B44E7A /* ClarityCity-Thin.otf in Resources */,
 				C987F83F29BA951E00B44E7A /* ClarityCity-SemiBold.otf in Resources */,
@@ -1870,6 +1888,7 @@
 				C9DEC006298947900078B43A /* sample_data.json in Resources */,
 				C94B2D182B17F5EC002104B6 /* sample_repost.json in Resources */,
 				C987F84929BA951E00B44E7A /* ClarityCity-BlackItalic.otf in Resources */,
+				509533002C62535400E0BACA /* zap_request.json in Resources */,
 				032634682C10C0D600E489B5 /* nostr_build_nip96_response.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -2290,6 +2309,7 @@
 				035729AE2BE4167E005FEE85 /* FollowTests.swift in Sources */,
 				5BFBB2952BD9D7EB002E909F /* URLParserTests.swift in Sources */,
 				C91400252B2A3ABF009B13B4 /* SQLiteStoreTestCase.swift in Sources */,
+				509532DF2C62360500E0BACA /* NotificationTests.swift in Sources */,
 				C9DEC04E29894BED0078B43A /* Author+CoreDataClass.swift in Sources */,
 				034EBDC72C2489B4006BA35A /* CurrentUserError.swift in Sources */,
 				C9ADB14229951CB10075E7F8 /* NSManagedObject+Nos.swift in Sources */,

--- a/Nos/Assets/Localization/Reply.xcstrings
+++ b/Nos/Assets/Localization/Reply.xcstrings
@@ -563,18 +563,18 @@
         }
       }
     },
-    "zappedYourProfile" : {
+    "zappedYou" : {
       "extractionState" : "manual",
       "localizations" : {
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "⚡️ your profile!"
+            "value" : "⚡️ zapped you!"
           }
         }
       }
     },
-    "zappedYourProfileSats" : {
+    "zappedYouSats" : {
       "extractionState" : "manual",
       "localizations" : {
         "en" : {
@@ -583,13 +583,13 @@
               "one" : {
                 "stringUnit" : {
                   "state" : "translated",
-                  "value" : "⚡️ your profile %ld sat!"
+                  "value" : "⚡️ zapped you %ld sat!"
                 }
               },
               "other" : {
                 "stringUnit" : {
                   "state" : "translated",
-                  "value" : "⚡️ your profile %ld sats!"
+                  "value" : "⚡️ zapped you %ld sats!"
                 }
               }
             }

--- a/Nos/Assets/Localization/Reply.xcstrings
+++ b/Nos/Assets/Localization/Reply.xcstrings
@@ -562,6 +562,40 @@
           }
         }
       }
+    },
+    "zappedYourProfile" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "⚡️ your profile!"
+          }
+        }
+      }
+    },
+    "zappedYourProfileSats" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "⚡️ your profile %ld sat!"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "⚡️ your profile %ld sats!"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "version" : "1.0"

--- a/Nos/Models/EventKind.swift
+++ b/Nos/Models/EventKind.swift
@@ -45,6 +45,12 @@ public enum EventKind: Int64, CaseIterable, Hashable {
     /// Notification Service Registration
     case notificationServiceRegistration = 6666
 
+    /// Zap Request
+    case zapRequest = 9734
+    
+    /// Zap Receipt
+    case zapReceipt = 9735
+    
     /// Mute List
     case mute = 10_000
 

--- a/Nos/Models/NotificationViewModel.swift
+++ b/Nos/Models/NotificationViewModel.swift
@@ -62,9 +62,10 @@ class NotificationViewModel: ObservableObject, Identifiable {
                 let amountTag = tags.first(where: { $0.first == "amount" }),
                 let amountInMillisatsAsString = amountTag[safe: 1],
                 let amountInMillisats = Int(amountInMillisatsAsString) {
-                actionText = authorName + AttributedString(String(localized: .reply.zappedYourProfileSats(amountInMillisats / 1000)))
+                let zapText = String(localized: .reply.zappedYouSats(amountInMillisats / 1000))
+                actionText = authorName + AttributedString(zapText)
             } else {
-                actionText = authorName + AttributedString(String(localized: .reply.zappedYourProfile))
+                actionText = authorName + AttributedString(String(localized: .reply.zappedYou))
             }
         } else if note.isReply(to: user) {
             actionText = authorName + AttributedString(String(localized: .reply.repliedToYourNote))

--- a/Nos/Models/NotificationViewModel.swift
+++ b/Nos/Models/NotificationViewModel.swift
@@ -57,7 +57,16 @@ class NotificationViewModel: ObservableObject, Identifiable {
         var range = Range(uncheckedBounds: (authorName.startIndex, authorName.endIndex))
         authorName[range].font = .boldSystemFont(ofSize: 17)
         
-        if note.isReply(to: user) {
+        if note.isProfileZap(to: user) {
+            if let tags = note.allTags as? [[String]],
+                let amountTag = tags.first(where: { $0.first == "amount" }),
+                let amountInMillisatsAsString = amountTag[safe: 1],
+                let amountInMillisats = Int(amountInMillisatsAsString) {
+                actionText = authorName + AttributedString(String(localized: .reply.zappedYourProfileSats(amountInMillisats / 1000)))
+            } else {
+                actionText = authorName + AttributedString(String(localized: .reply.zappedYourProfile))
+            }
+        } else if note.isReply(to: user) {
             actionText = authorName + AttributedString(String(localized: .reply.repliedToYourNote))
         } else if note.references(author: user) {
             actionText = authorName + AttributedString(String(localized: .reply.mentionedYou))

--- a/Nos/Service/CurrentUser.swift
+++ b/Nos/Service/CurrentUser.swift
@@ -175,7 +175,7 @@ import Dependencies
     }
 
     /// Subscribes to relays for important events concerning the current user like their latest contact list, 
-    /// notifications, reports, mutes, etc.
+    /// notifications, reports, mutes, zaps, etc.
     @MainActor func subscribe() async {
         guard let key = publicKeyHex, let author else {
             return
@@ -190,12 +190,12 @@ import Dependencies
         )
         
         // Subscribe to important events we may not get incidentally while browsing the feed
-        let latestRecievedEvent = try? viewContext.fetch(Event.lastReceived(for: author)).first
+        let latestReceivedEvent = try? viewContext.fetch(Event.lastReceived(for: author)).first
         let importantEventsFilter = Filter(
             authorKeys: [key],
-            kinds: [.mute, .delete, .report, .contactList],
+            kinds: [.mute, .delete, .report, .contactList, .zapRequest],
             limit: 100,
-            since: latestRecievedEvent?.receivedAt,
+            since: latestReceivedEvent?.receivedAt,
             keepSubscriptionOpen: true
         )
         subscriptions.append(

--- a/Nos/Service/EventProcessor.swift
+++ b/Nos/Service/EventProcessor.swift
@@ -4,6 +4,7 @@ import Logger
 
 /// The event processor consumes raw event data from the relays and writes it to Core Data.
 enum EventProcessor {
+    @discardableResult
     static func parse(
         jsonEvent: JSONEvent,
         from relay: Relay?,
@@ -30,6 +31,15 @@ enum EventProcessor {
                     throw EventError.invalidSignature(event)
                 }
                 event.isVerified = true
+            }
+            
+            // if this is a zap receipt, pull the zap request out of the description tag and parse it as well
+            if event.kind == EventKind.zapReceipt.rawValue,
+                let tags = event.allTags as? [[String]],
+                let descriptionTag = tags.first(where: { $0.first == "description" }),
+                let zapRequestJSONData = descriptionTag.last?.data(using: .utf8) {
+                let zapRequest = try JSONDecoder().decode(JSONEvent.self, from: zapRequestJSONData)
+                try parse(jsonEvent: zapRequest, from: relay, in: parseContext, skipVerification: skipVerification)
             }
             
             return event

--- a/Nos/Views/NotificationCard.swift
+++ b/Nos/Views/NotificationCard.swift
@@ -35,23 +35,25 @@ struct NotificationCard: View {
                 VStack {
                     HStack {
                         Text(viewModel.actionText)
-                            .lineLimit(1)
+                            .lineLimit(2)
                         Spacer()
                     }
-                    HStack {
-                        let contentText = Text("\"" + (content ?? "") + "\"")
-                            .lineLimit(2)
-                            .font(.body)
-                            .foregroundColor(.primaryTxt)
-                            .tint(.accent)
-                            .handleURLsInRouter()
-                        
-                        if viewModel.content == nil {
-                            contentText.redacted(reason: .placeholder)
-                        } else {
-                            contentText
+                    if let contentText = content, !contentText.characters.isEmpty {
+                        HStack {
+                            let contentText = Text("\"" + (content ?? "") + "\"")
+                                .lineLimit(2)
+                                .font(.body)
+                                .foregroundColor(.primaryTxt)
+                                .tint(.accent)
+                                .handleURLsInRouter()
+                            
+                            if viewModel.content == nil {
+                                contentText.redacted(reason: .placeholder)
+                            } else {
+                                contentText
+                            }
+                            Spacer()
                         }
-                        Spacer()
                     }
                 }
                 .frame(maxWidth: .infinity)

--- a/Nos/Views/NotificationCard.swift
+++ b/Nos/Views/NotificationCard.swift
@@ -38,9 +38,9 @@ struct NotificationCard: View {
                             .lineLimit(2)
                         Spacer()
                     }
-                    if let contentText = content, !contentText.characters.isEmpty {
+                    if let content, !content.characters.isEmpty {
                         HStack {
-                            let contentText = Text("\"" + (content ?? "") + "\"")
+                            let contentText = Text("\"" + content + "\"")
                                 .lineLimit(2)
                                 .font(.body)
                                 .foregroundColor(.primaryTxt)

--- a/Nos/Views/NotificationsView.swift
+++ b/Nos/Views/NotificationsView.swift
@@ -38,8 +38,8 @@ struct NotificationsView: View {
         }
         
         let filter = Filter(
-            kinds: [.text], 
-            pTags: [currentUserKey], 
+            kinds: [.text, .zapReceipt],
+            pTags: [currentUserKey],
             limit: 100,
             keepSubscriptionOpen: false
         )

--- a/NosTests/Fixtures/zap_receipt.json
+++ b/NosTests/Fixtures/zap_receipt.json
@@ -1,0 +1,22 @@
+{
+  "id" : "9e722b2b62772f9f48c786e084038ffc039f5600bace1f068bcc2307a5de1553",
+  "pubkey" : "8b7cd4981e30ed2dd6b5ef1f816763453b282b3e44f41ef2a3da77ff5ef8d141",
+  "tags" : [
+    [
+      "p",
+      "07ecf9838136fe430fac43fa0860dbc62a0aac0729c5a33df1192ce75e330c9f"
+    ],
+    [
+      "bolt11",
+      "lnbc200u1pn2aqcnpp527qdqg56k3fyccal2r0tw0uvup8c3yuaecdf6htphnn30aj07gcshp5susgwzf6jp49j4cxanz0sn3tty9gpacdu2pzffujsfh8aw7r22qqcqzzsxqrrs0sp56yqzrw23rjfwq5ltpcmphadkhez3n5rec48se9uzvjk6dcqwhwps9qyyssqs9auayqe55pt7y3l9akn78gha9zv9h2qmrnxtqhfmgzm3asyd4x4d9zwxsz0g9nmvyt44x7mca7zfxnzszhxm25zels3c3cf0jx0uwspk2txgx"
+    ],
+    [
+      "description",
+      "{\"tags\":[[\"p\",\"07ecf9838136fe430fac43fa0860dbc62a0aac0729c5a33df1192ce75e330c9f\"],[\"relays\",\"wss:\/\/welcome.nostr.wine\",\"wss:\/\/filter.nostr.wine\/npub1yaul8k059377u9lsu67de7y637w4jtgeuwcmh5n7788l6xnlnrgs3tvjmf?broadcast=true\",\"wss:\/\/relay.snort.social\",\"wss:\/\/nos.lol\",\"wss:\/\/purplepag.es\",\"wss:\/\/eden.nostr.land\",\"wss:\/\/relay.damus.io\",\"wss:\/\/relay.mostr.pub\",\"wss:\/\/relay.primal.net\",\"ws:\/\/100.120.59.45:4848\"],[\"anon\",\"pzap1xw4mzqgq0htadj7ghfkrhj2am4vulun5mddmsf9rts0ftphgd3ntakqwduwx5av70ny4dl0y2zzl49am5mme72cahsrf6cuacjj5ftzxexf7er06aeycxmve0m9whmup244cgecy48nhykx69qmd2q2dx9fmkxflxjjh8t9lqdxhudpv8mjwm090atl78tma52mhprq0rukep9p88g47k32ahpv06j3u4j89mmy4t0k8hl0y3sr5fqywg575nad9eu9hvff3gv7776zwe3juy6c92s8dryljuggay403tdvrda56wg6dgp8uaz66u05k3u67wcszt9j9hhpsu45djzp5xq08qk8na5ptk2m7nj5ga7qmvmx95ar8ns9phgv0lvhk9xxr242m7st7d6k73yefrkhqcc4j3cvx85frk3f2c8qf0fjcqgfrsddflu4csclnnrvy623l5d4nhku8sagmzaqqlt2d998rdmjvugccgsz9zjky38aqmehzx8kclzrd8g6xukvhhj04ng54kf8gtlvjxm3a45ukuem9592y3czd03xeyx05j9v9p8nsdfuekv2pgm2tyurv2h6sxt3p3zn4ppyxg0kr4cc3dt095edf9dajqjqazhfk9x7w0q42x26mceuyyywp6fnqglm79vpwzlvr22zlf6y2ehntgppf0xvswugjra2e05vmd5fmwu0hfmk2pnej4wxk867kz769p74m5hrxh6wefjwmfcnnv9v6e3flm3pzhxdu982kfe_iv1fczu7qaygvs0l8dvpkne3rkuusw0s2mk\"]],\"pubkey\":\"2656d1495cccf384035a59cce13451c6f280a329f0d1b3bb6758b4830f67909c\",\"kind\":9734,\"sig\":\"8b8758ac005558d8045010644167cae91e4b659321050e5225ee1d81c4c9cc94c375d27d72f2d3de0faf9eec5c9cf4b414226eff73a9f683751305ebef3c3cde\",\"id\":\"6715260809f6f62ea82f8b213ca4cc0abd0426dc860f1c963c0f0207f9fadddb\",\"created_at\":1722712850,\"content\":\"\"}"
+    ]
+  ],
+  "content" : "",
+  "sig" : "6c298a330561d94eb8ac5055bdebcd5b8657eac4b2fea6852e1fb42ad4c0ed8552069ed9dcad5b7d072f419f13a92c2f8e5858cc9fb6872a8b3d5755a069675a",
+  "created_at" : 1722712858,
+  "kind" : 9735
+}

--- a/NosTests/Fixtures/zap_request.json
+++ b/NosTests/Fixtures/zap_request.json
@@ -1,0 +1,18 @@
+{
+    "kind": 9734,
+    "content": "Zapped you!",
+    "tags": [
+        [
+            "p",
+            "alice"
+        ],
+        [
+            "amount",
+            "3500000"
+        ]
+    ],
+    "created_at": 1675264762,
+    "pubkey": "64c4fda06180d01cc83104797e58505359e1856a0fd0d21f1f0c66afd6c23ce0",
+    "id": "931b425e55559541451ddb99bd228bd1e0190af6ed21603b6b98544b42ee3317",
+    "sig": "79862bd81b316411c23467632239750c97f3aa974593c01bd61d2ca85eedbcfd9a18886b0dad1c17b2e8ceb231db37add136fc23120b45aa5403d6fd2d693e9b"
+}

--- a/NosTests/Fixtures/zap_request_no_amount.json
+++ b/NosTests/Fixtures/zap_request_no_amount.json
@@ -1,0 +1,14 @@
+{
+    "kind": 9734,
+    "content": "Zap!",
+    "tags": [
+        [
+            "p",
+            "alice"
+        ]
+    ],
+    "created_at": 1675264762,
+    "pubkey": "64c4fda06180d01cc83104797e58505359e1856a0fd0d21f1f0c66afd6c23ce0",
+    "id": "931b425e55559541451ddb99bd228bd1e0190af6ed21603b6b98544b42ee3317",
+    "sig": "79862bd81b316411c23467632239750c97f3aa974593c01bd61d2ca85eedbcfd9a18886b0dad1c17b2e8ceb231db37add136fc23120b45aa5403d6fd2d693e9b"
+}

--- a/NosTests/Fixtures/zap_request_one_sat.json
+++ b/NosTests/Fixtures/zap_request_one_sat.json
@@ -1,0 +1,18 @@
+{
+    "kind": 9734,
+    "content": "Only one sat",
+    "tags": [
+        [
+            "p",
+            "alice"
+        ],
+        [
+            "amount",
+            "1000"
+        ]
+    ],
+    "created_at": 1675264762,
+    "pubkey": "64c4fda06180d01cc83104797e58505359e1856a0fd0d21f1f0c66afd6c23ce0",
+    "id": "931b425e55559541451ddb99bd228bd1e0190af6ed21603b6b98544b42ee3317",
+    "sig": "79862bd81b316411c23467632239750c97f3aa974593c01bd61d2ca85eedbcfd9a18886b0dad1c17b2e8ceb231db37add136fc23120b45aa5403d6fd2d693e9b"
+}

--- a/NosTests/Integration/EventProcessorIntegrationTests.swift
+++ b/NosTests/Integration/EventProcessorIntegrationTests.swift
@@ -257,6 +257,25 @@ class EventProcessorIntegrationTests: CoreDataTestCase {
         XCTAssertEqual(event?.author?.follows.count, 2)
     }
 
+    // MARK: - Zap Receipt/Request parsing
+    
+    /// When a zap receipt event is parsed, expect that its embedded zap request is also parsed.
+    func testParseZapReceiptAndEmbeddedZapRequest() throws {
+        // Arrange
+        let zapReceiptData = try jsonData(filename: "zap_receipt")
+        let zapReceiptEvent = try JSONDecoder().decode(JSONEvent.self, from: zapReceiptData)
+
+        let context = persistenceController.viewContext
+        
+        // Act
+        _ = try EventProcessor.parse(jsonEvent: zapReceiptEvent, from: nil, in: context)!
+        
+        // Assert
+        let zapRequestEventID = "6715260809f6f62ea82f8b213ca4cc0abd0426dc860f1c963c0f0207f9fadddb"
+        let zapRequestEvent = Event.find(by: zapRequestEventID, context: context)
+        XCTAssertNotNil(zapRequestEvent)
+    }
+    
     // MARK: - Expiration
 
     func testParseExpirationDate() throws {

--- a/NosTests/Models/NotificationTests.swift
+++ b/NosTests/Models/NotificationTests.swift
@@ -11,7 +11,7 @@ final class NotificationTests: CoreDataTestCase {
         let viewModel = NotificationViewModel(note: zapRequest, user: recipient)
         
         let notification = viewModel.notificationCenterRequest
-        XCTAssertEqual(notification.content.title, "npub1vnz0m... ⚡️ your profile 3,500 sats!")
+        XCTAssertEqual(notification.content.title, "npub1vnz0m... ⚡️ zapped you 3,500 sats!")
         XCTAssertEqual(notification.content.body, "Zapped you!")
     }
     
@@ -22,7 +22,7 @@ final class NotificationTests: CoreDataTestCase {
         let viewModel = NotificationViewModel(note: zapRequest, user: recipient)
         
         let notification = viewModel.notificationCenterRequest
-        XCTAssertEqual(notification.content.title, "npub1vnz0m... ⚡️ your profile!")
+        XCTAssertEqual(notification.content.title, "npub1vnz0m... ⚡️ zapped you!")
         XCTAssertEqual(notification.content.body, "Zap!")
     }
     
@@ -33,7 +33,7 @@ final class NotificationTests: CoreDataTestCase {
         let viewModel = NotificationViewModel(note: zapRequest, user: recipient)
         
         let notification = viewModel.notificationCenterRequest
-        XCTAssertEqual(notification.content.title, "npub1vnz0m... ⚡️ your profile 1 sat!")
+        XCTAssertEqual(notification.content.title, "npub1vnz0m... ⚡️ zapped you 1 sat!")
         XCTAssertEqual(notification.content.body, "Only one sat")
     }
     

--- a/NosTests/Models/NotificationTests.swift
+++ b/NosTests/Models/NotificationTests.swift
@@ -1,0 +1,56 @@
+import CoreData
+import Foundation
+import XCTest
+
+final class NotificationTests: CoreDataTestCase {
+    
+    @MainActor
+    func testZapProfileNotification() throws {
+        let zapRequest = try zapRequestEvent(filename: "zap_request")
+        let recipient = try XCTUnwrap(Author.findOrCreate(by: "alice", context: testContext))
+        let viewModel = NotificationViewModel(note: zapRequest, user: recipient)
+        
+        let notification = viewModel.notificationCenterRequest
+        XCTAssertEqual(notification.content.title, "npub1vnz0m... ⚡️ your profile 3,500 sats!")
+        XCTAssertEqual(notification.content.body, "Zapped you!")
+    }
+    
+    @MainActor
+    func testZapProfileNotification_noAmount() throws {
+        let zapRequest = try zapRequestEvent(filename: "zap_request_no_amount")
+        let recipient = try XCTUnwrap(Author.findOrCreate(by: "alice", context: testContext))
+        let viewModel = NotificationViewModel(note: zapRequest, user: recipient)
+        
+        let notification = viewModel.notificationCenterRequest
+        XCTAssertEqual(notification.content.title, "npub1vnz0m... ⚡️ your profile!")
+        XCTAssertEqual(notification.content.body, "Zap!")
+    }
+    
+    @MainActor
+    func testZapProfileNotification_oneSat() throws {
+        let zapRequest = try zapRequestEvent(filename: "zap_request_one_sat")
+        let recipient = try XCTUnwrap(Author.findOrCreate(by: "alice", context: testContext))
+        let viewModel = NotificationViewModel(note: zapRequest, user: recipient)
+        
+        let notification = viewModel.notificationCenterRequest
+        XCTAssertEqual(notification.content.title, "npub1vnz0m... ⚡️ your profile 1 sat!")
+        XCTAssertEqual(notification.content.body, "Only one sat")
+    }
+    
+    // MARK: Helpers
+    
+    @MainActor
+    private func zapRequestEvent(filename: String) throws -> Event {
+        let jsonData = try jsonData(filename: filename)
+        let jsonEvent = try JSONDecoder().decode(JSONEvent.self, from: jsonData)
+        let zapRequestEvent = try XCTUnwrap(
+            try EventProcessor.parse(
+                jsonEvent: jsonEvent,
+                from: nil,
+                in: testContext,
+                skipVerification: true
+            )
+        )
+        return zapRequestEvent
+    }
+}


### PR DESCRIPTION
## Issues covered
#1371 

## Description
This PR enables push notifications for profile zaps and adds zaps to the Notifications view.

Note: This PR does not add notifications for note zaps.

## How to test
Navigate to the Notifications view and look for cards that say "⚡️ your profile".
OR
Receive a zap to your signed in key, and you should see a push notification for it.

## Screenshots/Video

Notifications view:  
<img width="320" alt="image" src="https://github.com/user-attachments/assets/46468cba-7415-4c26-9ff3-2653d665f30f">

Push notification:  
<img width="320" alt="image" src="https://github.com/user-attachments/assets/b93b5de0-9d98-470d-a35d-a5bb0ae71d09">