### PR TITLE
Refactor the New Notes Notification code

### DIFF
--- a/Nos.xcodeproj/project.pbxproj
+++ b/Nos.xcodeproj/project.pbxproj
@@ -8,9 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		030036852C5D39DD002C71F5 /* RefreshController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 030036842C5D39DD002C71F5 /* RefreshController.swift */; };
-		0300368F2C5D3AB4002C71F5 /* MockRefreshController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0300368E2C5D3AB4002C71F5 /* MockRefreshController.swift */; };
 		030036942C5D3AD3002C71F5 /* RefreshController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 030036842C5D39DD002C71F5 /* RefreshController.swift */; };
-		030036952C5D3AD9002C71F5 /* MockRefreshController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0300368E2C5D3AB4002C71F5 /* MockRefreshController.swift */; };
 		030036AB2C5D872B002C71F5 /* NewNotesButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 030036AA2C5D872B002C71F5 /* NewNotesButton.swift */; };
 		030AE4292BE3D63C004DEE02 /* FeaturedAuthor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 030AE4282BE3D63C004DEE02 /* FeaturedAuthor.swift */; };
 		0320C0FB2BFE43A600C4C080 /* RelayServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0320C0FA2BFE43A600C4C080 /* RelayServiceTests.swift */; };
@@ -512,7 +510,6 @@
 
 /* Begin PBXFileReference section */
 		030036842C5D39DD002C71F5 /* RefreshController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefreshController.swift; sourceTree = "<group>"; };
-		0300368E2C5D3AB4002C71F5 /* MockRefreshController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockRefreshController.swift; sourceTree = "<group>"; };
 		030036AA2C5D872B002C71F5 /* NewNotesButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewNotesButton.swift; sourceTree = "<group>"; };
 		030AE4282BE3D63C004DEE02 /* FeaturedAuthor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeaturedAuthor.swift; sourceTree = "<group>"; };
 		0320C0E42BFBB27E00C4C080 /* PerformanceTests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = PerformanceTests.xctestplan; sourceTree = "<group>"; };
@@ -979,7 +976,6 @@
 				0357299C2BE41653005FEE85 /* ContentWarningControllerTests.swift */,
 				0357299D2BE41653005FEE85 /* SocialGraphTests.swift */,
 				C99314932C5BE13600224BA6 /* NoteEditorControllerTests.swift */,
-				0300368E2C5D3AB4002C71F5 /* MockRefreshController.swift */,
 			);
 			path = Controller;
 			sourceTree = "<group>";
@@ -1937,7 +1933,6 @@
 				5BC0D9CC2B867B9D005D6980 /* NamesAPI.swift in Sources */,
 				C987F81D29BA6D9A00B44E7A /* ProfileTab.swift in Sources */,
 				C9ADB14129951CB10075E7F8 /* NSManagedObject+Nos.swift in Sources */,
-				030036952C5D3AD9002C71F5 /* MockRefreshController.swift in Sources */,
 				C9F84C21298DC36800C6714D /* AppView.swift in Sources */,
 				C9CE5B142A0172CF008E198C /* WebView.swift in Sources */,
 				CD4908D429B92941007443DB /* ReportABugMailView.swift in Sources */,
@@ -2295,7 +2290,6 @@
 				C9ADB14229951CB10075E7F8 /* NSManagedObject+Nos.swift in Sources */,
 				035729AB2BE4167E005FEE85 /* AuthorTests.swift in Sources */,
 				03B4E6AC2C125D13006E5F59 /* FileStorageUploadResponseJSONTests.swift in Sources */,
-				0300368F2C5D3AB4002C71F5 /* MockRefreshController.swift in Sources */,
 				C92DF80629C25DE900400561 /* URL+Extensions.swift in Sources */,
 				C9BAB09C2996FBA10003A84E /* EventProcessor.swift in Sources */,
 				C992B32B2B3613CC00704A9C /* SubscriptionCancellable.swift in Sources */,

--- a/Nos/Controller/PagedNoteDataSource.swift
+++ b/Nos/Controller/PagedNoteDataSource.swift
@@ -18,8 +18,6 @@ class PagedNoteDataSource<Header: View, EmptyPlaceholder: View>: NSObject, UICol
     private var managedObjectContext: NSManagedObjectContext
     private var header: () -> Header
     private var emptyPlaceholder: () -> EmptyPlaceholder
-    /// An action to perform when the data source is refreshed.
-    private var onRefresh: () -> Void
     let pageSize = 20
     
     // We intentionally generate unique IDs for cell reuse to get around 
@@ -34,8 +32,7 @@ class PagedNoteDataSource<Header: View, EmptyPlaceholder: View>: NSObject, UICol
         collectionView: UICollectionView, 
         managedObjectContext: NSManagedObjectContext,
         @ViewBuilder header: @escaping () -> Header,
-        @ViewBuilder emptyPlaceholder: @escaping () -> EmptyPlaceholder,
-        onRefresh: @escaping () -> Void
+        @ViewBuilder emptyPlaceholder: @escaping () -> EmptyPlaceholder
     ) {
         self.databaseFilter = databaseFilter
         self.fetchedResultsController = NSFetchedResultsController<Event>(
@@ -50,7 +47,6 @@ class PagedNoteDataSource<Header: View, EmptyPlaceholder: View>: NSObject, UICol
         self.relay = relay
         self.header = header
         self.emptyPlaceholder = emptyPlaceholder
-        self.onRefresh = onRefresh
 
         super.init()
         

--- a/Nos/Controller/RefreshController.swift
+++ b/Nos/Controller/RefreshController.swift
@@ -1,19 +1,19 @@
 import Foundation
 
-/// The default implementation of `RefreshController`.
+/// Defines a common interface for refreshing.
 @Observable @MainActor class RefreshController {
-    /// Whether a refresh should begin or not.
-    var shouldRefresh: Bool
+    /// Whether a refresh should start or not. When this is `true`, the view and data source will begin refreshing.
+    var startRefresh: Bool
 
     /// The last time the view was refreshed.
     var lastRefreshDate: Date
     
     /// Initializes a refresh controller with the given parameters.
     /// - Parameters:
-    ///   - shouldRefresh: Whether a refresh should begin or not. Defaults to `false`.
+    ///   - startRefresh: Whether a refresh should start or not. Defaults to `false`.
     ///   - lastRefreshDate: The last time the view was refreshed. Defaults to `.now`.
-    init(shouldRefresh: Bool = false, lastRefreshDate: Date = .now) {
-        self.shouldRefresh = shouldRefresh
+    init(startRefresh: Bool = false, lastRefreshDate: Date = .now) {
+        self.startRefresh = startRefresh
         self.lastRefreshDate = lastRefreshDate
     }
 }

--- a/Nos/Controller/RefreshController.swift
+++ b/Nos/Controller/RefreshController.swift
@@ -3,34 +3,19 @@ import Foundation
 /// Defines a common interface for refreshing.
 @MainActor protocol RefreshController: Observable {
     /// Whether a refresh should begin or not.
-    var shouldRefresh: Bool { get }
+    var shouldRefresh: Bool { get set }
 
     /// The last time the view was refreshed.
-    var lastRefreshDate: Date { get }
-
-    /// Update the state of `shouldRefresh` to the given value.
-    func setShouldRefresh(_: Bool)
-
-    /// Updates the last refresh date to the given value.
-    func setLastRefreshDate(_: Date)
+    var lastRefreshDate: Date { get set }
 }
 
 /// The default implementation of `RefreshController`.
 @Observable @MainActor class DefaultRefreshController: RefreshController {
     var shouldRefresh: Bool
-
     var lastRefreshDate: Date
 
     init(shouldRefresh: Bool = false, lastRefreshDate: Date = .now) {
         self.shouldRefresh = shouldRefresh
-        self.lastRefreshDate = lastRefreshDate
-    }
-
-    func setShouldRefresh(_ shouldRefresh: Bool) {
-        self.shouldRefresh = shouldRefresh
-    }
-
-    func setLastRefreshDate(_ lastRefreshDate: Date) {
         self.lastRefreshDate = lastRefreshDate
     }
 }

--- a/Nos/Controller/RefreshController.swift
+++ b/Nos/Controller/RefreshController.swift
@@ -6,7 +6,7 @@ import Foundation
     var shouldRefresh: Bool { get }
 
     /// The last time the view was refreshed.
-    var lastRefreshDate: Date? { get }
+    var lastRefreshDate: Date { get }
 
     /// Update the state of `shouldRefresh` to the given value.
     func setShouldRefresh(_: Bool)
@@ -19,9 +19,9 @@ import Foundation
 @Observable @MainActor class DefaultRefreshController: RefreshController {
     var shouldRefresh: Bool
 
-    var lastRefreshDate: Date?
+    var lastRefreshDate: Date
 
-    init(shouldRefresh: Bool = false, lastRefreshDate: Date? = nil) {
+    init(shouldRefresh: Bool = false, lastRefreshDate: Date = .now) {
         self.shouldRefresh = shouldRefresh
         self.lastRefreshDate = lastRefreshDate
     }

--- a/Nos/Controller/RefreshController.swift
+++ b/Nos/Controller/RefreshController.swift
@@ -1,19 +1,17 @@
 import Foundation
 
-/// Defines a common interface for refreshing.
-@MainActor protocol RefreshController: Observable {
+/// The default implementation of `RefreshController`.
+@Observable @MainActor class RefreshController {
     /// Whether a refresh should begin or not.
-    var shouldRefresh: Bool { get set }
+    var shouldRefresh: Bool
 
     /// The last time the view was refreshed.
-    var lastRefreshDate: Date { get set }
-}
-
-/// The default implementation of `RefreshController`.
-@Observable @MainActor class DefaultRefreshController: RefreshController {
-    var shouldRefresh: Bool
     var lastRefreshDate: Date
-
+    
+    /// Initializes a refresh controller with the given parameters.
+    /// - Parameters:
+    ///   - shouldRefresh: Whether a refresh should begin or not. Defaults to `false`.
+    ///   - lastRefreshDate: The last time the view was refreshed. Defaults to `.now`.
     init(shouldRefresh: Bool = false, lastRefreshDate: Date = .now) {
         self.shouldRefresh = shouldRefresh
         self.lastRefreshDate = lastRefreshDate

--- a/Nos/Views/Home/HomeFeedView.swift
+++ b/Nos/Views/Home/HomeFeedView.swift
@@ -11,7 +11,7 @@ struct HomeFeedView: View {
     @Environment(CurrentUser.self) var currentUser
     @ObservationIgnored @Dependency(\.analytics) private var analytics
 
-    @State private var refreshController: RefreshController = DefaultRefreshController()
+    @State private var refreshController = DefaultRefreshController()
     @State private var isVisible = false
     @State private var relaySubscriptions = [SubscriptionCancellable]()
     @State private var isShowingRelayList = false
@@ -31,6 +31,9 @@ struct HomeFeedView: View {
 
     init(user: Author) {
         self.user = user
+        refreshController.setLastRefreshDate(
+            Date(timeIntervalSince1970: Date.now.timeIntervalSince1970 + Double(Self.staticLoadTime))
+        )
     }
     
     var homeFeedFetchRequest: NSFetchRequest<Event> {

--- a/Nos/Views/Home/HomeFeedView.swift
+++ b/Nos/Views/Home/HomeFeedView.swift
@@ -11,9 +11,7 @@ struct HomeFeedView: View {
     @Environment(CurrentUser.self) var currentUser
     @ObservationIgnored @Dependency(\.analytics) private var analytics
 
-    @State private var refreshController = RefreshController(
-        lastRefreshDate: Date(timeIntervalSince1970: Date.now.timeIntervalSince1970 + Double(Self.staticLoadTime))
-    )
+    @State private var refreshController = RefreshController(lastRefreshDate: Date.now + Self.staticLoadTime)
     @State private var isVisible = false
     @State private var relaySubscriptions = [SubscriptionCancellable]()
     @State private var isShowingRelayList = false
@@ -85,9 +83,6 @@ struct HomeFeedView: View {
                             .padding()
                     }
                     .frame(minHeight: 300)
-                },
-                onRefresh: {
-                    refreshController.lastRefreshDate = .now
                 }
             )
             .padding(0)

--- a/Nos/Views/Home/HomeFeedView.swift
+++ b/Nos/Views/Home/HomeFeedView.swift
@@ -11,7 +11,7 @@ struct HomeFeedView: View {
     @Environment(CurrentUser.self) var currentUser
     @ObservationIgnored @Dependency(\.analytics) private var analytics
 
-    @State private var refreshController: RefreshController = DefaultRefreshController(
+    @State private var refreshController = RefreshController(
         lastRefreshDate: Date(timeIntervalSince1970: Date.now.timeIntervalSince1970 + Double(Self.staticLoadTime))
     )
     @State private var isVisible = false

--- a/Nos/Views/Home/HomeFeedView.swift
+++ b/Nos/Views/Home/HomeFeedView.swift
@@ -88,7 +88,7 @@ struct HomeFeedView: View {
             .padding(0)
 
             NewNotesButton(fetchRequest: FetchRequest(fetchRequest: newNotesRequest)) {
-                refreshController.shouldRefresh = true
+                refreshController.startRefresh = true
             }
 
             if showTimedLoadingIndicator {

--- a/Nos/Views/Home/HomeFeedView.swift
+++ b/Nos/Views/Home/HomeFeedView.swift
@@ -11,7 +11,9 @@ struct HomeFeedView: View {
     @Environment(CurrentUser.self) var currentUser
     @ObservationIgnored @Dependency(\.analytics) private var analytics
 
-    @State private var refreshController = DefaultRefreshController()
+    @State private var refreshController: RefreshController = DefaultRefreshController(
+        lastRefreshDate: Date(timeIntervalSince1970: Date.now.timeIntervalSince1970 + Double(Self.staticLoadTime))
+    )
     @State private var isVisible = false
     @State private var relaySubscriptions = [SubscriptionCancellable]()
     @State private var isShowingRelayList = false
@@ -31,16 +33,12 @@ struct HomeFeedView: View {
 
     init(user: Author) {
         self.user = user
-        refreshController.setLastRefreshDate(
-            Date(timeIntervalSince1970: Date.now.timeIntervalSince1970 + Double(Self.staticLoadTime))
-        )
     }
     
     var homeFeedFetchRequest: NSFetchRequest<Event> {
         Event.homeFeed(
             for: user,
-            before: refreshController.lastRefreshDate ??
-                Date(timeIntervalSince1970: Date.now.timeIntervalSince1970 + Double(Self.staticLoadTime)),
+            before: refreshController.lastRefreshDate,
             seenOn: selectedRelay
         )
     }
@@ -48,7 +46,7 @@ struct HomeFeedView: View {
     var newNotesRequest: NSFetchRequest<Event> {
         Event.homeFeed(
             for: user,
-            after: refreshController.lastRefreshDate ?? .now,
+            after: refreshController.lastRefreshDate,
             seenOn: selectedRelay
         )
     }

--- a/Nos/Views/Home/HomeFeedView.swift
+++ b/Nos/Views/Home/HomeFeedView.swift
@@ -70,12 +70,12 @@ struct HomeFeedView: View {
     var body: some View {
         ZStack {
             PagedNoteListView(
+                refreshController: $refreshController,
                 databaseFilter: homeFeedFetchRequest,
                 relayFilter: homeFeedFilter,
                 relay: selectedRelay,
                 managedObjectContext: viewContext,
                 tab: .home,
-                refreshController: refreshController,
                 header: {
                     EmptyView()
                 },
@@ -87,13 +87,13 @@ struct HomeFeedView: View {
                     .frame(minHeight: 300)
                 },
                 onRefresh: {
-                    refreshController.setLastRefreshDate(.now)
+                    refreshController.lastRefreshDate = .now
                 }
             )
             .padding(0)
 
             NewNotesButton(fetchRequest: FetchRequest(fetchRequest: newNotesRequest)) {
-                refreshController.setShouldRefresh(true)
+                refreshController.shouldRefresh = true
             }
 
             if showTimedLoadingIndicator {
@@ -112,7 +112,7 @@ struct HomeFeedView: View {
                 )
                 .onChange(of: selectedRelay) { _, _ in
                     showTimedLoadingIndicator = true
-                    refreshController.setLastRefreshDate(.now + Self.staticLoadTime)
+                    refreshController.lastRefreshDate = .now + Self.staticLoadTime
                     Task {
                         withAnimation {
                             showRelayPicker = false

--- a/Nos/Views/PagedNoteListView.swift
+++ b/Nos/Views/PagedNoteListView.swift
@@ -238,7 +238,7 @@ extension Notification.Name {
 
 #Preview {
     var previewData = PreviewData()
-    @State var refreshController: RefreshController = DefaultRefreshController()
+    @State var refreshController = RefreshController()
 
     return PagedNoteListView(
         refreshController: $refreshController,

--- a/Nos/Views/PagedNoteListView.swift
+++ b/Nos/Views/PagedNoteListView.swift
@@ -16,6 +16,9 @@ struct PagedNoteListView<Header: View, EmptyPlaceholder: View>: UIViewRepresenta
     /// Set the UIViewType to make the compiler happy as we implement `dismantleUIView`.
     typealias UIViewType = UICollectionView
 
+    /// Allows us to refresh the PagedNoteListView from outside this view itself, such as with a separate button.
+    @Binding var refreshController: RefreshController
+
     /// A fetch request that specifies the events that should be shown. The events should be sorted in 
     /// reverse-chronological order and should match the events returned by `relayFilter`.
     let databaseFilter: NSFetchRequest<Event>
@@ -34,9 +37,6 @@ struct PagedNoteListView<Header: View, EmptyPlaceholder: View>: UIViewRepresenta
     /// The tab in which this PagedNoteListView appears.
     /// Used to determine whether to scroll this view to the top when the tab is tapped.
     let tab: AppDestination
-
-    /// Allows us to refresh the PagedNoteListView from outside this view itself, such as with a separate button.
-    let refreshController: RefreshController
 
     /// A view that will be displayed as the collectionView header.
     let header: () -> Header
@@ -98,7 +98,7 @@ struct PagedNoteListView<Header: View, EmptyPlaceholder: View>: UIViewRepresenta
                 dataSource.updateFetchRequest(databaseFilter)
             }
             if refreshController.shouldRefresh {
-                refreshController.setShouldRefresh(false)
+                refreshController.shouldRefresh = false
 
                 guard let refreshControl = collectionView.refreshControl else { return }
                 collectionView.scrollRectToVisible(refreshControl.frame, animated: true)
@@ -238,15 +238,15 @@ extension Notification.Name {
 
 #Preview {
     var previewData = PreviewData()
-    let refreshController = DefaultRefreshController()
+    @State var refreshController: RefreshController = DefaultRefreshController()
 
     return PagedNoteListView(
+        refreshController: $refreshController,
         databaseFilter: previewData.alice.allPostsRequest(onlyRootPosts: false),
         relayFilter: Filter(), 
         relay: nil,
         managedObjectContext: previewData.previewContext,
         tab: .home,
-        refreshController: refreshController,
         header: {
             ProfileHeader(author: previewData.alice, selectedTab: .constant(.activity))
                 .compositingGroup()

--- a/Nos/Views/PagedNoteListView.swift
+++ b/Nos/Views/PagedNoteListView.swift
@@ -92,8 +92,8 @@ struct PagedNoteListView<Header: View, EmptyPlaceholder: View>: UIViewRepresenta
             if databaseFilter != dataSource.databaseFilter {
                 dataSource.updateFetchRequest(databaseFilter)
             }
-            if refreshController.shouldRefresh {
-                refreshController.shouldRefresh = false
+            if refreshController.startRefresh {
+                refreshController.startRefresh = false
 
                 guard let refreshControl = collectionView.refreshControl else { return }
                 collectionView.scrollRectToVisible(refreshControl.frame, animated: true)

--- a/Nos/Views/PagedNoteListView.swift
+++ b/Nos/Views/PagedNoteListView.swift
@@ -36,7 +36,7 @@ struct PagedNoteListView<Header: View, EmptyPlaceholder: View>: UIViewRepresenta
     let tab: AppDestination
 
     /// Allows us to refresh the PagedNoteListView from outside this view itself, such as with a separate button.
-    let refreshController: RefreshController
+    let refreshController: DefaultRefreshController
 
     /// A view that will be displayed as the collectionView header.
     let header: () -> Header

--- a/Nos/Views/PagedNoteListView.swift
+++ b/Nos/Views/PagedNoteListView.swift
@@ -36,7 +36,7 @@ struct PagedNoteListView<Header: View, EmptyPlaceholder: View>: UIViewRepresenta
     let tab: AppDestination
 
     /// Allows us to refresh the PagedNoteListView from outside this view itself, such as with a separate button.
-    let refreshController: DefaultRefreshController
+    let refreshController: RefreshController
 
     /// A view that will be displayed as the collectionView header.
     let header: () -> Header

--- a/Nos/Views/Profile/ProfileView.swift
+++ b/Nos/Views/Profile/ProfileView.swift
@@ -16,7 +16,7 @@ struct ProfileView: View {
     @Dependency(\.analytics) private var analytics
     @Dependency(\.unsAPI) private var unsAPI
 
-    @State private var refreshController = DefaultRefreshController()
+    @State private var refreshController: RefreshController = DefaultRefreshController()
     @State private var showingOptions = false
     @State private var showingReportMenu = false
     @State private var relaySubscriptions = SubscriptionCancellables()

--- a/Nos/Views/Profile/ProfileView.swift
+++ b/Nos/Views/Profile/ProfileView.swift
@@ -16,7 +16,7 @@ struct ProfileView: View {
     @Dependency(\.analytics) private var analytics
     @Dependency(\.unsAPI) private var unsAPI
 
-    @State private var refreshController: RefreshController = DefaultRefreshController()
+    @State private var refreshController = DefaultRefreshController()
     @State private var showingOptions = false
     @State private var showingReportMenu = false
     @State private var relaySubscriptions = SubscriptionCancellables()

--- a/Nos/Views/Profile/ProfileView.swift
+++ b/Nos/Views/Profile/ProfileView.swift
@@ -107,9 +107,6 @@ struct ProfileView: View {
                             }
                         }
                         .frame(minHeight: 300)
-                    },
-                    onRefresh: {
-                        refreshController.lastRefreshDate = .now
                     }
                 )
                 .padding(0)

--- a/Nos/Views/Profile/ProfileView.swift
+++ b/Nos/Views/Profile/ProfileView.swift
@@ -35,7 +35,7 @@ struct ProfileView: View {
     }
 
     var databaseFilter: NSFetchRequest<Event> {
-        selectedTab.databaseFilter(author: author, before: refreshController.lastRefreshDate ?? .now)
+        selectedTab.databaseFilter(author: author, before: refreshController.lastRefreshDate)
     }
 
     func downloadAuthorData() async {

--- a/Nos/Views/Profile/ProfileView.swift
+++ b/Nos/Views/Profile/ProfileView.swift
@@ -16,7 +16,7 @@ struct ProfileView: View {
     @Dependency(\.analytics) private var analytics
     @Dependency(\.unsAPI) private var unsAPI
 
-    @State private var refreshController: RefreshController = DefaultRefreshController()
+    @State private var refreshController = RefreshController()
     @State private var showingOptions = false
     @State private var showingReportMenu = false
     @State private var relaySubscriptions = SubscriptionCancellables()

--- a/Nos/Views/Profile/ProfileView.swift
+++ b/Nos/Views/Profile/ProfileView.swift
@@ -85,12 +85,12 @@ struct ProfileView: View {
         VStack(spacing: 0) {
             VStack {
                 PagedNoteListView(
+                    refreshController: $refreshController,
                     databaseFilter: databaseFilter,
                     relayFilter: selectedTab.relayFilter(author: author),
                     relay: nil,
                     managedObjectContext: viewContext,
                     tab: .profile, 
-                    refreshController: refreshController,
                     header: {
                         ProfileHeader(author: author, selectedTab: $selectedTab)
                             .compositingGroup()
@@ -103,13 +103,13 @@ struct ProfileView: View {
                                 .readabilityPadding()
                             
                             SecondaryActionButton(title: .localizable.tapToRefresh) {
-                                refreshController.setShouldRefresh(true)
+                                refreshController.shouldRefresh = true
                             }
                         }
                         .frame(minHeight: 300)
                     },
                     onRefresh: {
-                        refreshController.setLastRefreshDate(.now)
+                        refreshController.lastRefreshDate = .now
                     }
                 )
                 .padding(0)

--- a/Nos/Views/Profile/ProfileView.swift
+++ b/Nos/Views/Profile/ProfileView.swift
@@ -103,7 +103,7 @@ struct ProfileView: View {
                                 .readabilityPadding()
                             
                             SecondaryActionButton(title: .localizable.tapToRefresh) {
-                                refreshController.shouldRefresh = true
+                                refreshController.startRefresh = true
                             }
                         }
                         .frame(minHeight: 300)

--- a/NosTests/Controller/MockRefreshController.swift
+++ b/NosTests/Controller/MockRefreshController.swift
@@ -3,7 +3,7 @@ import Foundation
 /// A refresh controller used for testing.
 class MockRefreshController: RefreshController {
     var shouldRefresh = false
-    var lastRefreshDate: Date?
+    var lastRefreshDate: Date = .now
 
     func setShouldRefresh(_ shouldRefresh: Bool) {
     }

--- a/NosTests/Controller/MockRefreshController.swift
+++ b/NosTests/Controller/MockRefreshController.swift
@@ -4,10 +4,4 @@ import Foundation
 class MockRefreshController: RefreshController {
     var shouldRefresh = false
     var lastRefreshDate: Date = .now
-
-    func setShouldRefresh(_ shouldRefresh: Bool) {
-    }
-    
-    func setLastRefreshDate(_ lastRefreshDate: Date) {
-    }
 }

--- a/NosTests/Controller/MockRefreshController.swift
+++ b/NosTests/Controller/MockRefreshController.swift
@@ -1,7 +1,0 @@
-import Foundation
-
-/// A refresh controller used for testing.
-class MockRefreshController: RefreshController {
-    var shouldRefresh = false
-    var lastRefreshDate: Date = .now
-}


### PR DESCRIPTION
## Issues covered
#1386

## Description
Refactored away one of the unnecessary home feed predicates. Also removed the RefreshController protocol, which seemed to be causing SwiftUI problems, and simplified it even more.

## How to test
This is a refactor, so everything should still work as it used to. Specifically, though, look at the home feed and the profile screens.

1. Navigate to Feed
2. Wait for new notes to appear (or post one from another device)
3. Tap "New notes available"
4. Ensure the view is refreshed and scrolls to the top
5. Scroll down in the Feed
6. Tap a note to see details
7. Tap back
8. Ensure the Feed still appears in the same place as it was after you scrolled
9. Navigate to a profile
10. Scroll, tap, go back, refresh, make sure it all works.
