### PR TITLE
Show gallery in proper orientation when an image is the first link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,20 +8,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### External
 - Show quoted notes in note cards.
 - Added a new image viewer that appears when you tap an image.
+- Added a new gallery view that’s currently behind a feature flag.
 - Removed the like and repost counts from the Main and Profile feeds.
 - Removed wss:// from relay addresses in lists and removed the need to prepend relay addresses with wss://.
 - Localized the quotation marks on the Notifications view.
-
-### Internal
-- Included the npub in the properties list sent to analytics.
-- Replaced hard-coded color values.
-- Added a toggle for “Enable new media display” to Staging builds.
-- Added a new gallery view to display multiple links in a post. Currently behind the “Enable new media display” feature flag.
-- Show single images and gallery view in the proper orientation. Currently behind the “Enable new media display” feature flag.
-- Fixed typos in release notes.
+- Included the npub in the properties list sent to analytics. [skip-release-notes]
+- Replaced hard-coded color values. [skip-release-notes]
+- Added a feature flag toggle for “Enable new media display” to Staging builds. [skip-release-notes]
+- Added a new gallery view to display multiple links in a post. Currently behind the “Enable new media display” feature flag. [skip-release-notes]
+- Show single images and gallery view in the proper orientation. Currently behind the “Enable new media display” feature flag. [skip-release-notes]
+- Fixed typos in release notes. [skip-release-notes]
 
 ## [0.1.25] - 2024-08-21Z
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,16 +8,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### External
 - Show quoted notes in note cards.
 - Added a new image viewer that appears when you tap an image.
-- Added a new gallery view that’s currently behind a feature flag.
 - Removed the like and repost counts from the Main and Profile feeds.
 - Removed wss:// from relay addresses in lists and removed the need to prepend relay addresses with wss://.
-- Included the npub in the properties list sent to analytics. [skip-release-notes]
-- Replaced hard-coded color values. [skip-release-notes]
-- Added a toggle for “Enable new media display” to Staging builds. [skip-release-notes]
-- Fixed typos in release notes. [skip-release-notes]
 - Localized the quotation marks on the Notifications view.
+
+### Internal
+- Included the npub in the properties list sent to analytics.
+- Replaced hard-coded color values.
+- Added a toggle for “Enable new media display” to Staging builds.
+- Added a new gallery view to display multiple links in a post. Currently behind the “Enable new media display” feature flag.
+- Show single images and gallery view in the proper orientation. Currently behind the “Enable new media display” feature flag.
+- Fixed typos in release notes.
 
 ## [0.1.25] - 2024-08-21Z
 

--- a/Nos.xcodeproj/project.pbxproj
+++ b/Nos.xcodeproj/project.pbxproj
@@ -11,6 +11,10 @@
 		030036942C5D3AD3002C71F5 /* RefreshController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 030036842C5D39DD002C71F5 /* RefreshController.swift */; };
 		030036AB2C5D872B002C71F5 /* NewNotesButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 030036AA2C5D872B002C71F5 /* NewNotesButton.swift */; };
 		030AE4292BE3D63C004DEE02 /* FeaturedAuthor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 030AE4282BE3D63C004DEE02 /* FeaturedAuthor.swift */; };
+		0314D5AC2C7D31060002E7F4 /* MediaService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0314D5AB2C7D31060002E7F4 /* MediaService.swift */; };
+		0314D5AD2C7D31060002E7F4 /* MediaService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0314D5AB2C7D31060002E7F4 /* MediaService.swift */; };
+		0315B5EF2C7E451C0020E707 /* MockMediaService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0315B5EE2C7E451C0020E707 /* MockMediaService.swift */; };
+		0315B5F02C7E451C0020E707 /* MockMediaService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0315B5EE2C7E451C0020E707 /* MockMediaService.swift */; };
 		0317263C2C7935220030EDCA /* AspectRatioContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0317263B2C7935220030EDCA /* AspectRatioContainer.swift */; };
 		0317263D2C7935220030EDCA /* AspectRatioContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0317263B2C7935220030EDCA /* AspectRatioContainer.swift */; };
 		0320C0FB2BFE43A600C4C080 /* RelayServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0320C0FA2BFE43A600C4C080 /* RelayServiceTests.swift */; };
@@ -532,6 +536,8 @@
 		030036842C5D39DD002C71F5 /* RefreshController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefreshController.swift; sourceTree = "<group>"; };
 		030036AA2C5D872B002C71F5 /* NewNotesButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewNotesButton.swift; sourceTree = "<group>"; };
 		030AE4282BE3D63C004DEE02 /* FeaturedAuthor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeaturedAuthor.swift; sourceTree = "<group>"; };
+		0314D5AB2C7D31060002E7F4 /* MediaService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaService.swift; sourceTree = "<group>"; };
+		0315B5EE2C7E451C0020E707 /* MockMediaService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockMediaService.swift; sourceTree = "<group>"; };
 		0317263B2C7935220030EDCA /* AspectRatioContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AspectRatioContainer.swift; sourceTree = "<group>"; };
 		0320C0E42BFBB27E00C4C080 /* PerformanceTests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = PerformanceTests.xctestplan; sourceTree = "<group>"; };
 		0320C0FA2BFE43A600C4C080 /* RelayServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelayServiceTests.swift; sourceTree = "<group>"; };
@@ -956,6 +962,15 @@
 			path = CoreData;
 			sourceTree = "<group>";
 		};
+		0315B5ED2C7E44FD0020E707 /* Media */ = {
+			isa = PBXGroup;
+			children = (
+				0314D5AB2C7D31060002E7F4 /* MediaService.swift */,
+				0315B5EE2C7E451C0020E707 /* MockMediaService.swift */,
+			);
+			path = Media;
+			sourceTree = "<group>";
+		};
 		0320C0F92BFE439000C4C080 /* Relay */ = {
 			isa = PBXGroup;
 			children = (
@@ -1293,6 +1308,7 @@
 				C9A0DAF729C92F4500466635 /* UNSAPI.swift */,
 				C9F64D8B29ED840700563F2B /* Zipper.swift */,
 				032634512C10BB8F00E489B5 /* FileStorage */,
+				0315B5ED2C7E44FD0020E707 /* Media */,
 				03D1B42A2C3C1AE7001778CD /* NostrIdentifier */,
 				C98CA9052B14FA8500929141 /* Relay */,
 			);
@@ -1995,6 +2011,7 @@
 				C9F84C21298DC36800C6714D /* AppView.swift in Sources */,
 				C9CE5B142A0172CF008E198C /* WebView.swift in Sources */,
 				CD4908D429B92941007443DB /* ReportABugMailView.swift in Sources */,
+				0314D5AC2C7D31060002E7F4 /* MediaService.swift in Sources */,
 				5B7C93B02B6AD52400410ABE /* CreateUsernameWizard.swift in Sources */,
 				030036852C5D39DD002C71F5 /* RefreshController.swift in Sources */,
 				C9C2B78229E0735400548B4A /* RelaySubscriptionManager.swift in Sources */,
@@ -2204,6 +2221,7 @@
 				CD2CF38E299E67F900332116 /* CardButtonStyle.swift in Sources */,
 				03E181392C75467C00886CC6 /* GalleryView.swift in Sources */,
 				A336DD3C299FD78000A0CBA0 /* Filter.swift in Sources */,
+				0315B5EF2C7E451C0020E707 /* MockMediaService.swift in Sources */,
 				DC2E54C82A700F1400C2CAAB /* UIDevice+Simulator.swift in Sources */,
 				C97B288A2C10B07100DC1FC0 /* NosNavigationStack.swift in Sources */,
 				C98CA9072B14FBBF00929141 /* PagedNoteDataSource.swift in Sources */,
@@ -2325,6 +2343,7 @@
 				0326347B2C10C57A00E489B5 /* FileStorageAPIClient.swift in Sources */,
 				C9B678DC29EEBF3B00303F33 /* DependencyInjection.swift in Sources */,
 				C9F0BB6D29A503D9000547FC /* Int+Bool.swift in Sources */,
+				0314D5AD2C7D31060002E7F4 /* MediaService.swift in Sources */,
 				C9C097232C13534800F78EC3 /* DatabaseCleanerTests.swift in Sources */,
 				DC08FF812A7969C5009F87D1 /* UIDevice+Simulator.swift in Sources */,
 				5BFBB2962BD9D824002E909F /* URLParser.swift in Sources */,
@@ -2347,6 +2366,7 @@
 				A3B943D8299D758F00A15A08 /* Keychain.swift in Sources */,
 				035729B92BE416A6005FEE85 /* GiftWrapperTests.swift in Sources */,
 				032634702C10C40B00E489B5 /* NostrBuildAPIClientTests.swift in Sources */,
+				0315B5F02C7E451C0020E707 /* MockMediaService.swift in Sources */,
 				C9646EAA29B7A506007239A4 /* Analytics.swift in Sources */,
 				C9736E5E2C13B718005BCE70 /* EventFixture.swift in Sources */,
 				035729AF2BE4167E005FEE85 /* KeyPairTests.swift in Sources */,

--- a/Nos.xcodeproj/project.pbxproj
+++ b/Nos.xcodeproj/project.pbxproj
@@ -11,6 +11,8 @@
 		030036942C5D3AD3002C71F5 /* RefreshController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 030036842C5D39DD002C71F5 /* RefreshController.swift */; };
 		030036AB2C5D872B002C71F5 /* NewNotesButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 030036AA2C5D872B002C71F5 /* NewNotesButton.swift */; };
 		030AE4292BE3D63C004DEE02 /* FeaturedAuthor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 030AE4282BE3D63C004DEE02 /* FeaturedAuthor.swift */; };
+		0317263C2C7935220030EDCA /* AspectRatioContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0317263B2C7935220030EDCA /* AspectRatioContainer.swift */; };
+		0317263D2C7935220030EDCA /* AspectRatioContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0317263B2C7935220030EDCA /* AspectRatioContainer.swift */; };
 		0320C0FB2BFE43A600C4C080 /* RelayServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0320C0FA2BFE43A600C4C080 /* RelayServiceTests.swift */; };
 		0320C1152BFE63DC00C4C080 /* MockRelaySubscriptionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0320C1142BFE63DC00C4C080 /* MockRelaySubscriptionManager.swift */; };
 		032634682C10C0D600E489B5 /* nostr_build_nip96_response.json in Resources */ = {isa = PBXBuildFile; fileRef = 032634672C10C0D600E489B5 /* nostr_build_nip96_response.json */; };
@@ -530,6 +532,7 @@
 		030036842C5D39DD002C71F5 /* RefreshController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefreshController.swift; sourceTree = "<group>"; };
 		030036AA2C5D872B002C71F5 /* NewNotesButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewNotesButton.swift; sourceTree = "<group>"; };
 		030AE4282BE3D63C004DEE02 /* FeaturedAuthor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeaturedAuthor.swift; sourceTree = "<group>"; };
+		0317263B2C7935220030EDCA /* AspectRatioContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AspectRatioContainer.swift; sourceTree = "<group>"; };
 		0320C0E42BFBB27E00C4C080 /* PerformanceTests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = PerformanceTests.xctestplan; sourceTree = "<group>"; };
 		0320C0FA2BFE43A600C4C080 /* RelayServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelayServiceTests.swift; sourceTree = "<group>"; };
 		0320C1142BFE63DC00C4C080 /* MockRelaySubscriptionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockRelaySubscriptionManager.swift; sourceTree = "<group>"; };
@@ -1078,6 +1081,7 @@
 		03C8B4902C6D061900A07CCD /* Media */ = {
 			isa = PBXGroup;
 			children = (
+				0317263B2C7935220030EDCA /* AspectRatioContainer.swift */,
 				03E181382C75467C00886CC6 /* GalleryView.swift */,
 				03E1812E2C753C9B00886CC6 /* ImageButton.swift */,
 				03C8B4952C6D065900A07CCD /* ImageViewer.swift */,
@@ -2121,6 +2125,7 @@
 				C94D14812A12B3F70014C906 /* SearchBar.swift in Sources */,
 				C9A6C7472AD84263001F9500 /* UNSNamePicker.swift in Sources */,
 				C92E7F672C4EFF3D00B80638 /* WebSocketErrorEvent.swift in Sources */,
+				0317263C2C7935220030EDCA /* AspectRatioContainer.swift in Sources */,
 				C93EC2F729C351470012EE2A /* Optional+Unwrap.swift in Sources */,
 				A32B6C7829A6C99200653FF5 /* CompactAuthorCard.swift in Sources */,
 				C92DF80829C25FA900400561 /* SquareImage.swift in Sources */,
@@ -2306,6 +2311,7 @@
 				0383CD7B2C76798C007DB0E4 /* ImageButton.swift in Sources */,
 				5BE281CD2AE2CD4700880466 /* AvatarView.swift in Sources */,
 				C9F84C1A298DBB6300C6714D /* Data+Encoding.swift in Sources */,
+				0317263D2C7935220030EDCA /* AspectRatioContainer.swift in Sources */,
 				C9DEC0642989541F0078B43A /* Bundle+Current.swift in Sources */,
 				C9ADB13629928AF00075E7F8 /* KeyPair.swift in Sources */,
 				3FFB1D9729A6BBEC002A755D /* Collection+SafeSubscript.swift in Sources */,

--- a/Nos/Service/DependencyInjection.swift
+++ b/Nos/Service/DependencyInjection.swift
@@ -84,6 +84,11 @@ extension DependencyValues {
         get { self[KeychainKey.self] }
         set { self[KeychainKey.self] = newValue }
     }
+
+    var mediaService: MediaService {
+        get { self[MediaServiceKey.self] }
+        set { self[MediaServiceKey.self] = newValue }
+    }
 }
 
 fileprivate enum AnalyticsKey: DependencyKey {
@@ -175,4 +180,10 @@ fileprivate enum KeychainKey: DependencyKey {
     @MainActor static let liveValue: Keychain = SystemKeychain()
     @MainActor static let testValue: Keychain = InMemoryKeychain()
     @MainActor static let previewValue: Keychain = InMemoryKeychain()
+}
+
+fileprivate enum MediaServiceKey: DependencyKey {
+    static let liveValue: any MediaService = DefaultMediaService()
+    static let testValue: any MediaService = MockMediaService()
+    static let previewValue: any MediaService = DefaultMediaService() // enables us to manually test with previews
 }

--- a/Nos/Service/Media/MediaService.swift
+++ b/Nos/Service/Media/MediaService.swift
@@ -1,0 +1,68 @@
+import AVFoundation
+import Foundation
+import LinkPresentation
+import SDWebImage
+
+/// Determines the preferred ``MediaOrientation`` for a given `URL`.
+protocol MediaService {
+    /// Returns the preferred orientation for the media at the given URL.
+    /// - Parameter url: The URL of the media.
+    /// - Returns: The preferred orientation for the media at the given URL.
+    /// - Note: For images, the orientation will match the image when possible. For square images, `landscape` is
+    ///         returned. For web pages, `landscape` is returned. For videos, we're returning `portrait` until we
+    ///         implement [#1425](https://github.com/planetary-social/nos/issues/1425)
+    func orientation(for url: URL) async -> MediaOrientation
+}
+
+/// Loads media to determine its preferred ``MediaOrientation``.
+struct DefaultMediaService: MediaService {
+
+    // MARK: - MediaService protocol
+
+    func orientation(for url: URL) async -> MediaOrientation {
+        if url.isImage {
+            return await imageOrientation(url: url)
+        } else {
+            return await videoOrWebPageOrientation(url: url)
+        }
+    }
+
+    // MARK: - Private
+
+    /// Loads the image at the given URL and returns its orientation.
+    /// - Parameter url: The URL of the image to download.
+    /// - Returns: The orientation of the image, or `.landscape` if it's square.
+    /// - Note: If the image is square or its dimensions can't be determined, returns `.landscape` as a default
+    ///         since we only support `.portait` and `.landscape` for the gallery view.
+    private func imageOrientation(url: URL) async -> MediaOrientation {
+        await withCheckedContinuation { continuation in
+            SDWebImageDownloader().downloadImage(with: url) { image, _, _, _ in
+                if let image, image.size.height > image.size.width {
+                    continuation.resume(returning: .portrait)
+                } else {
+                    continuation.resume(returning: .landscape)
+                }
+            }
+        }
+    }
+
+    /// Loads the content at the given URL and returns its orientation.
+    /// - Parameter url: The URL of the data to download.
+    /// - Returns: The orientation of the content.
+    /// - Note: For web pages, `landscape` is returned. For videos, we're returning `portrait` until we implement
+    ///         [#1425](https://github.com/planetary-social/nos/issues/1425)
+    private func videoOrWebPageOrientation(url: URL) async -> MediaOrientation {
+        let provider = LPMetadataProvider()
+        let metadata = try? await provider.startFetchingMetadata(for: url)
+
+        guard let metadata else {
+            return .landscape
+        }
+
+        if metadata.videoProvider != nil || metadata.remoteVideoURL != nil {
+            return .portrait
+        } else {
+            return .landscape
+        }
+    }
+}

--- a/Nos/Service/Media/MockMediaService.swift
+++ b/Nos/Service/Media/MockMediaService.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+/// A mock media service for testing.
+struct MockMediaService: MediaService {
+    func orientation(for url: URL) async -> MediaOrientation {
+        .landscape
+    }
+}

--- a/Nos/Views/Components/Media/AspectRatioContainer.swift
+++ b/Nos/Views/Components/Media/AspectRatioContainer.swift
@@ -3,8 +3,7 @@ import SwiftUI
 /// A container that holds a view and crops it to fit the aspect ratio of determined by the ``orientation``.
 /// When the ``orientation`` is `.portrait`, the aspect ratio of the container will be 3:4. Otherwise, it'll be 4:3.
 struct AspectRatioContainer<Content: View>: View {
-    /// The orientation of this container. If `.portrait`, the aspect ratio of this container will be 3:4.
-    /// Otherwise, the aspect ratio will be 4:3.
+    /// The orientation, which determines the aspect ratio of this container.
     let orientation: MediaOrientation
     
     /// The content to be displayed in the container.
@@ -12,12 +11,7 @@ struct AspectRatioContainer<Content: View>: View {
 
     var body: some View {
         Color.clear
-            .aspectRatio(
-                orientation == .portrait ?
-                    CGSize(width: 3, height: 4) :
-                    CGSize(width: 4, height: 3),
-                contentMode: .fit
-            )
+            .aspectRatio(orientation.aspectRatio, contentMode: .fit)
             .overlay {
                 content()
             }
@@ -32,4 +26,15 @@ enum MediaOrientation {
     case landscape
     /// The media is taller than it is wide.
     case portrait
+
+    /// The aspect ratio to use for the view that displays this media.
+    /// For `landscape`, the aspect ratio will be 4:3. For `portrait`, the aspect ratio will be 3:4.
+    var aspectRatio: CGFloat {
+        switch self {
+        case .landscape:
+            4 / 3
+        case .portrait:
+            3 / 4
+        }
+    }
 }

--- a/Nos/Views/Components/Media/AspectRatioContainer.swift
+++ b/Nos/Views/Components/Media/AspectRatioContainer.swift
@@ -1,0 +1,35 @@
+import SwiftUI
+
+/// A container that holds a view and crops it to fit the aspect ratio of determined by the ``orientation``.
+/// When the ``orientation`` is `.portrait`, the aspect ratio of the container will be 3:4. Otherwise, it'll be 4:3.
+struct AspectRatioContainer<Content: View>: View {
+    /// The orientation of this container. If `.portrait`, the aspect ratio of this container will be 3:4.
+    /// Otherwise, the aspect ratio will be 4:3.
+    let orientation: MediaOrientation
+    
+    /// The content to be displayed in the container.
+    let content: () -> Content
+
+    var body: some View {
+        Color.clear
+            .aspectRatio(
+                orientation == .portrait ?
+                    CGSize(width: 3, height: 4) :
+                    CGSize(width: 4, height: 3),
+                contentMode: .fit
+            )
+            .overlay {
+                content()
+            }
+            .clipShape(.rect)
+            .contentShape(.rect)
+    }
+}
+
+/// The orientation of the media: either landscape or portrait.
+enum MediaOrientation {
+    /// The media is wider than it is tall.
+    case landscape
+    /// The media is taller than it is wide.
+    case portrait
+}

--- a/Nos/Views/Components/Media/GalleryView.swift
+++ b/Nos/Views/Components/Media/GalleryView.swift
@@ -1,3 +1,4 @@
+import SDWebImageSwiftUI
 import SwiftUI
 
 /// Displays an array of URLs in a tab view with custom paging indicators.
@@ -8,37 +9,64 @@ struct GalleryView: View {
     
     /// The currently-selected tab in the tab view.
     @State private var selectedTab = 0
+    
+    /// The orientation of all media in this gallery view. Initially set to `.landscape` until we load the first URL and
+    /// determine its orientation, then updated to match the first item's orientation.
+    @State private var orientation: MediaOrientation?
+    
+    /// This essential first image determines the orientation of the gallery view. Whatever orientation this is, so the
+    /// rest shall be.
+    /// Oh, but also: it's not always an image, so this won't work if it's a video or web link. Oopsie.
+    @State private var firstImage: Image?
 
     var body: some View {
-        if urls.count == 1, let url = urls.first {
-            if url.isImage {
-                ImageButton(url: url)
+        if let orientation {
+            if urls.count == 1, let url = urls.first {
+                AspectRatioContainer(orientation: orientation) {
+                    LinkView(url: url)
+                }
             } else {
-                LinkView(url: url)
+                VStack {
+                    TabView(selection: $selectedTab) {
+                        ForEach(urls.indices, id: \.self) { index in
+                            AspectRatioContainer(orientation: orientation) {
+                                LinkView(url: urls[index])
+                                    .tag(index)
+                            }
+                        }
+                    }
+                    .tabViewStyle(.page(indexDisplayMode: .never))
+                    .frame(
+                        minWidth: 0,
+                        maxWidth: .infinity,
+                        minHeight: 0,
+                        maxHeight: .infinity
+                    )
+                    .aspectRatio(orientation == .portrait ? 3 / 4 : 4 / 3, contentMode: .fit)
+                    .padding(.bottom, 10)
+                    .clipShape(.rect)
+
+                    GalleryIndexView(numberOfPages: urls.count, currentIndex: selectedTab)
+                }
+                .padding(.bottom, 10)
             }
         } else {
-            VStack {
-                TabView(selection: $selectedTab) {
-                    ForEach(urls.indices, id: \.self) { index in
-                        LinkView(url: urls[index])
-                            .frame(maxWidth: .infinity)
-                            .tag(index)
-                    }
-                }
-                .tabViewStyle(.page(indexDisplayMode: .never))
-                .frame(
-                    minWidth: 0,
-                    maxWidth: .infinity,
-                    minHeight: 0,
-                    maxHeight: .infinity
-                )
-                .aspectRatio(4 / 3, contentMode: .fit)
-                .padding(.bottom, 10)
-                .clipShape(.rect)
-
-                GalleryIndexView(numberOfPages: urls.count, currentIndex: selectedTab)
+            AspectRatioContainer(orientation: .landscape) {
+                ActivityIndicator(.constant(true))
             }
-            .padding(.bottom, 10)
+            .task {
+                if let url = urls.first, url.isImage {
+                    SDWebImageDownloader().downloadImage(with: urls.first) { image, _, _, _ in
+                        if let image, image.size.height > image.size.width {
+                            orientation = .portrait
+                        } else {
+                            orientation = .landscape
+                        }
+                    }
+                } else { // it must be a video or a web link of some sort... TODO: figure out its orientation
+                    orientation = .landscape
+                }
+            }
         }
     }
 }

--- a/Nos/Views/Components/Media/ImageButton.swift
+++ b/Nos/Views/Components/Media/ImageButton.swift
@@ -1,46 +1,24 @@
 import SDWebImageSwiftUI
 import SwiftUI
 
-/// A button that's filled entirely with an image and presents an `ImageViewer` when tapped.
+/// A button that's filled entirely with an image and presents an ``ImageViewer`` when tapped.
 struct ImageButton: View {
-    /// The URL of the image to display as the button label.
+    /// The image to display in the button.
     let url: URL
 
     /// Whether the image viewer is presented or not.
     @State private var isViewerPresented = false
 
-    /// The size of the image that was loaded.
-    @State private var imageSize: CGSize?
-
     var body: some View {
-        Color.clear
-            .aspectRatio(aspectRatio, contentMode: .fit)
-            .overlay(
-                Button {
-                    isViewerPresented = true
-                } label: {
-                    WebImage(url: url)
-                        .onSuccess { image, _, _ in
-                            imageSize = image.size
-                        }
-                        .resizable()
-                        .indicator(.activity)
-                        .scaledToFill()
-                }
-            )
-            .clipShape(.rect)
-            .contentShape(.rect)
-            .sheet(isPresented: $isViewerPresented) {
-                ImageViewer(url: url)
-            }
-    }
-    
-    /// The aspect ratio of the view. If the image is loaded and is taller than wide, this returns 3/4. Otherwise, 4/3.
-    var aspectRatio: CGFloat {
-        if let imageSize, imageSize.height > imageSize.width {
-            return 3 / 4
-        } else {
-            return 4 / 3
+        Button {
+            isViewerPresented = true
+        } label: {
+            WebImage(url: url)
+                .resizable()
+                .scaledToFill()
+        }
+        .sheet(isPresented: $isViewerPresented) {
+            ImageViewer(url: url)
         }
     }
 }

--- a/Nos/Views/Components/Media/ImageButton.swift
+++ b/Nos/Views/Components/Media/ImageButton.swift
@@ -9,11 +9,17 @@ struct ImageButton: View {
     /// Whether the image viewer is presented or not.
     @State private var isViewerPresented = false
 
+    /// The size of the image that was loaded.
+    @State private var imageSize: CGSize?
+
     var body: some View {
         Button {
             isViewerPresented = true
         } label: {
             WebImage(url: url)
+                .onSuccess { image, _, _ in
+                    imageSize = image.size
+                }
                 .resizable()
                 .indicator(.activity)
                 .aspectRatio(contentMode: .fill)
@@ -23,11 +29,20 @@ struct ImageButton: View {
                     minHeight: 0,
                     maxHeight: .infinity
                 )
-                .aspectRatio(4 / 3, contentMode: .fit)
+                .aspectRatio(aspectRatio, contentMode: .fit)
                 .clipShape(.rect)
         }
         .sheet(isPresented: $isViewerPresented) {
             ImageViewer(url: url)
+        }
+    }
+    
+    /// The aspect ratio of the view. If the image is loaded and is taller than wide, this returns 3/4. Otherwise, 4/3.
+    var aspectRatio: CGFloat {
+        if let imageSize, imageSize.height > imageSize.width {
+            return 3 / 4
+        } else {
+            return 4 / 3
         }
     }
 }

--- a/Nos/Views/Components/Media/ImageButton.swift
+++ b/Nos/Views/Components/Media/ImageButton.swift
@@ -13,28 +13,26 @@ struct ImageButton: View {
     @State private var imageSize: CGSize?
 
     var body: some View {
-        Button {
-            isViewerPresented = true
-        } label: {
-            WebImage(url: url)
-                .onSuccess { image, _, _ in
-                    imageSize = image.size
+        Color.clear
+            .aspectRatio(aspectRatio, contentMode: .fit)
+            .overlay(
+                Button {
+                    isViewerPresented = true
+                } label: {
+                    WebImage(url: url)
+                        .onSuccess { image, _, _ in
+                            imageSize = image.size
+                        }
+                        .resizable()
+                        .indicator(.activity)
+                        .scaledToFill()
                 }
-                .resizable()
-                .indicator(.activity)
-                .aspectRatio(contentMode: .fill)
-                .frame(
-                    minWidth: 0,
-                    maxWidth: .infinity,
-                    minHeight: 0,
-                    maxHeight: .infinity
-                )
-                .aspectRatio(aspectRatio, contentMode: .fit)
-                .clipShape(.rect)
-        }
-        .sheet(isPresented: $isViewerPresented) {
-            ImageViewer(url: url)
-        }
+            )
+            .clipShape(.rect)
+            .contentShape(.rect)
+            .sheet(isPresented: $isViewerPresented) {
+                ImageViewer(url: url)
+            }
     }
     
     /// The aspect ratio of the view. If the image is loaded and is taller than wide, this returns 3/4. Otherwise, 4/3.


### PR DESCRIPTION
## Issues covered
#1171 

## Description
Shows gallery views in the proper orientation when an image is the first link in a post. If the first link is a portrait image, the entire gallery will display in portrait (3:4 aspect ratio). If the first link is a landscape or square image, the entire gallery will display in landscape (4:3 aspect ratio).

Doing this for video is more complicated; see #1425 for an explanation. We'll address landscape and portrait videos later; for now, Linda requested that we default to portrait for videos.

## How to test
📣 **Important!** New media display is off by default and can only be toggled on in Settings for now. Follow the instructions below to turn it on.
1. Navigate to Settings
2. Toggle "Enable new media display" to `on`
3. Go back to the feed, or a profile, or a thread and observe or create posts with multiple links.
4. Verify that the gallery appears in the proper orientation
5. Find or create a post with a single portrait image
6. Verify that it's displayed in 3:4 aspect ratio
7. Find or create a post with a single landscape image
8. Verify that it's displayed in 4:3 aspect ratio

## Screenshots/Video

https://github.com/user-attachments/assets/0d2c8eeb-81ca-4fed-8153-c1cc846de7bf
