### PR TITLE
fixed issue where relay metadata is never updated #1472

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed a bug where nostr entities in URLs were treated like quoted note links.
 - Added in-app profile photo editing.
 - Changed "Name" to "Display Name" on the Edit Profile View.
+- Fixed issue where relay metadata is never updated.
 
 ### Internal Changes
 - Included the npub in the properties list sent to analytics.

--- a/Nos/Service/Relay/RelayService.swift
+++ b/Nos/Service/Relay/RelayService.swift
@@ -801,6 +801,7 @@ extension RelayService {
     }
     
     private func queryRelayMetadataIfNeeded(_ relayAddress: URL) async throws {
+        let metadataMaxAge: TimeInterval = 86_400 * 3 // 3 days
         let address = relayAddress.absoluteString
         let shouldQueryRelayMetadata = try await backgroundContext.perform { [backgroundContext] in
             guard let relay = try backgroundContext.fetch(Relay.relay(by: address)).first else {
@@ -809,7 +810,7 @@ extension RelayService {
             guard let timestamp = relay.metadataFetchedAt else {
                 return true
             }
-            return timestamp.timeIntervalSinceNow > 86_400 * 3 // 3 days
+            return Date.now.timeIntervalSince(timestamp) > metadataMaxAge
         }
         guard shouldQueryRelayMetadata else {
             return


### PR DESCRIPTION
## Issues covered
#1472

## Description
Faulty date logic prevented relay metadata from ever being updated after the initial time. The check in `RelayService.queryRelayMetadataIfNeeded(_:)` was backwards and resulted in a negative number for the time interval, failing the check every time.

## How to test
The issue and the fix are not readily observable from the UI. However, a developer can add log statements to confirm the issue and the fix for it.

Before (from the ticket):  
The breakpoint is never hit, even though some of the relays' metadata is two weeks old.  
<img width="827" alt="Nos_—_RelayService_swift" src="https://github.com/user-attachments/assets/b3830ee6-9f36-408d-9409-fa00e08dca6a">

After:  
The breakpoint is hit (and metadata will be updated) when the code encounters the first relay whose metadata is over 3 days old:  
<img width="969" alt="Nos_—_RelayService_swift" src="https://github.com/user-attachments/assets/63c80da6-d235-4402-a930-d7c2af4cb431">

