### PR TITLE
Update/dots note menu copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed a bug where nostr entities in URLs were treated like quoted note links.
 - Added in-app profile photo editing.
 - Changed "Name" to "Display Name" on the Edit Profile View.
+- Updated the copy on the 3 dots note menu 
 
 ### Internal Changes
 - Included the npub in the properties list sent to analytics.

--- a/Nos/Assets/Localization/Localizable.xcstrings
+++ b/Nos/Assets/Localization/Localizable.xcstrings
@@ -2500,67 +2500,67 @@
       "localizations" : {
         "de" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Note-Identifikator kopieren"
           }
         },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Copy Note Identifier"
+            "value" : "Copy Nostr note ID"
           }
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Copiar identificador de nota"
           }
         },
         "fa" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "کپی کردن شناسه یادداشت"
           }
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Copier l'identifiant de la note"
           }
         },
         "ja" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "ノート識別子をコピーする"
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Kopieer Notitie-ID"
           }
         },
         "pt-BR" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Copiar identificador da nota"
           }
         },
         "sv" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Kopiera antecknings-Id"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "复制笔记标识符"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "複製筆記標識符"
           }
         }
@@ -2571,67 +2571,67 @@
       "localizations" : {
         "de" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Note-Text kopieren"
           }
         },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Copy Note Text"
+            "value" : "Copy note text"
           }
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Copiar texto de nota"
           }
         },
         "fa" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "کپی کردن متن یادداشت"
           }
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Copier le texte de la note"
           }
         },
         "ja" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "ノートのテキストをコピーする"
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Kopieer Tekst"
           }
         },
         "pt-BR" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Copiar texto da nota"
           }
         },
         "sv" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Kopiera anteckningstext"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "复制笔记文本"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "複製筆記文本"
           }
         }
@@ -10136,7 +10136,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Flag This Content"
+            "value" : "Flag this note"
           }
         },
         "fa" : {
@@ -11231,6 +11231,17 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "分享 Nos"
+          }
+        }
+      }
+    },
+    "shareNote" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Share note"
           }
         }
       }
@@ -13268,67 +13279,67 @@
       "localizations" : {
         "de" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Quelle anzeigen"
           }
         },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "View Source"
+            "value" : "View source"
           }
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Ver código fuente"
           }
         },
         "fa" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "مشاهده منبع"
           }
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Afficher la source"
           }
         },
         "ja" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "ソースを見る"
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Bekijk broncode"
           }
         },
         "pt-BR" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Ver fonte"
           }
         },
         "sv" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Visa källa"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "查看源代码"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "查看源代碼"
           }
         }

--- a/Nos/Service/Analytics.swift
+++ b/Nos/Service/Analytics.swift
@@ -265,8 +265,8 @@ class Analytics {
         track("Copied Note Identifier")
     }
     
-    func copiedNoteLink() {
-        track("Copied Note Link")
+    func sharedNoteLink() {
+        track("Shared Note Link")
     }
     
     func copiedNoteText() {

--- a/Nos/Views/Components/Button/NoteOptionsButton.swift
+++ b/Nos/Views/Components/Button/NoteOptionsButton.swift
@@ -33,9 +33,8 @@ struct NoteOptionsButton: View {
                     analytics.copiedNoteIdentifier()
                     copyMessageIdentifier()
                 }
-                Button(String(localized: .localizable.copyLink)) {
-                    analytics.copiedNoteLink()
-                    copyLink()
+                Button(String(localized: .localizable.shareNote)) {
+                    analytics.sharedNoteLink()
                 }
                 if !note.isStub {
                     Button(String(localized: .localizable.copyNoteText)) {
@@ -89,10 +88,6 @@ struct NoteOptionsButton: View {
     
     func copyMessageIdentifier() {
         UIPasteboard.general.string = note.bech32NoteID
-    }
-    
-    func copyLink() {
-        UIPasteboard.general.string = note.webLink
     }
     
     func copyMessage() {


### PR DESCRIPTION
## Issues covered
#1028 

## Description
This PR updates the copy of the confirmation dialogue that shows up when the 3 dots menu icon on the notes is clicked. The following changes were made:

- The following localizable keys were updated: `copyNoteIdentifier`, `copyNoteText`, `reportNote`.
- A new localizable key `shareNote` was added.
- Analytics to track `copiedNoteLink` was replaced with `sharedNoteLink`.
- copyLink button was changed to share button in the `NoteOptions` file.

## How to test
1. Build the app.
2. Go to the Feed tab.
3. Choose any note and select the 3 dots menu at the top right of the note, just beside the time.
4. Please make sure the copy is as expected.

## Screenshots/Video
| Before | After |
|--------|-------|
| <img src="https://github.com/user-attachments/assets/a774af13-d87a-4ebd-bfb0-4fecfac2cbd5" alt="Before" width="250"/> | <img src="https://github.com/user-attachments/assets/9cc844ed-bc26-4bc8-abe2-fe36399b446b" alt="After" width="250"/> |
