### PR TITLE
Add share note functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed a bug where nostr entities in URLs were treated like quoted note links.
 - Added in-app profile photo editing.
 - Changed "Name" to "Display Name" on the Edit Profile View.
-- Updated the copy on the 3 dots note menu 
+- Updated the copy on the 3 dots note menu.
+- Added functionality to share notes link through the 3 dots note menu. 
 
 ### Internal Changes
 - Included the npub in the properties list sent to analytics.

--- a/Nos/Views/Components/ActivityView.swift
+++ b/Nos/Views/Components/ActivityView.swift
@@ -5,11 +5,19 @@ struct ActivityViewController: UIViewControllerRepresentable {
 
     var activityItems: [Any]
     var applicationActivities: [UIActivity]?
+    var completion: (() -> Void)? // Completion handler for dismissing the sheet
 
     func makeUIViewController(
         context: UIViewControllerRepresentableContext<ActivityViewController>
     ) -> UIActivityViewController {
-        UIActivityViewController(activityItems: activityItems, applicationActivities: applicationActivities)
+        let controller = UIActivityViewController(
+            activityItems: activityItems,
+            applicationActivities: applicationActivities
+        )
+        controller.completionWithItemsHandler = { _, _, _, _  in
+            completion?()
+        }
+        return controller
     }
 
     func updateUIViewController(

--- a/Nos/Views/Components/ActivityView.swift
+++ b/Nos/Views/Components/ActivityView.swift
@@ -5,7 +5,7 @@ struct ActivityViewController: UIViewControllerRepresentable {
 
     var activityItems: [Any]
     var applicationActivities: [UIActivity]?
-    var completion: (() -> Void)? // Completion handler for dismissing the sheet
+    var completion: (() -> Void)? // Completion handler called after the share activity is finished
 
     func makeUIViewController(
         context: UIViewControllerRepresentableContext<ActivityViewController>

--- a/Nos/Views/Components/ActivityView.swift
+++ b/Nos/Views/Components/ActivityView.swift
@@ -5,7 +5,8 @@ struct ActivityViewController: UIViewControllerRepresentable {
 
     var activityItems: [Any]
     var applicationActivities: [UIActivity]?
-    var completion: (() -> Void)? // Completion handler called after the share activity is finished
+    /// The completion handler to execute after the activity view controller is dismissed.
+    var completion: (() -> Void)?
 
     func makeUIViewController(
         context: UIViewControllerRepresentableContext<ActivityViewController>

--- a/Nos/Views/Components/Button/NoteOptionsButton.swift
+++ b/Nos/Views/Components/Button/NoteOptionsButton.swift
@@ -34,6 +34,7 @@ struct NoteOptionsButton: View {
                     copyMessageIdentifier()
                 }
                 Button(String(localized: .localizable.shareNote)) {
+                    showingShare = true
                     analytics.sharedNoteLink()
                 }
                 if !note.isStub {
@@ -82,6 +83,8 @@ struct NoteOptionsButton: View {
                 }
             }
             .sheet(isPresented: $showingShare) {
+                let url = note.webLink
+                ActivityViewController(activityItems: [url])
             }
         }
     }

--- a/Nos/Views/Components/Button/NoteOptionsButton.swift
+++ b/Nos/Views/Components/Button/NoteOptionsButton.swift
@@ -84,7 +84,9 @@ struct NoteOptionsButton: View {
             }
             .sheet(isPresented: $showingShare) {
                 let url = note.webLink
-                ActivityViewController(activityItems: [url])
+                ActivityViewController(activityItems: [url]) {
+                    showingShare = false
+                }
             }
         }
     }


### PR DESCRIPTION
## Issues covered
#1272

## Description
This PR adds a share functionality to the share note button option on the  confirmation dialogue in the `NoteOptionsButton` file. The following changes were made:

- A `showingShare` state variable was already present, so set it to `true` when the share note button is pressed.
- The share sheet was already present, so updated the code block to include sending the note link to the Apple Share sheet.
- Adds an optional completion handler to the `ActivityViewController` to perform actions after the share activity is finished.
- Sets `showingShare` to `false` in this completion handler to dismiss the share sheet after the share activity is finished.

## How to test
1. Build the app.
2. Go to the Feed tab.
3. Choose any note and select the 3 dots menu at the top right of the note, just beside the time.
4. Click the share note button option
5. Please confirm that Apple's share sheet comes up and you can share the note link anywhere.

## Screenshots/Video

https://github.com/user-attachments/assets/4eee13a6-2f6a-4eb6-9ffa-b5bbd0300db4


