### PR TITLE
Add feature toggle for new media to staging builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Included the npub in the properties list sent to analytics.
 - Removed the like and repost counts from the Main and Profile feeds.
 - Replaced hard-coded color values.
+- Added a toggle for “Enable new media display” to Staging builds.
 
 ## [0.1.25] - 2024-08-21Z
 

--- a/Nos/Service/FeatureFlags.swift
+++ b/Nos/Service/FeatureFlags.swift
@@ -9,7 +9,7 @@ protocol FeatureFlags {
 
     // MARK: - Additional requirements for debug mode
 
-    #if DEBUG
+    #if DEBUG || STAGING
     /// Sets the value of `newMediaDisplayEnabled`.
     func setNewMediaDisplayEnabled(_ enabled: Bool)
     #endif
@@ -25,7 +25,7 @@ class DefaultFeatureFlags: FeatureFlags, DependencyKey {
     private(set) var newMediaDisplayEnabled = false
 }
 
-#if DEBUG
+#if DEBUG || STAGING
 extension DefaultFeatureFlags {
     func setNewMediaDisplayEnabled(_ enabled: Bool) {
         newMediaDisplayEnabled = enabled

--- a/Nos/Views/SettingsView.swift
+++ b/Nos/Views/SettingsView.swift
@@ -215,6 +215,10 @@ struct SettingsView: View {
                     }
                 }
 
+                #if STAGING
+                stagingControls
+                #endif
+
                 #if DEBUG
                 debugControls
                 #endif
@@ -262,21 +266,42 @@ struct SettingsView: View {
     }
 }
 
-#if DEBUG
+// DEBUG builds will have everything that's in STAGING builds and more.
+#if STAGING || DEBUG
 extension SettingsView {
-    private var enableNewMediaDisplay: Binding<Bool> {
+    /// Whether the new media display is enabled.
+    private var isNewMediaDisplayEnabled: Binding<Bool> {
         Binding<Bool>(
             get: { featureFlags.newMediaDisplayEnabled },
             set: { featureFlags.setNewMediaDisplayEnabled($0) }
         )
     }
+    
+    /// A toggle for the new media display that allows the user to turn the feature on or off.
+    private var newMediaFeatureToggle: some View {
+        Toggle(isOn: isNewMediaDisplayEnabled) {
+            Text(.localizable.enableNewMediaDisplay)
+                .foregroundColor(.primaryTxt)
+        }
+    }
+}
+#endif
 
-    @MainActor var debugControls: some View {
+#if STAGING
+extension SettingsView {
+    /// Controls that will appear when the app is built for STAGING.
+    @MainActor private var stagingControls: some View {
+        newMediaFeatureToggle
+    }
+}
+#endif
+
+#if DEBUG
+extension SettingsView {
+    /// Controls that will appear when the app is built for DEBUG.
+    @MainActor private var debugControls: some View {
         Group {
-            Toggle(isOn: enableNewMediaDisplay) {
-                Text(.localizable.enableNewMediaDisplay)
-                    .foregroundColor(.primaryTxt)
-            }
+            newMediaFeatureToggle
 
             Text(.localizable.sampleDataInstructions)
                 .foregroundColor(.primaryTxt)


### PR DESCRIPTION
## Issues covered
#1177

## Description
In order to test #1177, Linda will need to be able to turn on the new media feature. This gives her (and all Staging users) the ability to do that.

## How to test
1. Build NosStaging
2. Navigate to Settings
3. Observe "Enable new media display"
4. Toggle it on
5. See how it looks

## Screenshots/Video
| Staging | Dev |
|--------|--------|
| ![Simulator Screenshot - iPhone 15 Pro - 2024-08-23 at 10 57 35](https://github.com/user-attachments/assets/845bb68d-a276-4dd9-988c-5c545d5add54) | ![Simulator Screenshot - iPhone 15 Pro - 2024-08-23 at 11 58 25](https://github.com/user-attachments/assets/7e1f668e-fc19-4bea-bca3-7855b93b321b) | 
