### PR TITLE
fix: confirmationDialog buttons turn red while you swipe #1064

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added push notifications for zaps.
 - Added zaps to the Notifications view.
 - Created Colors.xcassets and move all colors into it. Thanks @lingoslinger!
+- Fixed a bug where confirmation dialog buttons turn red while swiping across them.
 
 ## [0.1.23] - 2024-07-31Z
 

--- a/Nos/NosApp.swift
+++ b/Nos/NosApp.swift
@@ -17,6 +17,10 @@ struct NosApp: App {
     
     init() {
         _ = crashReporting // force crash reporting init as early as possible
+        
+        // hack to fix confirmationDialog color issue
+        // https://github.com/planetary-social/nos/issues/1064
+        UIView.appearance(whenContainedInInstancesOf: [UIAlertController.self]).tintColor = .systemBlue
     }
     
     var body: some Scene {


### PR DESCRIPTION
## Issues covered
#1064 

## Description
The change offered here is admittedly a hack and is labeled such in the code. I leave it up to maintainers to decide if we really want this or not.

## How to test
1. Navigate to the feed.
2. Tap the three dots button at the top right of any note card.
3. Swipe up and down along the buttons displayed.

## Screenshots/Video
| Before | After |
|--------|--------|
|![nos-before](https://github.com/user-attachments/assets/17431444-63d5-49a5-9465-b35f126cac8f)|![nos-after](https://github.com/user-attachments/assets/f35bbdeb-2fb0-4495-bfee-78cc28c39cd2)|

Regression check:  

Destructive buttons are still styled as expected:
<img width="414" alt="iPhone_15" src="https://github.com/user-attachments/assets/873c506d-5930-420d-825c-39c00adba401">

