### PR TITLE
Remove reply and repost count from Home and Profile feeds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Removed the like and repost counts from the Main and Profile feeds.
 - Fixed an issue where the sheet asking users to set up a NIP-05 username would appear after reinstalling Nos, even if the profile already had a NIP-05 username.
 - Fixed a bug where urls with periods after them would include the period.
 

--- a/Nos/Controller/PagedNoteDataSource.swift
+++ b/Nos/Controller/PagedNoteDataSource.swift
@@ -131,6 +131,8 @@ class PagedNoteDataSource<Header: View, EmptyPlaceholder: View>: NSObject, UICol
                 note: note,
                 hideOutOfNetwork: false,
                 repliesDisplayType: .discussion,
+                showLikeCount: false,
+                showRepostCount: false,
                 fetchReplies: true,
                 displayRootMessage: true
             )

--- a/Nos/Controller/PagedNoteDataSource.swift
+++ b/Nos/Controller/PagedNoteDataSource.swift
@@ -131,8 +131,8 @@ class PagedNoteDataSource<Header: View, EmptyPlaceholder: View>: NSObject, UICol
                 note: note,
                 hideOutOfNetwork: false,
                 repliesDisplayType: .discussion,
-                showLikeCount: false,
-                showRepostCount: false,
+                showsLikeCount: false,
+                showsRepostCount: false,
                 fetchReplies: true,
                 displayRootMessage: true
             )

--- a/Nos/Views/LikeButton.swift
+++ b/Nos/Views/LikeButton.swift
@@ -24,7 +24,7 @@ struct LikeButton: View {
 
     /// Initializes a LikeButton object.
     ///
-    /// - Parameter note: Note event to display likes to.
+    /// - Parameter note: The event associated with this Like button.
     /// - Parameter showsCount: Whether the number of likes is displayed. Defaults to `true`.
     internal init(note: Event, showsCount: Bool = true) {
         self.note = note

--- a/Nos/Views/LikeButton.swift
+++ b/Nos/Views/LikeButton.swift
@@ -26,7 +26,7 @@ struct LikeButton: View {
     ///
     /// - Parameter note: The event associated with this Like button.
     /// - Parameter showsCount: Whether the number of likes is displayed. Defaults to `true`.
-    internal init(note: Event, showsCount: Bool = true) {
+    init(note: Event, showsCount: Bool = true) {
         self.note = note
         self.showsCount = showsCount
         if let noteID = note.identifier {

--- a/Nos/Views/LikeButton.swift
+++ b/Nos/Views/LikeButton.swift
@@ -5,6 +5,10 @@ import SwiftUI
 struct LikeButton: View {
     
     var note: Event
+
+    /// Indicates whether the number of likes is displayed.
+    var showsCount: Bool
+
     @FetchRequest private var likes: FetchedResults<Event>
 
     /// Provides instant feedback when the button is tapped, even though the action it performs is async.
@@ -18,8 +22,13 @@ struct LikeButton: View {
     @Environment(\.managedObjectContext) private var viewContext
     @ObservationIgnored @Dependency(\.analytics) private var analytics
 
-    internal init(note: Event) {
+    /// Initializes a LikeButton object.
+    ///
+    /// - Parameter note: Note event to display likes to.
+    /// - Parameter showsCount: Whether the number of likes is displayed. Defaults to `true`.
+    internal init(note: Event, showsCount: Bool = true) {
         self.note = note
+        self.showsCount = showsCount
         if let noteID = note.identifier {
             _likes = FetchRequest(fetchRequest: Event.likes(noteID: noteID))
         } else {
@@ -51,7 +60,7 @@ struct LikeButton: View {
             } else {
                 Image.buttonLikeDefault
             }
-            if likeCount > 0 {
+            if showsCount, likeCount > 0 {
                 Text(likeCount.description)
                     .font(.clarity(.medium, textStyle: .subheadline))
                     .foregroundColor(.secondaryTxt)

--- a/Nos/Views/NoteButton.swift
+++ b/Nos/Views/NoteButton.swift
@@ -16,10 +16,10 @@ struct NoteButton: View {
     var repliesDisplayType: RepliesDisplayType
 
     /// Indicates whether the number of likes is displayed.
-    var showLikeCount: Bool
+    var showsLikeCount: Bool
 
     /// Indicates whether the number of reposts is displayed.
-    var showRepostCount: Bool
+    var showsRepostCount: Bool
 
     /// Whether replies should be fetched from relays.
     var fetchReplies: Bool
@@ -43,8 +43,8 @@ struct NoteButton: View {
     /// - Parameter hideOutOfNetwork: Blur the card if the author is not inside the user's
     /// network. Defaults to true.
     /// - Parameter repliesDisplayType: Replies Label style. Defaults to `.displayNothing`.
-    /// - Parameter showLikeCount: Whether the number of likes is displayed. Defaults to `true`.
-    /// - Parameter showRepostCount: Whether the number of reposts is displayed. Defaults to `true`.
+    /// - Parameter showsLikeCount: Whether the number of likes is displayed. Defaults to `true`.
+    /// - Parameter showsRepostCount: Whether the number of reposts is displayed. Defaults to `true`.
     /// - Parameter fetchReplies: Whether replies should be fetched from relays. Defaults
     /// to false.
     /// - Parameter displayRootMessage: Display the root note above if the note is a reply.
@@ -60,8 +60,8 @@ struct NoteButton: View {
         shouldTruncate: Bool = true, 
         hideOutOfNetwork: Bool = true, 
         repliesDisplayType: RepliesDisplayType = .displayNothing,
-        showLikeCount: Bool = true,
-        showRepostCount: Bool = true,
+        showsLikeCount: Bool = true,
+        showsRepostCount: Bool = true,
         fetchReplies: Bool = false,
         displayRootMessage: Bool = false,
         isTapEnabled: Bool = true,
@@ -73,8 +73,8 @@ struct NoteButton: View {
         self.shouldTruncate = shouldTruncate
         self.hideOutOfNetwork = hideOutOfNetwork
         self.repliesDisplayType = repliesDisplayType
-        self.showLikeCount = showLikeCount
-        self.showRepostCount = showRepostCount
+        self.showsLikeCount = showsLikeCount
+        self.showsRepostCount = showsRepostCount
         self.fetchReplies = fetchReplies
         self.displayRootMessage = displayRootMessage
         self.isTapEnabled = isTapEnabled
@@ -120,8 +120,8 @@ struct NoteButton: View {
                 shouldTruncate: shouldTruncate,
                 hideOutOfNetwork: hideOutOfNetwork,
                 repliesDisplayType: repliesDisplayType,
-                showLikeCount: showLikeCount,
-                showRepostCount: showRepostCount,
+                showsLikeCount: showsLikeCount,
+                showsRepostCount: showsRepostCount,
                 replyAction: replyAction
             )
 

--- a/Nos/Views/NoteButton.swift
+++ b/Nos/Views/NoteButton.swift
@@ -15,6 +15,12 @@ struct NoteButton: View {
     var hideOutOfNetwork: Bool
     var repliesDisplayType: RepliesDisplayType
 
+    /// Indicates whether the number of likes is displayed.
+    var showLikeCount: Bool
+
+    /// Indicates whether the number of reposts is displayed.
+    var showRepostCount: Bool
+
     /// Whether replies should be fetched from relays.
     var fetchReplies: Bool
 
@@ -37,6 +43,8 @@ struct NoteButton: View {
     /// - Parameter hideOutOfNetwork: Blur the card if the author is not inside the user's
     /// network. Defaults to true.
     /// - Parameter repliesDisplayType: Replies Label style. Defaults to `.displayNothing`.
+    /// - Parameter showLikeCount: Whether the number of likes is displayed. Defaults to `true`.
+    /// - Parameter showRepostCount: Whether the number of reposts is displayed. Defaults to `true`.
     /// - Parameter fetchReplies: Whether replies should be fetched from relays. Defaults
     /// to false.
     /// - Parameter displayRootMessage: Display the root note above if the note is a reply.
@@ -52,6 +60,8 @@ struct NoteButton: View {
         shouldTruncate: Bool = true, 
         hideOutOfNetwork: Bool = true, 
         repliesDisplayType: RepliesDisplayType = .displayNothing,
+        showLikeCount: Bool = true,
+        showRepostCount: Bool = true,
         fetchReplies: Bool = false,
         displayRootMessage: Bool = false,
         isTapEnabled: Bool = true,
@@ -63,6 +73,8 @@ struct NoteButton: View {
         self.shouldTruncate = shouldTruncate
         self.hideOutOfNetwork = hideOutOfNetwork
         self.repliesDisplayType = repliesDisplayType
+        self.showLikeCount = showLikeCount
+        self.showRepostCount = showRepostCount
         self.fetchReplies = fetchReplies
         self.displayRootMessage = displayRootMessage
         self.isTapEnabled = isTapEnabled
@@ -108,6 +120,8 @@ struct NoteButton: View {
                 shouldTruncate: shouldTruncate,
                 hideOutOfNetwork: hideOutOfNetwork,
                 repliesDisplayType: repliesDisplayType,
+                showLikeCount: showLikeCount,
+                showRepostCount: showRepostCount,
                 replyAction: replyAction
             )
 

--- a/Nos/Views/NoteCard.swift
+++ b/Nos/Views/NoteCard.swift
@@ -19,15 +19,37 @@ struct NoteCard: View {
 
     private var shouldTruncate: Bool
     private let repliesDisplayType: RepliesDisplayType
+    
+    /// Indicates whether the number of likes is displayed.
+    private let showLikeCount: Bool
+
+    /// Indicates whether the number of reposts is displayed.
+    private let showRepostCount: Bool
+
     private var hideOutOfNetwork: Bool
     private var replyAction: ((Event) -> Void)?
     
+    /// Initializes a NoteCard object.
+    ///
+    /// - Parameter note: Note event to display.
+    /// - Parameter style: Card style. Defaults to `.compact`.
+    /// - Parameter shouldTruncate: Whether the card should display just some lines or the
+    /// full content of the note. Defaults to true.
+    /// - Parameter hideOutOfNetwork: Blur the card if the author is not inside the user's
+    /// network. Defaults to true.
+    /// - Parameter repliesDisplayType: Replies Label style. Defaults to `.displayNothing`.
+    /// - Parameter showLikeCount: Whether the number of likes is displayed. Defaults to `true`.
+    /// - Parameter showRepostCount: Whether the number of reposts is displayed. Defaults to `true`.
+    /// - Parameter replyAction: Handler that gets called when the user taps on the Reply
+    /// button. Defaults to `nil`.
     init(
         note: Event,
         style: CardStyle = .compact,
         shouldTruncate: Bool = true,
         hideOutOfNetwork: Bool = true,
         repliesDisplayType: RepliesDisplayType = .displayNothing,
+        showLikeCount: Bool = true,
+        showRepostCount: Bool = true,
         replyAction: ((Event) -> Void)? = nil
     ) {
         self.note = note
@@ -35,6 +57,8 @@ struct NoteCard: View {
         self.shouldTruncate = shouldTruncate
         self.hideOutOfNetwork = hideOutOfNetwork
         self.repliesDisplayType = repliesDisplayType
+        self.showLikeCount = showLikeCount
+        self.showRepostCount = showRepostCount
         self.replyAction = replyAction
     }
     
@@ -89,8 +113,8 @@ struct NoteCard: View {
                                 }
                             }
                             Spacer()
-                            RepostButton(note: note) 
-                            LikeButton(note: note)
+                            RepostButton(note: note, showsCount: showRepostCount)
+                            LikeButton(note: note, showsCount: showLikeCount)
                             ReplyButton(note: note, replyAction: replyAction)
                         }
                         .padding(.leading, 13)

--- a/Nos/Views/NoteCard.swift
+++ b/Nos/Views/NoteCard.swift
@@ -21,10 +21,10 @@ struct NoteCard: View {
     private let repliesDisplayType: RepliesDisplayType
     
     /// Indicates whether the number of likes is displayed.
-    private let showLikeCount: Bool
+    private let showsLikeCount: Bool
 
     /// Indicates whether the number of reposts is displayed.
-    private let showRepostCount: Bool
+    private let showsRepostCount: Bool
 
     private var hideOutOfNetwork: Bool
     private var replyAction: ((Event) -> Void)?
@@ -34,12 +34,12 @@ struct NoteCard: View {
     /// - Parameter note: Note event to display.
     /// - Parameter style: Card style. Defaults to `.compact`.
     /// - Parameter shouldTruncate: Whether the card should display just some lines or the
-    /// full content of the note. Defaults to true.
+    /// full content of the note. Defaults to `true`.
     /// - Parameter hideOutOfNetwork: Blur the card if the author is not inside the user's
-    /// network. Defaults to true.
+    /// network. Defaults to `true`.
     /// - Parameter repliesDisplayType: Replies Label style. Defaults to `.displayNothing`.
-    /// - Parameter showLikeCount: Whether the number of likes is displayed. Defaults to `true`.
-    /// - Parameter showRepostCount: Whether the number of reposts is displayed. Defaults to `true`.
+    /// - Parameter showsLikeCount: Whether the number of likes is displayed. Defaults to `true`.
+    /// - Parameter showsRepostCount: Whether the number of reposts is displayed. Defaults to `true`.
     /// - Parameter replyAction: Handler that gets called when the user taps on the Reply
     /// button. Defaults to `nil`.
     init(
@@ -48,8 +48,8 @@ struct NoteCard: View {
         shouldTruncate: Bool = true,
         hideOutOfNetwork: Bool = true,
         repliesDisplayType: RepliesDisplayType = .displayNothing,
-        showLikeCount: Bool = true,
-        showRepostCount: Bool = true,
+        showsLikeCount: Bool = true,
+        showsRepostCount: Bool = true,
         replyAction: ((Event) -> Void)? = nil
     ) {
         self.note = note
@@ -57,8 +57,8 @@ struct NoteCard: View {
         self.shouldTruncate = shouldTruncate
         self.hideOutOfNetwork = hideOutOfNetwork
         self.repliesDisplayType = repliesDisplayType
-        self.showLikeCount = showLikeCount
-        self.showRepostCount = showRepostCount
+        self.showsLikeCount = showsLikeCount
+        self.showsRepostCount = showsRepostCount
         self.replyAction = replyAction
     }
     
@@ -113,8 +113,8 @@ struct NoteCard: View {
                                 }
                             }
                             Spacer()
-                            RepostButton(note: note, showsCount: showRepostCount)
-                            LikeButton(note: note, showsCount: showLikeCount)
+                            RepostButton(note: note, showsCount: showsRepostCount)
+                            LikeButton(note: note, showsCount: showsLikeCount)
                             ReplyButton(note: note, replyAction: replyAction)
                         }
                         .padding(.leading, 13)

--- a/Nos/Views/RepostButton.swift
+++ b/Nos/Views/RepostButton.swift
@@ -23,7 +23,7 @@ struct RepostButton: View {
     ///
     /// - Parameter note: Note event to display reposts to.
     /// - Parameter showsCount: Whether the number of reposts is displayed. Defaults to `true`.
-    internal init(note: Event, showsCount: Bool = true) {
+    init(note: Event, showsCount: Bool = true) {
         self.note = note
         self.showsCount = showsCount
         _reposts = FetchRequest(fetchRequest: Event.reposts(noteID: note.identifier ?? ""))

--- a/Nos/Views/RepostButton.swift
+++ b/Nos/Views/RepostButton.swift
@@ -5,7 +5,10 @@ import Logger
 struct RepostButton: View {
     
     var note: Event
-    
+
+    /// Indicates whether the number of reposts is displayed.
+    var showsCount: Bool
+
     @FetchRequest private var reposts: FetchedResults<Event>
     @EnvironmentObject private var relayService: RelayService
     @Environment(CurrentUser.self) private var currentUser
@@ -16,8 +19,13 @@ struct RepostButton: View {
     @State private var shouldConfirmRepost = false
     @State private var shouldConfirmDelete = false
     
-    internal init(note: Event) {
+    /// Initializes a RepostButton object.
+    ///
+    /// - Parameter note: Note event to display reposts to.
+    /// - Parameter showsCount: Whether the number of reposts is displayed. Defaults to `true`.
+    internal init(note: Event, showsCount: Bool = true) {
         self.note = note
+        self.showsCount = showsCount
         _reposts = FetchRequest(fetchRequest: Event.reposts(noteID: note.identifier ?? ""))
     }
     
@@ -40,7 +48,7 @@ struct RepostButton: View {
                     Image.repostButton
                 }
                 
-                if reposts.count > 0 {
+                if showsCount, reposts.count > 0 {
                     Text(reposts.count.description)
                         .font(.clarity(.medium, textStyle: .subheadline))
                         .foregroundColor(.secondaryTxt)

--- a/Nos/Views/ThreadView.swift
+++ b/Nos/Views/ThreadView.swift
@@ -32,8 +32,8 @@ struct ThreadView: View {
             NoteButton(
                 note: root,
                 repliesDisplayType: .count,
-                showLikeCount: false,
-                showRepostCount: false,
+                showsLikeCount: true,
+                showsRepostCount: true,
                 tapAction: { event in
                     router.push(event)
                 }

--- a/Nos/Views/ThreadView.swift
+++ b/Nos/Views/ThreadView.swift
@@ -32,6 +32,8 @@ struct ThreadView: View {
             NoteButton(
                 note: root,
                 repliesDisplayType: .count,
+                showLikeCount: false,
+                showRepostCount: false,
                 tapAction: { event in
                     router.push(event)
                 }


### PR DESCRIPTION
## Issues covered
#1358

## Description
Removes the like and reposts counts from the Home and Profile feeds.

## How to test
1. Navigate to a Home Feed
2. Check that counts are not being displayed
3. Navigate to a post
4. Check that counts are displayed in the Thread view.

## Screenshots/Video

| ![IMG_2429](https://github.com/user-attachments/assets/1cea4ae0-0bb9-4591-aebd-ef68266d6d1d) | ![IMG_2428](https://github.com/user-attachments/assets/aee5175f-1206-4b52-995b-b86ed93e63d3) |

