### PR TITLE
truncated text is expanding out due to not fixing the size of the view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed a bug where nostr entities in URLs were treated like quoted note links.
 - Added in-app profile photo editing.
 - Changed "Name" to "Display Name" on the Edit Profile View.
+- Fixed a bug where content of a quoted note expanded out beyond width of viewport. 
 
 ### Internal Changes
 - Included the npub in the properties list sent to analytics.

--- a/Nos/Views/Note/CompactNoteView.swift
+++ b/Nos/Views/Note/CompactNoteView.swift
@@ -99,6 +99,7 @@ struct CompactNoteView: View {
                     .fixedSize(horizontal: false, vertical: true)
             } else {
                 formattedText
+                    .fixedSize(horizontal: false, vertical: true)
                     .lineLimit(truncationLineLimit)
                     .background {
                         GeometryReader { geometryProxy in


### PR DESCRIPTION
## Issues covered
#1463: Some quoted notes are rendered offscreen

## Description
Hi Nos team! 
I noticed this issue and spent an hour or so diagnosing it. Unfortunately the CompactNoteView only has a single unit test. But I realized none of the preview data includes a quoted reference with the referenced note having long text and a wide image. 
I tried to replicate it but I think my contextual knowledge of note references is lacking.  
Either way, I hope this PR saves you some time. 

## How to test
1. Tap search button on tab bar 
2. In search field, paste `8f95884af2646903601b2bf1d535f849a1fd1adcf4b57bc1c49b9a42efc2f94f` 
3. Scroll down slowly until the August 23rd note is displayed 
4. The quote preview is now constrained with the width of the parent note

## Screenshots/Video
<img width="390" alt="Screenshot 2024-09-06 at 11 23 22 PM" src="https://github.com/user-attachments/assets/2310b4eb-485a-45ac-ad79-6922a84fc324">
