### PR TITLE
Replace relay.snort.social with nos.lol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Added nos.lol to the default relay list for new accounts and removed relay.snort.social.
 - Show quoted notes in note cards.
 - Added quote-reposting.
 - Added a new image viewer that appears when you tap an image.

--- a/Nos/Models/CoreData/Relay+CoreDataClass.swift
+++ b/Nos/Models/CoreData/Relay+CoreDataClass.swift
@@ -12,9 +12,9 @@ public class Relay: NosManagedObject {
 
     static var recommended: [String] {
         [
+        nosAddress.absoluteString,
         "wss://relay.damus.io",
         "wss://purplepag.es",
-        nosAddress.absoluteString,
         "wss://nos.lol",
         ]
     }

--- a/Nos/Models/CoreData/Relay+CoreDataClass.swift
+++ b/Nos/Models/CoreData/Relay+CoreDataClass.swift
@@ -15,8 +15,7 @@ public class Relay: NosManagedObject {
         "wss://relay.damus.io",
         "wss://purplepag.es",
         nosAddress.absoluteString,
-        "wss://relay.snort.social",
-        "wss://olympics2024.nos.social",
+        "wss://nos.lol",
         ]
     }
     


### PR DESCRIPTION
## Issues covered
#1427

## Description
Replaces relay.snort.social with nos.lol in our default relay list

## How to test
- Create a fresh account and verify that the relay list looks correct
- Remove nos.lol from your relay list and make sure it shows up in the "recommended" section.