### PR TITLE
fix: urls with periods after them include the period and don't work as expected #1233

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added push notifications for zaps.
 - Added zaps to the Notifications view.
 - Created Colors.xcassets and move all colors into it. Thanks @lingoslinger!
+- Fixed a bug where urls with periods after them would include the period.
 
 ## [0.1.23] - 2024-07-31Z
 

--- a/Nos/Models/URLParser.swift
+++ b/Nos/Models/URLParser.swift
@@ -54,7 +54,7 @@ struct URLParser {
         // https://en.wikipedia.org/wiki/Domain_Name_System#Domain_name_syntax,_internationalization
 
         // swiftlint:disable:next line_length
-        let regexPattern = "(\\s*)(?<url>((https?://){1}|(?<![\\w@.]))([a-zA-Z0-9][-a-zA-Z0-9]{0,62}\\.){1,127}[a-z]{2,63}\\b[-a-zA-Z0-9@:%_\\+.~#?&/=]*)"
+        let regexPattern = "(\\s*)(?<url>((https?://){1}|(?<![\\w@.]))([a-zA-Z0-9][-a-zA-Z0-9]{0,62}\\.){1,127}[a-z]{2,63}\\b[-a-zA-Z0-9@:%_\\+.~#?&/=]*(?<![.,!?\\)\\]]))"
 
         var urls: [URL] = []
         do {

--- a/NosTests/URLParserTests.swift
+++ b/NosTests/URLParserTests.swift
@@ -106,6 +106,22 @@ class URLParserTests: XCTestCase {
         XCTAssertEqual(actualString, expectedString)
         XCTAssertEqual(actualURLs, expectedURLs)
     }
+    
+    func testExtractURLsDoesNotIncludePeriodsInURLs() throws {
+        // Arrange
+        let string = "Welcome to nos.social. It's a place for humans"
+        let expectedString = "Welcome to [nos.social](https://nos.social). It's a place for humans"
+        let expectedURLs = [
+            URL(string: "https://nos.social")!
+        ]
+
+        // Act
+        let (actualString, actualURLs) = sut.replaceUnformattedURLs(in: string)
+
+        // Assert
+        XCTAssertEqual(actualString, expectedString)
+        XCTAssertEqual(actualURLs, expectedURLs)
+    }
 
     func testExtractURLsWithImage() throws {
         let string = "Hello, world!https://cdn.ymaws.com/footprints.jpg"


### PR DESCRIPTION
## Issues covered
#1233 

## Description
I updated the regex the finds URLs and added a test that failed prior to the change and passes after the change.

## How to test
1. Navigate a note with a url in it that has a punctuation mark after it, such as a period.
2. The link has the punctuation in it and therefore doesn't work as expected when you tap it.

## Screenshots/Video
| Before | After |
| --- | --- |
|![nos-before2](https://github.com/user-attachments/assets/1f44ca50-97fa-4f65-8c17-f57654c9ee32)|![nos-after2](https://github.com/user-attachments/assets/e3caaa13-e436-4994-8d95-4590b8a54bda)|

