### PR TITLE
Added more instructions to the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,7 @@ All notable changes to this project will be documented in this file.
 
 We define "Noteworthy changes" as 1) user-facing features or bugfixes 2) significant technical or architectural changes that contributors will notice. If your Pull Request does not contain any changes of this nature i.e. minor string/translation changes, patch releases of dependencies, refactoring, etc. then add the `Skip-Changelog` label. 
 
-P/S: The Release Notes section is for changes that the are relevant to users, and they should know about.
-   The Internal Changes section is for other changes that are not visible to users since the changes may not be relevant to them, e.g technical improvements, but the developers should still be aware of.
+P/S: The Release Notes section is for changes that the are relevant to users, and they should know about. The Internal Changes section is for other changes that are not visible to users since the changes may not be relevant to them, e.g technical improvements, but the developers should still be aware of.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).


### PR DESCRIPTION
This PR includes extra instruction to the `changelog` file, to help external contributors who do not have access to notion (This has explained this already in the iOS Dev Onboarding document on notion), have a good understanding about what should be included in each section.
