### PR TITLE
fixed a bug with data calculation for relay update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed typos in release notes.
 - Renamed and reorganized files.
 - Added more instructions to the changelog file
+- Fixed a date calculation bug affecting log during relay update
 
 ## [0.1.25] - 2024-08-21Z
 

--- a/Nos/Service/Relay/RelayService.swift
+++ b/Nos/Service/Relay/RelayService.swift
@@ -809,7 +809,7 @@ extension RelayService {
             guard let timestamp = relay.metadataFetchedAt else {
                 return true
             }
-            return timestamp.timeIntervalSinceNow > 86_400 * 3 // 3 days
+            return -timestamp.timeIntervalSinceNow > 86_400 * 3 // 3 days
         }
         guard shouldQueryRelayMetadata else {
             return


### PR DESCRIPTION
## Issues covered
Add reference(s) to a related issue in your repository.

## Description
The timeSinceNow property is actually calculated in negative and not as a difference, so it's never possible for it to be greater than 86_400 * 3. 
I simply reversed it. 
I do think that a Date extension that returns the number of days since now would be good. Plus unit tests can be written for it. 

## How to test
1. Inside `queryRelayMetadataIfNeeded` function on L#811, add a new line 
2. write a print function, `print("!!! >>> timestamp.timeIntervalSinceNow \(timestamp.timeIntervalSinceNow)`
3. Load the application and wait a few seconds for the function to be called. 
4. Observe the value is negative. 
5. Repeat steps 1-4 with a `-` in front of timestamp. 

## Screenshots/Video

<img width="444" alt="Screenshot 2024-09-09 at 11 03 28 AM" src="https://github.com/user-attachments/assets/5f5a6ce0-dc6e-4c41-a767-e8d1d50783d5">
<img width="595" alt="Screenshot 2024-09-09 at 11 01 59 AM" src="https://github.com/user-attachments/assets/505bc66d-70c7-4914-8120-9ff2d61f03c9">
