### PR TITLE
Fixes toggle white background color bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added the option to preview a note before posting it.
 - Fixed side menu accessibility issues.
-- Fixed a bug where content of a quoted note expanded out beyond width of viewport. 
+- Fixed a bug where content of a quoted note expanded out beyond width of viewport.
+- Fixed a bug where toggles in the settings page were white instead of green, when togled on. [#1251](https://github.com/planetary-social/nos/issues/1251)
 
 ### Internal Changes
 - Use NIP-92 media metadata to display media in the proper orientation. Currently behind the “Enable new media display” feature flag.

--- a/Nos.xcodeproj/project.pbxproj
+++ b/Nos.xcodeproj/project.pbxproj
@@ -97,6 +97,7 @@
 		03FE3F7C2C87AC9900D25810 /* Event+InlineMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03FE3F7B2C87AC9900D25810 /* Event+InlineMetadata.swift */; };
 		03FE3F7D2C87AC9900D25810 /* Event+InlineMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03FE3F7B2C87AC9900D25810 /* Event+InlineMetadata.swift */; };
 		03FE3F8C2C87BC9500D25810 /* text_note_multiple_media.json in Resources */ = {isa = PBXBuildFile; fileRef = 03FE3F8A2C87BC9500D25810 /* text_note_multiple_media.json */; };
+		042406F32C907A15008F2A21 /* NosToggle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 042406F22C907A15008F2A21 /* NosToggle.swift */; };
 		2D06BB9D2AE249D70085F509 /* ThreadRootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D06BB9C2AE249D70085F509 /* ThreadRootView.swift */; };
 		2D4010A22AD87DF300F93AD4 /* KnownFollowersView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D4010A12AD87DF300F93AD4 /* KnownFollowersView.swift */; };
 		3A1C296F2B2A537C0020B753 /* Moderation.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = 3A1C296E2B2A537C0020B753 /* Moderation.xcstrings */; };
@@ -615,6 +616,7 @@
 		03FE3F782C87A9D900D25810 /* EventError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventError.swift; sourceTree = "<group>"; };
 		03FE3F7B2C87AC9900D25810 /* Event+InlineMetadata.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Event+InlineMetadata.swift"; sourceTree = "<group>"; };
 		03FE3F8A2C87BC9500D25810 /* text_note_multiple_media.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = text_note_multiple_media.json; sourceTree = "<group>"; };
+		042406F22C907A15008F2A21 /* NosToggle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NosToggle.swift; sourceTree = "<group>"; };
 		2D06BB9C2AE249D70085F509 /* ThreadRootView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ThreadRootView.swift; sourceTree = "<group>"; };
 		2D4010A12AD87DF300F93AD4 /* KnownFollowersView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KnownFollowersView.swift; sourceTree = "<group>"; };
 		3A1C296E2B2A537C0020B753 /* Moderation.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Moderation.xcstrings; sourceTree = "<group>"; };
@@ -1386,6 +1388,7 @@
 				2D4010A12AD87DF300F93AD4 /* KnownFollowersView.swift */,
 				C9A0DADC29C689C900466635 /* NosNavigationBar.swift */,
 				C97B28892C10B07100DC1FC0 /* NosNavigationStack.swift */,
+				042406F22C907A15008F2A21 /* NosToggle.swift */,
 				C9B708BA2A13BE41006C613A /* NoteTextEditor.swift */,
 				C986510F2B0BD49200597B68 /* PagedNoteListView.swift */,
 				C9E37E112A1E7EC5003D4B0A /* PreviewContainer.swift */,
@@ -2167,6 +2170,7 @@
 				5BFF66B62A58A8A000AA79DD /* MutesView.swift in Sources */,
 				C913DA0A2AEAF52B003BDD6D /* NoteWarningController.swift in Sources */,
 				3F30020929C23895003D4F8B /* OnboardingNotOldEnoughView.swift in Sources */,
+				042406F32C907A15008F2A21 /* NosToggle.swift in Sources */,
 				03B4E6AE2C125D61006E5F59 /* FileStorageUploadResponseJSON.swift in Sources */,
 				5B79F6112B98AD0A002DA9BE /* ExcellentChoiceSheet.swift in Sources */,
 				C973AB612A323167002AED16 /* Author+CoreDataProperties.swift in Sources */,

--- a/Nos/Views/Components/NosToggle.swift
+++ b/Nos/Views/Components/NosToggle.swift
@@ -1,6 +1,5 @@
 import SwiftUI
 /// A toggle with the tint color set to green.
-/// - Note: Fixes [#1251](https://github.com/planetary-social/nos/issues/1251)
 struct NosToggle: View {
     @Binding var isOn: Bool
     /// A string that shows up beside the toggle. Optional.
@@ -13,7 +12,7 @@ struct NosToggle: View {
                     .foregroundColor(.primaryTxt)
             }
         }
-        .tint(.green)
+        .tint(.green) // Fixes [#1251](https://github.com/planetary-social/nos/issues/1251)
     }
 }
 

--- a/Nos/Views/Components/NosToggle.swift
+++ b/Nos/Views/Components/NosToggle.swift
@@ -2,7 +2,7 @@ import SwiftUI
 /// A toggle with the tint color set to green.
 struct NosToggle: View {
     @Binding var isOn: Bool
-    /// Optional, in case we need to use a toggle without a string
+    /// A string that shows up beside the toggle. Optional.
     var labelText: LocalizedStringResource?
 
     var body: some View {

--- a/Nos/Views/Components/NosToggle.swift
+++ b/Nos/Views/Components/NosToggle.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 /// A toggle with the tint color set to green.
+/// - Note: Fixes [#1251](https://github.com/planetary-social/nos/issues/1251)
 struct NosToggle: View {
     @Binding var isOn: Bool
     /// A string that shows up beside the toggle. Optional.

--- a/Nos/Views/Components/NosToggle.swift
+++ b/Nos/Views/Components/NosToggle.swift
@@ -1,0 +1,23 @@
+import SwiftUI
+
+struct NosToggle: View {
+    @Binding var isOn: Bool
+    var labelText: LocalizedStringResource
+
+    var body: some View {
+        Toggle(isOn: $isOn) {
+            Text(labelText)
+                .foregroundColor(.primaryTxt)
+        }
+        .tint(.green)
+    }
+}
+
+#Preview {
+    @State var isOn = true
+
+    return NosToggle(
+        isOn: $isOn,
+        labelText: .localizable.useReportsFromFollows
+    )
+}

--- a/Nos/Views/Components/NosToggle.swift
+++ b/Nos/Views/Components/NosToggle.swift
@@ -1,13 +1,16 @@
 import SwiftUI
-
+/// A toggle with the tint color set to green.
 struct NosToggle: View {
     @Binding var isOn: Bool
-    var labelText: LocalizedStringResource
+    /// Optional, in case we need to use a toggle without a string
+    var labelText: LocalizedStringResource?
 
     var body: some View {
         Toggle(isOn: $isOn) {
-            Text(labelText)
-                .foregroundColor(.primaryTxt)
+            if let labelText = labelText {
+                Text(labelText)
+                    .foregroundColor(.primaryTxt)
+            }
         }
         .tint(.green)
     }

--- a/Nos/Views/NoteComposer/ComposerActionBar.swift
+++ b/Nos/Views/NoteComposer/ComposerActionBar.swift
@@ -144,9 +144,7 @@ struct ComposerActionBar: View {
             Text(.localizable.preview)
                 .padding(.horizontal, 10)
                 .foregroundColor(Color.secondaryTxt)
-            Toggle(isOn: $showPreview) {
-                EmptyView()
-            }
+            NosToggle(isOn: $showPreview)
             .labelsHidden()
             .disabled(editingController.isEmpty)
         }

--- a/Nos/Views/NoteComposer/ComposerActionBar.swift
+++ b/Nos/Views/NoteComposer/ComposerActionBar.swift
@@ -145,8 +145,8 @@ struct ComposerActionBar: View {
                 .padding(.horizontal, 10)
                 .foregroundColor(Color.secondaryTxt)
             NosToggle(isOn: $showPreview)
-            .labelsHidden()
-            .disabled(editingController.isEmpty)
+                .labelsHidden()
+                .disabled(editingController.isEmpty)
         }
     }
 

--- a/Nos/Views/Settings/SettingsView.swift
+++ b/Nos/Views/Settings/SettingsView.swift
@@ -117,10 +117,7 @@ struct SettingsView: View {
             
             Section {
                 VStack {
-                    Toggle(isOn: $showReportWarnings) { 
-                        Text(.localizable.useReportsFromFollows)
-                            .foregroundColor(.primaryTxt)
-                    }
+                    NosToggle(isOn: $showReportWarnings, labelText: .localizable.useReportsFromFollows)
                     .onChange(of: showReportWarnings) { _, newValue in
                         userDefaults.set(newValue, forKey: showReportWarningsKey)
                     }
@@ -135,10 +132,7 @@ struct SettingsView: View {
                 .padding(.bottom, 8)
 
                 VStack {
-                    Toggle(isOn: $showOutOfNetworkWarning) { 
-                        Text(.localizable.showOutOfNetworkWarnings)
-                            .foregroundColor(.primaryTxt)
-                    }
+                    NosToggle(isOn: $showOutOfNetworkWarning, labelText: .localizable.showOutOfNetworkWarnings)
                     .onChange(of: showOutOfNetworkWarning) { _, newValue in
                         userDefaults.set(newValue, forKey: showOutOfNetworkWarningKey)
                     }
@@ -279,10 +273,7 @@ extension SettingsView {
     
     /// A toggle for the new media display that allows the user to turn the feature on or off.
     private var newMediaFeatureToggle: some View {
-        Toggle(isOn: isNewMediaDisplayEnabled) {
-            Text(.localizable.enableNewMediaDisplay)
-                .foregroundColor(.primaryTxt)
-        }
+        NosToggle(isOn: isNewMediaDisplayEnabled, labelText: .localizable.enableNewMediaDisplay)
     }
 }
 #endif


### PR DESCRIPTION
## Issues covered
#1251 

## Description
This PR fixes the issue with the toggles' background color being changed to white instead of green, after it has been turned on. The following changes were made:
- A new component NosToggle with a tint color of green to override the white tint color set in the AppView; is added to the project.
- The Toggles in the SettingsView are replaced with the new NosToggle component.

## How to test
1. Build the app.
2. Click the side menu at the top left of the app.
3. Click the settings menu
4. Please scroll through the page and see that the toggles' background colors are green when turned on.

## Screenshots/Video
| Before | After |
|--------|-------|
| <img src="https://github.com/user-attachments/assets/085dd4eb-cf3c-4b09-9cf9-5a045090f1c7" alt="Before" width="250"/> | <img src="https://github.com/user-attachments/assets/45c8db86-4532-4e66-abc3-9379ed9bbedd" alt="After" width="250"/> |
