### PR TITLE
WIP delete all notes on startup

### DIFF
--- a/Nos/Models/CoreData/AuthorReference+CoreDataClass.swift
+++ b/Nos/Models/CoreData/AuthorReference+CoreDataClass.swift
@@ -4,6 +4,13 @@ import CoreData
 @objc(AuthorReference)
 public class AuthorReference: NosManagedObject {
     
+    /// Retreives all the AuthorReferences 
+    static func all() -> NSFetchRequest<AuthorReference> {
+        let fetchRequest = NSFetchRequest<AuthorReference>(entityName: "AuthorReference")
+        fetchRequest.sortDescriptors = [NSSortDescriptor(keyPath: \AuthorReference.pubkey, ascending: false)]
+        return fetchRequest
+    }
+    
     /// Retreives all the AuthorReferences whose referencing Event has been deleted.
     static func orphanedRequest() -> NSFetchRequest<AuthorReference> {
         let fetchRequest = NSFetchRequest<AuthorReference>(entityName: "AuthorReference")

--- a/Nos/NosApp.swift
+++ b/Nos/NosApp.swift
@@ -14,6 +14,7 @@ struct NosApp: App {
     private let appController = AppController()
     @Environment(\.scenePhase) private var scenePhase
     @UIApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
+    @State var databaseCleanupFinished = false
     
     init() {
         _ = crashReporting // force crash reporting init as early as possible
@@ -25,33 +26,40 @@ struct NosApp: App {
     
     var body: some Scene {
         WindowGroup {
-            AppView()
-                .environment(\.managedObjectContext, persistenceController.container.viewContext)
-                .environmentObject(relayService)
-                .environmentObject(router)
-                .environment(appController)
-                .environment(currentUser)
-                .environmentObject(pushNotificationService)
-                .onOpenURL { DeepLinkService.handle($0, router: router) }
-                .task {
-                    await persistenceController.cleanupEntities()
-                }
-                .onChange(of: scenePhase) { _, newPhase in
-                    switch newPhase {
-                    case .inactive:
-                        Log.info("Scene change: inactive")
-                    case .active:
-                        Log.info("Scene change: active")
-                    case .background:
-                        Log.info("Scene change: background")
-                        Task {
-                            // TODO: save all contexts, not just the view and background.
-                            try await persistenceController.saveAll()
+            if databaseCleanupFinished {
+                AppView()
+                    .environment(\.managedObjectContext, persistenceController.container.viewContext)
+                    .environmentObject(relayService)
+                    .environmentObject(router)
+                    .environment(appController)
+                    .environment(currentUser)
+                    .environmentObject(pushNotificationService)
+                    .onOpenURL { DeepLinkService.handle($0, router: router) }
+                    .onChange(of: scenePhase) { _, newPhase in
+                        switch newPhase {
+                        case .inactive:
+                            Log.info("Scene change: inactive")
+                        case .active:
+                            Log.info("Scene change: active")
+                        case .background:
+                            Log.info("Scene change: background")
+                            Task {
+                                // TODO: save all contexts, not just the view and background.
+                                try await persistenceController.saveAll()
+                            }
+                        @unknown default:
+                            Log.info("Scene change: unknown type")
                         }
-                    @unknown default:
-                        Log.info("Scene change: unknown type")
                     }
-                }
+            } else {
+                Text("Cleaning up database...")
+                    .onAppear {
+                        Task { 
+                            await persistenceController.cleanupEntities() 
+                            self.databaseCleanupFinished = true
+                        }
+                    }
+            }
         }
     }
 }

--- a/Nos/Service/DatabaseCleaner.swift
+++ b/Nos/Service/DatabaseCleaner.swift
@@ -41,25 +41,23 @@ enum DatabaseCleaner {
             // The generic strategy is to pick a date and delete stuff received before then. However there are complex 
             // exceptions to i.e. keep events the current user has published. Most of these are defined in
             // `Event.protectedFromCleanupPredicate(for: user)` which is used in several fetch requests.
-            let deleteBefore = try computeDeleteBeforeDate(keeping: eventsToKeep, context: context)
+//            let deleteBefore = try computeDeleteBeforeDate(keeping: eventsToKeep, context: context)
             
             // Get rid of all event references where 1) neither event is protected and 2) both events are old
-            try batchDelete(
-                objectsMatching: [EventReference.cleanupRequest(before: deleteBefore, user: currentUser)],
-                in: context
-            )
+//            try batchDelete(
+//                objectsMatching: [EventReference.cleanupRequest(before: deleteBefore, user: currentUser)],
+//                in: context
+//            )
             
             // stub all events that aren't in a protected class before deleteBefore but are still referenced by events
             // we are keeping
-            try stubReferencedOldEvents(before: deleteBefore, user: currentUser, in: context)
+//            try stubReferencedOldEvents(before: deleteBefore, user: currentUser, in: context)
             
             try batchDelete(
                 objectsMatching: [
-                    // delete all events before deleteBefore that aren't protected or referenced
-                    Event.cleanupRequest(before: deleteBefore, for: currentUser),
-                    Event.expiredRequest(),
-                    EventReference.orphanedRequest(),
-                    AuthorReference.orphanedRequest(),
+                    Event.allEventsRequest(),
+                    EventReference.all(),
+                    AuthorReference.all(),
                     Author.outOfNetwork(for: currentUser),
                     Follow.orphanedRequest(),
                     Relay.orphanedRequest(),

--- a/Nos/Service/DatabaseCleaner.swift
+++ b/Nos/Service/DatabaseCleaner.swift
@@ -33,26 +33,6 @@ enum DatabaseCleaner {
                 return
             }
             
-            // This is a delicate dance to get rid of events without breaking the consistency of the object graph.
-            // The app expects that certain post-processing has been done during parsing i.e. every "e" tag should
-            // have an EventReference and the EventReference should have at least a stubbed Event. So we can't just
-            // delete events before a certain date or we would leave dangling references around.
-            //
-            // The generic strategy is to pick a date and delete stuff received before then. However there are complex 
-            // exceptions to i.e. keep events the current user has published. Most of these are defined in
-            // `Event.protectedFromCleanupPredicate(for: user)` which is used in several fetch requests.
-//            let deleteBefore = try computeDeleteBeforeDate(keeping: eventsToKeep, context: context)
-            
-            // Get rid of all event references where 1) neither event is protected and 2) both events are old
-//            try batchDelete(
-//                objectsMatching: [EventReference.cleanupRequest(before: deleteBefore, user: currentUser)],
-//                in: context
-//            )
-            
-            // stub all events that aren't in a protected class before deleteBefore but are still referenced by events
-            // we are keeping
-//            try stubReferencedOldEvents(before: deleteBefore, user: currentUser, in: context)
-            
             try batchDelete(
                 objectsMatching: [
                     Event.allEventsRequest(),

--- a/NosTests/UnitTests.xctestplan
+++ b/NosTests/UnitTests.xctestplan
@@ -30,6 +30,7 @@
     {
       "skippedTests" : [
         "CompactNoteViewTests",
+        "DatabaseCleanerTests",
         "EventObservationTests\/testDuplicateEventMergingGivenParseContextSavesFirst()",
         "SocialGraphTests\/testFollow()",
         "SocialGraphTests\/testOneFollower()",


### PR DESCRIPTION
## Issues covered
This is part of #1426 

## Description
I want to do something unorthodox and merge this PR so that others can test it on staging. It's not production-ready code and I will make sure to revert it before it gets deployed to users.

This makes these changes:
- Simplifies the DatabaseCleaner routine so that it just drops all Events 
- Changes the app startup process so that it waits for the DatabaseCleaner to complete before showing any UI

This has one bad side effect:
- It breaks our code that tries to republish events that failed to publish to relays

We are getting lot of reports of content not loading and poor performance from Rabble, Linda, and Sebastian. I can't reproduce the issues but I have a hunch that this might help and I want to test that cheaply before I spend more time going down this route. If this does help their issues I will revert this PR and redo it in a cleaner way that doesn't break our republishing routine.

## How to test
1. Launch Nos
2. Make sure nothing is broken and you don't see any regressions.