### PR TITLE
Fix #1387: After navigating back to Feed, scroll position is lost

### DIFF
--- a/Nos/Controller/RefreshController.swift
+++ b/Nos/Controller/RefreshController.swift
@@ -6,7 +6,7 @@ import Foundation
     var shouldRefresh: Bool { get }
 
     /// The last time the view was refreshed.
-    var lastRefreshDate: Date? { get }
+    var lastRefreshDate: Date { get }
 
     /// Update the state of `shouldRefresh` to the given value.
     func setShouldRefresh(_: Bool)
@@ -19,9 +19,9 @@ import Foundation
 @Observable @MainActor class DefaultRefreshController: RefreshController {
     var shouldRefresh: Bool
 
-    var lastRefreshDate: Date?
+    var lastRefreshDate: Date
 
-    init(shouldRefresh: Bool = false, lastRefreshDate: Date? = nil) {
+    init(shouldRefresh: Bool = false, lastRefreshDate: Date = .now) {
         self.shouldRefresh = shouldRefresh
         self.lastRefreshDate = lastRefreshDate
     }

--- a/Nos/Views/Home/HomeFeedView.swift
+++ b/Nos/Views/Home/HomeFeedView.swift
@@ -11,7 +11,7 @@ struct HomeFeedView: View {
     @Environment(CurrentUser.self) var currentUser
     @ObservationIgnored @Dependency(\.analytics) private var analytics
 
-    @State private var refreshController: RefreshController = DefaultRefreshController()
+    @State private var refreshController = DefaultRefreshController()
     @State private var isVisible = false
     @State private var relaySubscriptions = [SubscriptionCancellable]()
     @State private var isShowingRelayList = false
@@ -31,6 +31,9 @@ struct HomeFeedView: View {
 
     init(user: Author) {
         self.user = user
+        refreshController.setLastRefreshDate(
+            Date(timeIntervalSince1970: Date.now.timeIntervalSince1970 + Double(Self.staticLoadTime))
+        )
     }
     
     var homeFeedFetchRequest: NSFetchRequest<Event> {

--- a/Nos/Views/Home/HomeFeedView.swift
+++ b/Nos/Views/Home/HomeFeedView.swift
@@ -12,7 +12,7 @@ struct HomeFeedView: View {
     @ObservationIgnored @Dependency(\.analytics) private var analytics
 
     @State private var refreshController: RefreshController = DefaultRefreshController(
-        lastRefreshDate: Date(timeIntervalSince1970: Date.now.timeIntervalSince1970 + Double(Self.staticLoadTime))
+        lastRefreshDate: .now + Self.staticLoadTime
     )
     @State private var isVisible = false
     @State private var relaySubscriptions = [SubscriptionCancellable]()

--- a/Nos/Views/Home/HomeFeedView.swift
+++ b/Nos/Views/Home/HomeFeedView.swift
@@ -11,7 +11,9 @@ struct HomeFeedView: View {
     @Environment(CurrentUser.self) var currentUser
     @ObservationIgnored @Dependency(\.analytics) private var analytics
 
-    @State private var refreshController = DefaultRefreshController()
+    @State private var refreshController: RefreshController = DefaultRefreshController(
+        lastRefreshDate: Date(timeIntervalSince1970: Date.now.timeIntervalSince1970 + Double(Self.staticLoadTime))
+    )
     @State private var isVisible = false
     @State private var relaySubscriptions = [SubscriptionCancellable]()
     @State private var isShowingRelayList = false
@@ -31,16 +33,12 @@ struct HomeFeedView: View {
 
     init(user: Author) {
         self.user = user
-        refreshController.setLastRefreshDate(
-            Date(timeIntervalSince1970: Date.now.timeIntervalSince1970 + Double(Self.staticLoadTime))
-        )
     }
     
     var homeFeedFetchRequest: NSFetchRequest<Event> {
         Event.homeFeed(
             for: user,
-            before: refreshController.lastRefreshDate ??
-                Date(timeIntervalSince1970: Date.now.timeIntervalSince1970 + Double(Self.staticLoadTime)),
+            before: refreshController.lastRefreshDate,
             seenOn: selectedRelay
         )
     }
@@ -48,7 +46,7 @@ struct HomeFeedView: View {
     var newNotesRequest: NSFetchRequest<Event> {
         Event.homeFeed(
             for: user,
-            after: refreshController.lastRefreshDate ?? .now,
+            after: refreshController.lastRefreshDate,
             seenOn: selectedRelay
         )
     }

--- a/Nos/Views/PagedNoteListView.swift
+++ b/Nos/Views/PagedNoteListView.swift
@@ -36,7 +36,7 @@ struct PagedNoteListView<Header: View, EmptyPlaceholder: View>: UIViewRepresenta
     let tab: AppDestination
 
     /// Allows us to refresh the PagedNoteListView from outside this view itself, such as with a separate button.
-    let refreshController: RefreshController
+    let refreshController: DefaultRefreshController
 
     /// A view that will be displayed as the collectionView header.
     let header: () -> Header

--- a/Nos/Views/PagedNoteListView.swift
+++ b/Nos/Views/PagedNoteListView.swift
@@ -36,7 +36,7 @@ struct PagedNoteListView<Header: View, EmptyPlaceholder: View>: UIViewRepresenta
     let tab: AppDestination
 
     /// Allows us to refresh the PagedNoteListView from outside this view itself, such as with a separate button.
-    let refreshController: DefaultRefreshController
+    let refreshController: RefreshController
 
     /// A view that will be displayed as the collectionView header.
     let header: () -> Header

--- a/Nos/Views/Profile/ProfileView.swift
+++ b/Nos/Views/Profile/ProfileView.swift
@@ -16,7 +16,7 @@ struct ProfileView: View {
     @Dependency(\.analytics) private var analytics
     @Dependency(\.unsAPI) private var unsAPI
 
-    @State private var refreshController = DefaultRefreshController()
+    @State private var refreshController: RefreshController = DefaultRefreshController()
     @State private var showingOptions = false
     @State private var showingReportMenu = false
     @State private var relaySubscriptions = SubscriptionCancellables()

--- a/Nos/Views/Profile/ProfileView.swift
+++ b/Nos/Views/Profile/ProfileView.swift
@@ -16,7 +16,7 @@ struct ProfileView: View {
     @Dependency(\.analytics) private var analytics
     @Dependency(\.unsAPI) private var unsAPI
 
-    @State private var refreshController: RefreshController = DefaultRefreshController()
+    @State private var refreshController = DefaultRefreshController()
     @State private var showingOptions = false
     @State private var showingReportMenu = false
     @State private var relaySubscriptions = SubscriptionCancellables()

--- a/Nos/Views/Profile/ProfileView.swift
+++ b/Nos/Views/Profile/ProfileView.swift
@@ -35,7 +35,7 @@ struct ProfileView: View {
     }
 
     var databaseFilter: NSFetchRequest<Event> {
-        selectedTab.databaseFilter(author: author, before: refreshController.lastRefreshDate ?? .now)
+        selectedTab.databaseFilter(author: author, before: refreshController.lastRefreshDate)
     }
 
     func downloadAuthorData() async {

--- a/NosTests/Controller/MockRefreshController.swift
+++ b/NosTests/Controller/MockRefreshController.swift
@@ -3,7 +3,7 @@ import Foundation
 /// A refresh controller used for testing.
 class MockRefreshController: RefreshController {
     var shouldRefresh = false
-    var lastRefreshDate: Date?
+    var lastRefreshDate: Date = .now
 
     func setShouldRefresh(_ shouldRefresh: Bool) {
     }


### PR DESCRIPTION
## Issues covered
#1387

## Description
The `lastRefreshDate` was `nil` and therefore the `homeFeedFetchRequest` was constantly being updated. Whenever the fetch request is updated, the view scrolls to the top (probably/maybe through a `reloadData()` on the collection view).

## How to test
1. Go to Feed
2. Scroll down
3. Tap a note to see the Thread view
4. Tap Back to go back to Feed
5. Observe that your scroll position is maintained

## Screenshots/Video
https://github.com/user-attachments/assets/638c4525-ef23-4372-8d2f-0677da263d66

## Additional Information
I'm skipping the CHANGELOG on this one since we didn't release the bug (which was introduced when we merged #1370), so users might be confused if they see the fix in the release notes. I suppose I could add it to the CHANGELOG and then make sure it's not in the external release notes. Open to suggestions on this.