### PR TITLE
Hide the out of network warning on quoted notes

### DIFF
--- a/Nos/Views/NoteCard.swift
+++ b/Nos/Views/NoteCard.swift
@@ -110,10 +110,15 @@ struct NoteCard: View {
                                 Button {
                                     router.push(quotedNote)
                                 } label: {
-                                    NoteCard(note: quotedNote, rendersQuotedNotes: false, showsActions: false)
-                                        .withStyledBorder()
-                                        .padding(.horizontal, 16)
-                                        .padding(.bottom, 16)
+                                    NoteCard(
+                                        note: quotedNote, 
+                                        hideOutOfNetwork: false, 
+                                        rendersQuotedNotes: false, 
+                                        showsActions: false
+                                    )
+                                    .withStyledBorder()
+                                    .padding(.horizontal, 16)
+                                    .padding(.bottom, 16)
                                 }
                             }
                         }


### PR DESCRIPTION
## Issues covered
A small tweak to #944 discussed [here](https://planetary-app.slack.com/archives/CE6RE5400/p1724493723592289).

## Description
This hides the "This user is outside your network" overlay on quoted notes. We already have code to hide these on reposts, because the out of network warning is kind of designed to keep the user from seeing objectionable content, bots, or spam from people with whom they have no social relationship. But if a note is reposted or quoted by someone they follow then there is a transitive relationship there.

I hope you don't feel like I went over your head here @bryanmontz, but this was such a quick and simple tweak that I decided to just make it quickly rather than passing the feedback back to you.

## How to test
1. Find a note that quotes another note from someone outside your network.
2. It should not display a "This user is outside your network" overlay.

## Screenshots/Video
| Before | After |
|--------|--------|
| ![IMG_5E828B4CDF3C-1](https://github.com/user-attachments/assets/2d6d2e4e-4a1b-4402-a202-cb3533a74290) | ![Simulator Screenshot - iPhone 15 - 2024-08-29 at 15 56 55](https://github.com/user-attachments/assets/22aa6349-3b45-4ba0-91e7-fee3f6da2bc5) | 