### PR TITLE
Update CHANGELOG format for easier release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,18 +8,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Release Notes
 - Show quoted notes in note cards.
 - Added a new image viewer that appears when you tap an image.
 - Added a new gallery view that’s currently behind a feature flag.
 - Removed the like and repost counts from the Main and Profile feeds.
 - Removed wss:// from relay addresses in lists and removed the need to prepend relay addresses with wss://.
 - Localized the quotation marks on the Notifications view.
-- Included the npub in the properties list sent to analytics. [skip-release-notes]
-- Replaced hard-coded color values. [skip-release-notes]
-- Added a feature flag toggle for “Enable new media display” to Staging builds. [skip-release-notes]
-- Added a new gallery view to display multiple links in a post. Currently behind the “Enable new media display” feature flag. [skip-release-notes]
-- Show single images and gallery view in the proper orientation. Currently behind the “Enable new media display” feature flag. [skip-release-notes]
-- Fixed typos in release notes. [skip-release-notes]
+
+### Internal Changes
+- Included the npub in the properties list sent to analytics.
+- Replaced hard-coded color values.
+- Added a feature flag toggle for “Enable new media display” to Staging builds. 
+- Added a new gallery view to display multiple links in a post. Currently behind the “Enable new media display” feature flag.
+- Show single images and gallery view in the proper orientation. Currently behind the “Enable new media display” feature flag.
+- Fixed typos in release notes.
 
 ## [0.1.25] - 2024-08-21Z
 


### PR DESCRIPTION
## Issues covered
None

## Description
In order to make it easier to create release notes for TestFlight, @bryanmontz suggested tagging entries in the CHANGELOG. Together, we settled on `[skip-release-notes]` at the end of each line that should not appear in the TestFlight release notes. I'm proposing we remove the need to duplicate this string in each line of the CHANGELOG that should not appear in the TestFlight release notes by using headings instead. I'm still not 100% sure what those headings should be, but this PR has my best thoughts at the moment.

This is a continuation of the discussion in https://github.com/planetary-social/nos/pull/1423#discussion_r1734511906