### PR TITLE
fixes and improvements related to Core Data usage #1443

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed a bug where nostr entities in URLs were treated like quoted note links.
 - Added in-app profile photo editing.
 - Changed "Name" to "Display Name" on the Edit Profile View.
+- Fixes and improvements related to Core Data usage.
 
 ### Internal Changes
 - Included the npub in the properties list sent to analytics.

--- a/Nos/Controller/SearchController.swift
+++ b/Nos/Controller/SearchController.swift
@@ -49,9 +49,7 @@ class SearchController: ObservableObject {
     /// The timer for showing the "not finding results" view. Resets any time the query is changed.
     private var timer: Timer?
 
-    private lazy var context: NSManagedObjectContext = {
-        persistenceController.viewContext
-    }()
+    private lazy var context = persistenceController.viewContext
 
     /// The amount of time, in seconds, to remain in the `.loading` state until switching to `.stillLoading`.
     private let stillLoadingTime: TimeInterval = 10
@@ -141,7 +139,7 @@ class SearchController: ObservableObject {
         authorResults = []
     }
     
-    func note(fromPublicKey publicKeyString: String) -> Event? {
+    private func note(fromPublicKey publicKeyString: String) -> Event? {
         let strippedString = publicKeyString.trimmingCharacters(
             in: NSCharacterSet.whitespacesAndNewlines
         )

--- a/Nos/Models/CoreData/Event+CoreDataClass.swift
+++ b/Nos/Models/CoreData/Event+CoreDataClass.swift
@@ -10,9 +10,6 @@ public class Event: NosManagedObject, VerifiableEvent {
     @Dependency(\.currentUser) @ObservationIgnored private var currentUser
 
     var pubKey: String { author?.hexadecimalPublicKey ?? "" }
-    
-    static var replyNoteReferences = "kind = 1 AND ANY eventReferences.referencedEvent.identifier == %@ " +
-        "AND author.muted = false"
 
     @nonobjc public class func allEventsRequest() -> NSFetchRequest<Event> {
         let fetchRequest = NSFetchRequest<Event>(entityName: "Event")
@@ -113,7 +110,6 @@ public class Event: NosManagedObject, VerifiableEvent {
     
     @nonobjc public class func lastReceived(for user: Author) -> NSFetchRequest<Event> {
         let fetchRequest = NSFetchRequest<Event>(entityName: "Event")
-        fetchRequest.sortDescriptors = [NSSortDescriptor(keyPath: \Event.createdAt, ascending: false)]
         fetchRequest.predicate = NSPredicate(format: "author != %@", user)
         fetchRequest.fetchLimit = 1
         fetchRequest.sortDescriptors = [NSSortDescriptor(keyPath: \Event.receivedAt, ascending: false)]
@@ -128,6 +124,11 @@ public class Event: NosManagedObject, VerifiableEvent {
         guard let noteID else {
             return emptyRequest()
         }
+        
+        let replyNoteReferences = "kind = 1 " +
+            "AND ANY eventReferences.referencedEvent.identifier == %@ " +
+            "AND author.muted = false"
+        
         let fetchRequest = NSFetchRequest<Event>(entityName: "Event")
         fetchRequest.sortDescriptors = [NSSortDescriptor(keyPath: \Event.receivedAt, ascending: false)]
         fetchRequest.predicate = NSPredicate(
@@ -480,8 +481,8 @@ public class Event: NosManagedObject, VerifiableEvent {
     
     // MARK: - Creating
 
-    func createIfNecessary(
-        jsonEvent: JSONEvent, 
+    static func createIfNecessary(
+        jsonEvent: JSONEvent,
         relay: Relay?, 
         context: NSManagedObjectContext
     ) throws -> Event? {
@@ -562,7 +563,7 @@ public class Event: NosManagedObject, VerifiableEvent {
     }
 
     /// Populates an event stub (with only its ID set) using the data in the given JSON.
-    func hydrate(from jsonEvent: JSONEvent, relay: Relay?, in context: NSManagedObjectContext) throws {
+    private func hydrate(from jsonEvent: JSONEvent, relay: Relay?, in context: NSManagedObjectContext) throws {
         assert(isStub, "Tried to hydrate an event that isn't a stub. This is a programming error")
         
         // if this stub was created with a replaceableIdentifier and author, it won't have an identifier yet
@@ -629,7 +630,11 @@ public class Event: NosManagedObject, VerifiableEvent {
         }
     }
     
-    func hydrateContactList(from jsonEvent: JSONEvent, author newAuthor: Author, context: NSManagedObjectContext) {
+    private func hydrateContactList(
+        from jsonEvent: JSONEvent,
+        author newAuthor: Author,
+        context: NSManagedObjectContext
+    ) {
         guard createdAt! > newAuthor.lastUpdatedContactList ?? Date.distantPast else {
             return
         }
@@ -682,7 +687,7 @@ public class Event: NosManagedObject, VerifiableEvent {
         }
     }
     
-    func hydrateDefault(from jsonEvent: JSONEvent, context: NSManagedObjectContext) {
+    private func hydrateDefault(from jsonEvent: JSONEvent, context: NSManagedObjectContext) {
         let newEventReferences = NSMutableOrderedSet()
         let newAuthorReferences = NSMutableOrderedSet()
         for jsonTag in jsonEvent.tags {
@@ -706,7 +711,7 @@ public class Event: NosManagedObject, VerifiableEvent {
         authorReferences = newAuthorReferences
     }
     
-    func hydrateMetaData(from jsonEvent: JSONEvent, author newAuthor: Author, context: NSManagedObjectContext) {
+    private func hydrateMetaData(from jsonEvent: JSONEvent, author newAuthor: Author, context: NSManagedObjectContext) {
         guard createdAt! > newAuthor.lastUpdatedMetadata ?? Date.distantPast else {
             // This is old data
             return
@@ -738,7 +743,7 @@ public class Event: NosManagedObject, VerifiableEvent {
         seenOnRelays.insert(relay) 
     }
     
-    func hydrateMuteList(from jsonEvent: JSONEvent, context: NSManagedObjectContext) {
+    private func hydrateMuteList(from jsonEvent: JSONEvent, context: NSManagedObjectContext) {
         let mutedKeys = jsonEvent.tags.map { $0[1] }
         
         let request = Author.allAuthorsRequest(muted: true)
@@ -766,19 +771,15 @@ public class Event: NosManagedObject, VerifiableEvent {
     }
 
     /// Tries to parse a new event out of the given jsonEvent's `content` field.
-    @discardableResult
-    func parseContent(from jsonEvent: JSONEvent, context: NSManagedObjectContext) -> Event? {
+    private func parseContent(from jsonEvent: JSONEvent, context: NSManagedObjectContext) {
         do {
             if let contentData = jsonEvent.content.data(using: .utf8) {
                 let jsonEvent = try JSONDecoder().decode(JSONEvent.self, from: contentData)
-                return try Event().createIfNecessary(jsonEvent: jsonEvent, relay: nil, context: context)
+                _ = try Event.createIfNecessary(jsonEvent: jsonEvent, relay: nil, context: context)
             }
         } catch {
             Log.error("Could not parse content for jsonEvent: \(jsonEvent)")
-            return nil
         }
-        
-        return nil
     }
     
     // MARK: - Preloading and Caching
@@ -887,9 +888,8 @@ public class Event: NosManagedObject, VerifiableEvent {
         @Dependency(\.persistenceController) var persistenceController
         let context = persistenceController.backgroundViewContext
         
-        _ = try? Event.findOrCreateStubBy(id: quotedNoteID, context: context)
-        
         await context.perform {
+            _ = try? Event.findOrCreateStubBy(id: quotedNoteID, context: context)
             try? context.save()
         }
         

--- a/Nos/NosApp.swift
+++ b/Nos/NosApp.swift
@@ -26,7 +26,7 @@ struct NosApp: App {
     var body: some Scene {
         WindowGroup {
             AppView()
-                .environment(\.managedObjectContext, persistenceController.container.viewContext)
+                .environment(\.managedObjectContext, persistenceController.viewContext)
                 .environmentObject(relayService)
                 .environmentObject(router)
                 .environment(appController)

--- a/Nos/Service/EventProcessor.swift
+++ b/Nos/Service/EventProcessor.swift
@@ -11,7 +11,7 @@ enum EventProcessor {
         in parseContext: NSManagedObjectContext,
         skipVerification: Bool = false
     ) throws -> Event? {
-        if let event = try Event().createIfNecessary(jsonEvent: jsonEvent, relay: relay, context: parseContext) {
+        if let event = try Event.createIfNecessary(jsonEvent: jsonEvent, relay: relay, context: parseContext) {
             relay.unwrap {
                 do {
                     try event.trackDelete(on: $0, context: parseContext)
@@ -79,7 +79,7 @@ enum EventProcessor {
         from relay: Relay?,
         in persistenceController: PersistenceController
     ) throws -> [Event] {
-        let parseContext = persistenceController.container.viewContext
+        let parseContext = persistenceController.viewContext
         return try parse(jsonData: jsonData, from: relay, in: parseContext)
     }
 }

--- a/Nos/Service/Relay/RelayService.swift
+++ b/Nos/Service/Relay/RelayService.swift
@@ -384,11 +384,8 @@ extension RelayService {
                 for (event, socket) in eventData {
                     let relay = self.relay(from: socket, in: self.persistenceController.parseContext)
                     do {
-                        if try EventProcessor.parse(
-                            jsonEvent: event,
-                            from: relay,
-                            in: self.persistenceController.parseContext
-                        ) != nil {
+                        let context = self.persistenceController.parseContext
+                        if try EventProcessor.parse(jsonEvent: event, from: relay, in: context) != nil {
                             savedEvents += 1
                         }
                     } catch {

--- a/Nos/Service/Relay/RelayService.swift
+++ b/Nos/Service/Relay/RelayService.swift
@@ -16,7 +16,6 @@ class RelayService: ObservableObject {
     private var backgroundProcessTimer: AsyncTimer?
     private var eventProcessingLoop: Task<Void, Error>?
     private var backgroundContext: NSManagedObjectContext
-    private var parseContext: NSManagedObjectContext
     private var processingQueue = DispatchQueue(label: "RelayService-processing", qos: .userInitiated)
     private var parseQueue = ParseQueue()
     
@@ -30,7 +29,6 @@ class RelayService: ObservableObject {
         self.subscriptionManager = subscriptionManager
         @Dependency(\.persistenceController) var persistenceController
         self.backgroundContext = persistenceController.newBackgroundContext()
-        self.parseContext = persistenceController.parseContext
         
         Task { await self.subscriptionManager.set(socketQueue: processingQueue, delegate: self) }
         
@@ -63,7 +61,7 @@ class RelayService: ObservableObject {
         })
         
         Task { @MainActor in
-            currentUser.viewContext = persistenceController.container.viewContext
+            currentUser.viewContext = persistenceController.viewContext
         }
         
         NotificationCenter.default.addObserver(
@@ -381,12 +379,16 @@ extension RelayService {
             return false
         } else {
             let remainingEventCount = await parseQueue.count
-            try await self.parseContext.perform {
+            try await persistenceController.parseContext.perform {
                 var savedEvents = 0
                 for (event, socket) in eventData {
-                    let relay = self.relay(from: socket, in: self.parseContext)
+                    let relay = self.relay(from: socket, in: self.persistenceController.parseContext)
                     do {
-                        if try EventProcessor.parse(jsonEvent: event, from: relay, in: self.parseContext) != nil {
+                        if try EventProcessor.parse(
+                            jsonEvent: event,
+                            from: relay,
+                            in: self.persistenceController.parseContext
+                        ) != nil {
                             savedEvents += 1
                         }
                     } catch {
@@ -402,7 +404,7 @@ extension RelayService {
                 if remainingEventCount >= 1000 && remainingEventCount < 1030 {
                     self.crashReporting.report("Parse queue is large: currently 1000+ events")
                 }
-                try self.parseContext.saveIfNeeded()
+                try self.persistenceController.parseContext.saveIfNeeded()
                 try self.persistenceController.viewContext.saveIfNeeded()
             }
             return true
@@ -410,7 +412,7 @@ extension RelayService {
     }
 }
 
-// MARK: Relay Communciation
+// MARK: Relay Communication
 extension RelayService {
     
     private func parseOK(_ responseArray: [Any], _ socket: WebSocket) async {
@@ -716,12 +718,12 @@ extension RelayService {
     /// These events could have failed to publish becuase the relay was offline, or because the user was offline. Often 
     /// the user has relay in their list that they don't have write access to so eventually this function will stop
     /// trying to republish the same event.
-    @MainActor func retryFailedPublishes() async {
+    @MainActor private func retryFailedPublishes() async {
         guard let userKey = currentUser.author?.hexadecimalPublicKey else {
             return
         }
         
-        await self.backgroundContext.perform {
+        await backgroundContext.perform {
             
             guard let user = try? Author.find(by: userKey, context: self.backgroundContext) else {
                 return
@@ -731,10 +733,12 @@ extension RelayService {
             
             // Try to publish each of these again to each relay that failed.
             for event in eventsToRetry {
-                let missedRelays = event.shouldBePublishedTo.subtracting(event.publishedTo)
+                guard let jsonEvent = event.codable else { continue }
                 
-                for missedRelay in missedRelays {
-                    guard let missedAddress = missedRelay.address, let jsonEvent = event.codable else { continue }
+                let missedRelays = event.shouldBePublishedTo.subtracting(event.publishedTo)
+                let missedAddresses = missedRelays.compactMap { $0.address }
+                
+                for missedAddress in missedAddresses {
                     Task {
                         if let socket = await self.subscriptionManager.socket(for: missedAddress) {
                             // Publish again to this socket

--- a/Nos/Views/AppView.swift
+++ b/Nos/Views/AppView.swift
@@ -194,7 +194,7 @@ struct AppView_Previews: PreviewProvider {
     
     static var previewData = PreviewData()
     static var persistenceController = PersistenceController.preview
-    static var previewContext = persistenceController.container.viewContext
+    static var previewContext = persistenceController.viewContext
     static var relayService = previewData.relayService
     static var router = Router()
     static var currentUser = previewData.currentUser 

--- a/Nos/Views/Components/Button/NoteOptionsButton.swift
+++ b/Nos/Views/Components/Button/NoteOptionsButton.swift
@@ -116,7 +116,7 @@ struct NoteOptionsButton: View {
 struct NoteOptionsButton_Previews: PreviewProvider {
     static var previewData = PreviewData()
     static var persistenceController = PersistenceController.preview
-    static var previewContext = persistenceController.container.viewContext
+    static var previewContext = persistenceController.viewContext
     static var currentUser = previewData.currentUser
     
     static var shortNote: Event {

--- a/Nos/Views/Components/GoldenPostView.swift
+++ b/Nos/Views/Components/GoldenPostView.swift
@@ -123,7 +123,7 @@ struct GoldenPostView: View {
 struct GoldenPostView_Previews: PreviewProvider {
     
     static var persistenceController = PersistenceController.preview
-    static var previewContext = persistenceController.container.viewContext
+    static var previewContext = persistenceController.viewContext
     
     static var shortNote: Event {
         let note = Event(context: previewContext)

--- a/Nos/Views/Components/ThreadView.swift
+++ b/Nos/Views/Components/ThreadView.swift
@@ -68,11 +68,11 @@ struct ThreadView: View {
 struct ThreadView_Previews: PreviewProvider {
     static var previewData = PreviewData()
     static var persistenceController = PersistenceController.preview
-    static var previewContext = persistenceController.container.viewContext
+    static var previewContext = persistenceController.viewContext
     static var router = Router()
     
     static var emptyPersistenceController = PersistenceController.empty
-    static var emptyPreviewContext = emptyPersistenceController.container.viewContext
+    static var emptyPreviewContext = emptyPersistenceController.viewContext
     static var emptyRelayService = previewData.relayService
     static var currentUser = previewData.currentUser
     

--- a/Nos/Views/Discover/DiscoverTab.swift
+++ b/Nos/Views/Discover/DiscoverTab.swift
@@ -74,7 +74,7 @@ struct DiscoverTab_Previews: PreviewProvider {
     
     static var previewData = PreviewData()
     static var persistenceController = PersistenceController.preview
-    static var previewContext = persistenceController.container.viewContext
+    static var previewContext = persistenceController.viewContext
 
     static var currentUser = previewData.currentUser
     static var router = Router()

--- a/Nos/Views/Fixtures/PreviewData.swift
+++ b/Nos/Views/Fixtures/PreviewData.swift
@@ -28,7 +28,7 @@ struct PreviewData {
     @Dependency(\.currentUser) var currentUser
     
     lazy var previewContext: NSManagedObjectContext = {
-        persistenceController.container.viewContext  
+        persistenceController.viewContext  
     }()
     
     // MARK: - Authors

--- a/Nos/Views/Note/NoteView.swift
+++ b/Nos/Views/Note/NoteView.swift
@@ -171,7 +171,7 @@ struct RepliesView_Previews: PreviewProvider {
     
     static var previewData = PreviewData(currentUserKey: KeyFixture.alice)
     static var persistenceController = PersistenceController.preview
-    static var previewContext = persistenceController.container.viewContext
+    static var previewContext = persistenceController.viewContext
     static var emptyRelayService = previewData.relayService
     static var router = Router()
     static var currentUser = previewData.currentUser

--- a/Nos/Views/Profile/ProfileView.swift
+++ b/Nos/Views/Profile/ProfileView.swift
@@ -246,7 +246,7 @@ struct ProfileView: View {
     @Dependency(\.persistenceController) var persistenceController 
     
     lazy var previewContext: NSManagedObjectContext = {
-        persistenceController.container.viewContext  
+        persistenceController.viewContext  
     }()
     
     var previewData = PreviewData(currentUserKey: KeyFixture.eve)

--- a/Nos/Views/Relay/RelayDetailView.swift
+++ b/Nos/Views/Relay/RelayDetailView.swift
@@ -79,7 +79,7 @@ struct RelayDetailView: View {
 }
 
 struct RelayDetailView_Previews: PreviewProvider {
-    static var previewContext = PersistenceController.preview.container.viewContext
+    static var previewContext = PersistenceController.preview.viewContext
     static var relay: Relay {
         do {
             return try Relay.findOrCreate(by: "wss://example.com", context: previewContext) 

--- a/Nos/Views/Relay/RelayView.swift
+++ b/Nos/Views/Relay/RelayView.swift
@@ -228,9 +228,9 @@ struct RelayView: View {
 struct RelayView_Previews: PreviewProvider {
     
     static var previewData = PreviewData()
-    static var previewContext = PersistenceController.preview.container.viewContext
+    static var previewContext = PersistenceController.preview.viewContext
     
-    static var emptyContext = PersistenceController.empty.container.viewContext
+    static var emptyContext = PersistenceController.empty.viewContext
 
     static var user: Author {
         let author = Author(context: previewContext)

--- a/NosTests/TestHelpers/SQLiteStoreTestCase.swift
+++ b/NosTests/TestHelpers/SQLiteStoreTestCase.swift
@@ -22,3 +22,23 @@ class SQLiteStoreTestCase: XCTestCase {
 }
 
 // swiftlint:enable implicitly_unwrapped_optional
+
+extension PersistenceController {
+    func tearDown() throws {
+        for store in container.persistentStoreCoordinator.persistentStores {
+            try container.persistentStoreCoordinator.remove(store)
+        }
+        
+        try container.persistentStoreDescriptions.forEach { storeDescription in
+            try container.persistentStoreCoordinator.destroyPersistentStore(
+                at: storeDescription.url!,
+                ofType: NSSQLiteStoreType,
+                options: nil
+            )
+        }
+        
+        viewContext.reset()
+        backgroundViewContext.reset()
+        parseContext.reset()
+    }
+}

--- a/NosTests/Views/EventObservationTests.swift
+++ b/NosTests/Views/EventObservationTests.swift
@@ -56,7 +56,7 @@ final class EventObservationTests: CoreDataTestCase {
         fullEvent.content = eventContent
         
         let view = EventObservationTestView()
-        ViewHosting.host(view: view.environment(\.managedObjectContext, persistenceController.container.viewContext))
+        ViewHosting.host(view: view.environment(\.managedObjectContext, persistenceController.viewContext))
         // sanity check
         let expectNullContent = view.inspection.inspect { view in
             let eventContentInView = try view.find(ViewType.Text.self).string()


### PR DESCRIPTION
## Issues covered
#1443 

## Description
These changes are the result of the Core Data usage research prescribed by #1443. They are the changes I was confident making without further discussion. Other suggestions will be mentioned in the ticket.

1. This code: `Event().createIfNecessary(jsonEvent...` is creating Events and throwing them away immediately and causing the console error message "Failed to call designated initializer on NSManagedObject". The resolution is to make the `createIfNecessary...` function static.

2. Adding the launch argument `-com.apple.CoreData.ConcurrencyDebug 1` reveals that `Event.loadFirstQuotedNote()` is creating an event on the wrong thread. The resolution is to move the `Event.findOrCreateStubBy...` call to inside the `context.perform` call below. Reference https://useyourloaf.com/blog/debugging-core-data/.

3. In `RelayService.retryFailedPublishes()`, a JSONEvent was being created inside a nested loop. This caused needless extra work because it could be created only in the outer loop.

## How to test
These changes aren't user testable, but they are dev testable.
Running `main` (prior to the changes in this PR), you will see a message in the console like this:
"Failed to call designated initializer on NSManagedObject"

If you add the launch argument `-com.apple.CoreData.ConcurrencyDebug 1` to the scheme and run the code, you will get a crash (an assert really) if you scroll around in a feed view that contains quoted notes.

After the changes in this PR, both of those issues are resolved.