### PR TITLE
Replace remaining Color(hex:) references with semantic Color assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed the like and repost counts from the Main and Profile feeds.
 - Fixed an issue where the sheet asking users to set up a NIP-05 username would appear after reinstalling Nos, even if the profile already had a NIP-05 username.
 - Fixed a bug where urls with periods after them would include the period.
-- Replaced hard-coded color values.
+- Replaced hard-coded hex color values.
 
 ## [0.1.24] - 2024-08-09Z
 

--- a/Nos/Assets/Colors.xcassets/big-action-button-background.colorset/Contents.json
+++ b/Nos/Assets/Colors.xcassets/big-action-button-background.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x36",
+          "green" : "0x30",
+          "red" : "0xC1"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Nos/Assets/Colors.xcassets/big-action-button-gradient-bottom.colorset/Contents.json
+++ b/Nos/Assets/Colors.xcassets/big-action-button-gradient-bottom.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x55",
+          "green" : "0x43",
+          "red" : "0xF2"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Nos/Assets/Colors.xcassets/big-action-button-gradient-bottom.colorset/Contents.json
+++ b/Nos/Assets/Colors.xcassets/big-action-button-gradient-bottom.colorset/Contents.json
@@ -6,7 +6,7 @@
         "components" : {
           "alpha" : "1.000",
           "blue" : "0x55",
-          "green" : "0x43",
+          "green" : "0x4E",
           "red" : "0xF2"
         }
       },

--- a/Nos/Assets/Colors.xcassets/big-action-button-gradient-top.colorset/Contents.json
+++ b/Nos/Assets/Colors.xcassets/big-action-button-gradient-top.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x37",
+          "green" : "0x63",
+          "red" : "0xF0"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Nos/Assets/Colors.xcassets/gold-bg-gradient-bottom.colorset/Contents.json
+++ b/Nos/Assets/Colors.xcassets/gold-bg-gradient-bottom.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x21",
+          "green" : "0x7C",
+          "red" : "0xDE"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Nos/Assets/Colors.xcassets/gold-bg-gradient-top.colorset/Contents.json
+++ b/Nos/Assets/Colors.xcassets/gold-bg-gradient-top.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x6B",
+          "green" : "0xC4",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Nos/Assets/Colors.xcassets/nip05-field-fg-gradient-bottom.colorset/Contents.json
+++ b/Nos/Assets/Colors.xcassets/nip05-field-fg-gradient-bottom.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x09",
+          "green" : "0x25",
+          "red" : "0xA4"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Nos/Assets/Colors.xcassets/nip05-field-fg-gradient-top.colorset/Contents.json
+++ b/Nos/Assets/Colors.xcassets/nip05-field-fg-gradient-top.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x21",
+          "green" : "0x51",
+          "red" : "0xE5"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Nos/Assets/Colors.xcassets/nip05-field-text-foreground.colorset/Contents.json
+++ b/Nos/Assets/Colors.xcassets/nip05-field-text-foreground.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x08",
+          "green" : "0xA1",
+          "red" : "0xF0"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Nos/Views/BigActionButton.swift
+++ b/Nos/Views/BigActionButton.swift
@@ -32,8 +32,8 @@ extension LinearGradient {
     static var bigAction: LinearGradient {
         LinearGradient(
             colors: [
-                Color(hex: "#F06337"),
-                Color(hex: "#F24E55")
+                Color.bigActionButtonGradientTop,
+                Color.bigActionButtonGradientBottom
             ],
             startPoint: .top,
             endPoint: .bottom
@@ -52,7 +52,7 @@ struct BigActionButtonStyle: ButtonStyle {
         ZStack {
             // Button shadow/background
             ZStack {
-                Color(hex: "#C13036")
+                Color.bigActionButtonBackground
             }
             .cornerRadius(80)
             .offset(y: 4.5)

--- a/Nos/Views/Modifiers/LinearGradient+Planetary.swift
+++ b/Nos/Views/Modifiers/LinearGradient+Planetary.swift
@@ -45,7 +45,7 @@ extension LinearGradient {
     )
 
     public static let gold = LinearGradient(
-        colors: [Color(hex: "#FFC46B"), Color(hex: "#DE7C21")],
+        colors: [Color.goldBgGradientTop, Color.goldBgGradientBottom],
         startPoint: .top,
         endPoint: .bottom
     )

--- a/Nos/Views/ProfileEdit/ProfileEditView.swift
+++ b/Nos/Views/ProfileEdit/ProfileEditView.swift
@@ -234,7 +234,10 @@ fileprivate struct NosNIP05Field: View {
                         Image(systemName: "minus.circle.fill")
                             .foregroundStyle(
                                 LinearGradient(
-                                    colors: [Color(hex: "#E55121"), Color(hex: "#A42509")],
+                                    colors: [
+                                        Color.nip05FieldFgGradientTop,
+                                        Color.nip05FieldFgGradientBottom
+                                    ],
                                     startPoint: .top,
                                     endPoint: .bottom
                                 )
@@ -248,7 +251,7 @@ fileprivate struct NosNIP05Field: View {
                 .padding(.vertical, 15)
                 (
                     Text(Image(systemName: "exclamationmark.triangle"))
-                        .foregroundStyle(Color(hex: "#F0A108")) +
+                        .foregroundStyle(Color.nip05FieldTextForeground) +
                     Text(" ") +
                     Text(.localizable.usernameWarningMessage)
                         .foregroundStyle(Color.secondaryTxt)
@@ -282,7 +285,10 @@ fileprivate struct NIP05Field: View {
                         Image(systemName: "minus.circle.fill")
                             .foregroundStyle(
                                 LinearGradient(
-                                    colors: [Color(hex: "#E55121"), Color(hex: "#A42509")],
+                                    colors: [
+                                        Color.nip05FieldFgGradientTop,
+                                        Color.nip05FieldFgGradientBottom
+                                    ],
                                     startPoint: .top,
                                     endPoint: .bottom
                                 )
@@ -296,7 +302,7 @@ fileprivate struct NIP05Field: View {
                 .padding(.vertical, 15)
                 (
                     Text(Image(systemName: "exclamationmark.triangle"))
-                        .foregroundStyle(Color(hex: "#F0A108")) +
+                        .foregroundStyle(Color.nip05FieldTextForeground) +
                     Text(" ") +
                     Text(.localizable.usernameWarningMessage)
                         .foregroundStyle(Color.secondaryTxt)


### PR DESCRIPTION
## Issues covered
[1375](https://github.com/planetary-social/nos/issues/1375) (ongoing work)

## Description
Replaced remaining Color(hex:) references with semantically names colors in Colors.xcassets

## How to test
- Verify that the hex colors in each asset match the hard coded hex color in the changed file; smoke test the app to verify

## Notes
- changes to Color(white: opacity) and hard coded RGB colors will be addressed in separate PRs.
