### PR TITLE
add quote reposting #940 #941 #942 #943

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed the like and repost counts from the Main and Profile feeds.
 - Replaced hard-coded color values.
 - Show quoted notes in note cards.
+- Added quote-reposting.
 
 ## [0.1.25] - 2024-08-21Z
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Show quoted notes in note cards.
 - Added a new image viewer that appears when you tap an image.
 - Added a new gallery view that’s currently behind a feature flag.
 - Removed the like and repost counts from the Main and Profile feeds.
@@ -17,7 +18,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a toggle for “Enable new media display” to Staging builds. [skip-release-notes]
 - Fixed typos in release notes. [skip-release-notes]
 - Localized the quotation marks on the Notifications view.
-- Show quoted notes in note cards.
 - Added quote-reposting.
 
 ## [0.1.25] - 2024-08-21Z

--- a/Nos/Assets/Localization/Localizable.xcstrings
+++ b/Nos/Assets/Localization/Localizable.xcstrings
@@ -9221,6 +9221,17 @@
         }
       }
     },
+    "quote" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Quote"
+          }
+        }
+      }
+    },
     "readMore" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/Nos/Views/NoteComposer/NoteComposer.swift
+++ b/Nos/Views/NoteComposer/NoteComposer.swift
@@ -89,10 +89,15 @@ struct NoteComposer: View {
                                             .id(0)
                                     }
                                     if let quotedNote {
-                                        NoteCard(note: quotedNote, rendersQuotedNotes: false, showsActions: false)
-                                            .withStyledBorder()
-                                            .padding(.horizontal, 16)
-                                            .padding(.bottom, 16)
+                                        NoteCard(
+                                            note: quotedNote,
+                                            hideOutOfNetwork: false,
+                                            rendersQuotedNotes: false,
+                                            showsActions: false
+                                        )
+                                        .withStyledBorder()
+                                        .padding(.horizontal, 16)
+                                        .padding(.bottom, 16)
                                     }
                                 }
                                 .onAppear {

--- a/Nos/Views/NoteComposer/NoteComposer.swift
+++ b/Nos/Views/NoteComposer/NoteComposer.swift
@@ -169,7 +169,7 @@ struct NoteComposer: View {
                 },
                 trailing: ActionButton(title: .localizable.post, action: postAction)
                     .frame(height: 22)
-                    .disabled(!canPost)
+                    .disabled(!isPostEnabled)
                     .padding(.bottom, 3)
             )
             .onAppear {
@@ -240,7 +240,7 @@ struct NoteComposer: View {
         )
     }
 
-    private var canPost: Bool {
+    private var isPostEnabled: Bool {
         !isUploadingImage && (!editingController.isEmpty || quotedNote?.bech32NoteID.isEmptyOrNil == false)
     }
     
@@ -262,7 +262,7 @@ struct NoteComposer: View {
             return
         }
         
-        guard canPost else {
+        guard isPostEnabled else {
             Log.error("Tried to publish a post with empty text")
             return
         }

--- a/Nos/Views/RepostButton.swift
+++ b/Nos/Views/RepostButton.swift
@@ -18,6 +18,7 @@ struct RepostButton: View {
     @State private var tapped = false
     @State private var shouldConfirmRepost = false
     @State private var shouldConfirmDelete = false
+    @State private var showQuotedNoteComposer = false
     
     /// Initializes a RepostButton object.
     ///
@@ -62,6 +63,9 @@ struct RepostButton: View {
             Button(String(localized: .localizable.repost)) {
                 Task { await repostNote() }
             }
+            Button(String(localized: .localizable.quote)) {
+                quoteNote()
+            }
             Button(String(localized: .localizable.cancel), role: .cancel) {
                 tapped = false
             }
@@ -71,6 +75,14 @@ struct RepostButton: View {
                 Task { await deleteReposts() }
             }
         }
+        .sheet(isPresented: $showQuotedNoteComposer, content: {
+            NoteComposer(quotedNoteID: note.identifier, isPresented: $showQuotedNoteComposer)
+                .environment(currentUser)
+                .interactiveDismissDisabled()
+                .onDisappear {
+                    tapped = false
+                }
+        })
     }
     
     func buttonPressed() async {
@@ -110,6 +122,10 @@ struct RepostButton: View {
         } catch {
             Log.error(error, "Error creating event for repost")
         }
+    }
+    
+    private func quoteNote() {
+        showQuotedNoteComposer = true
     }
     
     func deleteReposts() async {

--- a/Nos/Views/RepostButton.swift
+++ b/Nos/Views/RepostButton.swift
@@ -64,7 +64,7 @@ struct RepostButton: View {
                 Task { await repostNote() }
             }
             Button(String(localized: .localizable.quote)) {
-                quoteNote()
+                showQuotedNoteComposer = true
             }
             Button(String(localized: .localizable.cancel), role: .cancel) {
                 tapped = false
@@ -75,14 +75,14 @@ struct RepostButton: View {
                 Task { await deleteReposts() }
             }
         }
-        .sheet(isPresented: $showQuotedNoteComposer, content: {
+        .sheet(isPresented: $showQuotedNoteComposer) {
             NoteComposer(quotedNoteID: note.identifier, isPresented: $showQuotedNoteComposer)
                 .environment(currentUser)
                 .interactiveDismissDisabled()
                 .onDisappear {
                     tapped = false
                 }
-        })
+        }
     }
     
     func buttonPressed() async {
@@ -122,10 +122,6 @@ struct RepostButton: View {
         } catch {
             Log.error(error, "Error creating event for repost")
         }
-    }
-    
-    private func quoteNote() {
-        showQuotedNoteComposer = true
     }
     
     func deleteReposts() async {


### PR DESCRIPTION
## Issues covered
#940 #941 #942 #943 

## Description
Adds the ability to quote a note. When the user taps the repost button on a note, they will now be given two options: Repost and Quote. Repost continues to do what it did previously. Quote will open the note composer view with the quoted note shown at the bottom.

## How to test
1. Navigate to any feed.
2. Tap the repost button on any note.
3. Tap Quote.

Here you can either post it immediately, and it will post a note that only contains a link to another note. Or you can add your own comment and post it. The link to the quoted note will be appended to the end of the content before publishing.

## Screenshots/Video

Menu change:  
![menu change](https://github.com/user-attachments/assets/3d772e55-0df6-4456-9629-227eff4fb952)

Multiline comment and canceling:  
![multiline and cancel](https://github.com/user-attachments/assets/73954f05-7ce9-4ff8-a30d-c11a3dde5b63)

Long note visibility:  
![long note](https://github.com/user-attachments/assets/9b448210-8f0c-4deb-a948-f60440f3f18f)

Full path:  
![full](https://github.com/user-attachments/assets/0eef154f-5497-4d67-815e-dfebf0182cbe)
