### PR TITLE
Refactored feature flag and added a feature flag toggle for “Enable new moderation flow” to Staging builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Use NIP-92 media metadata to display media in the proper orientation. Currently behind the “Enable new media display” feature flag. [#1172](https://github.com/planetary-social/nos/issues/1172)
 - Added more instructions to the changelog file.
 - Added some logging when a content warning is displayed. [cleanstr#53](https://github.com/planetary-social/cleanstr/issues/53)
-- Refactored feature flag and Added a feature flag toggle for “Enable new moderation flow” to Staging builds. [#1496](https://github.com/planetary-social/nos/issues/1496)
+- Refactored feature flag and added a feature flag toggle for “Enable new moderation flow” to Staging builds. [#1496](https://github.com/planetary-social/nos/issues/1496)
 
 ## [0.1.26] - 2024-09-09Z
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Use NIP-92 media metadata to display media in the proper orientation. Currently behind the “Enable new media display” feature flag. [#1172](https://github.com/planetary-social/nos/issues/1172)
 - Added more instructions to the changelog file.
 - Added some logging when a content warning is displayed. [cleanstr#53](https://github.com/planetary-social/cleanstr/issues/53)
+- Refactored feature flag and Added a feature flag toggle for “Enable new moderation flow” to Staging builds. [#1496](https://github.com/planetary-social/nos/issues/1496)
 
 ## [0.1.26] - 2024-09-09Z
 

--- a/Nos/Assets/Localization/Localizable.xcstrings
+++ b/Nos/Assets/Localization/Localizable.xcstrings
@@ -3739,6 +3739,17 @@
         }
       }
     },
+    "enableNewModerationFlow" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enable new moderation flow"
+          }
+        }
+      }
+    },
     "enterCode" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/Nos/Service/FeatureFlags.swift
+++ b/Nos/Service/FeatureFlags.swift
@@ -1,17 +1,25 @@
 import Foundation
 import Dependencies
 
-/// The set of feature flags used by the app.
-protocol FeatureFlags {
+/// Enum to represent each feature flag. Add new feature flags here easily.
+enum FeatureFlag: String {
     /// Whether the new media display should be enabled or not.
     /// - Note: See [#1177](https://github.com/planetary-social/nos/issues/1177) for details on the new media display.
-    var newMediaDisplayEnabled: Bool { get }
+    case newMediaDisplay
+    /// Whether the new moderation flow should be enabled or not.
+    /// - Note: See [#1489](https://github.com/planetary-social/nos/issues/1489) for details on the new moderation flow.
+    case newModerationFlow
+}
+
+/// The set of feature flags used by the app.
+protocol FeatureFlags {
+    /// Retrieves the value of the specified feature flag.
+    func isEnabled(_ feature: FeatureFlag) -> Bool
 
     // MARK: - Additional requirements for debug mode
-
     #if DEBUG || STAGING
-    /// Sets the value of `newMediaDisplayEnabled`.
-    func setNewMediaDisplayEnabled(_ enabled: Bool)
+    /// Sets the value of the specified feature flag.
+    func setEnabled(_ feature: FeatureFlag, enabled: Bool)
     #endif
 }
 
@@ -22,13 +30,19 @@ class DefaultFeatureFlags: FeatureFlags, DependencyKey {
 
     private init() {}
 
-    private(set) var newMediaDisplayEnabled = false
-}
+    /// A dictionary to store the values of feature flags.
+    private var featureFlags: [FeatureFlag: Bool] = [
+        .newMediaDisplay: false,
+        .newModerationFlow: false
+    ]
 
-#if DEBUG || STAGING
-extension DefaultFeatureFlags {
-    func setNewMediaDisplayEnabled(_ enabled: Bool) {
-        newMediaDisplayEnabled = enabled
+    func isEnabled(_ feature: FeatureFlag) -> Bool {
+        featureFlags[feature] ?? false
     }
+
+    #if DEBUG || STAGING
+    func setEnabled(_ feature: FeatureFlag, enabled: Bool) {
+        featureFlags[feature] = enabled
+    }
+    #endif
 }
-#endif

--- a/Nos/Views/Note/CompactNoteView.swift
+++ b/Nos/Views/Note/CompactNoteView.swift
@@ -155,7 +155,7 @@ struct CompactNoteView: View {
                 .allowsHitTesting(!note.isPreview)
             }
             if note.kind == EventKind.text.rawValue, showLinkPreviews, !note.contentLinks.isEmpty {
-                if featureFlags.newMediaDisplayEnabled {
+                if featureFlags.isEnabled(.newMediaDisplay) {
                     GalleryView(urls: note.contentLinks, metadata: note.inlineMetadata)
                 } else {
                     LinkPreviewCarousel(links: note.contentLinks)

--- a/Nos/Views/Settings/SettingsView.swift
+++ b/Nos/Views/Settings/SettingsView.swift
@@ -270,10 +270,23 @@ extension SettingsView {
             set: { featureFlags.setEnabled(.newMediaDisplay, enabled: $0) }
         )
     }
-    
+
     /// A toggle for the new media display that allows the user to turn the feature on or off.
     private var newMediaFeatureToggle: some View {
         NosToggle(isOn: isNewMediaDisplayEnabled, labelText: .localizable.enableNewMediaDisplay)
+    }
+
+    /// Whether the new moderation flow is enabled.
+    private var isNewModerationFlowEnabled: Binding<Bool> {
+        Binding<Bool>(
+            get: { featureFlags.isEnabled(.newModerationFlow) },
+            set: { featureFlags.setEnabled(.newModerationFlow, enabled: $0) }
+        )
+    }
+
+    /// A toggle for the new moderation flow that allows the user to turn the feature on or off.
+    private var newModerationFlowToggle: some View {
+        NosToggle(isOn: isNewModerationFlowEnabled, labelText: .localizable.enableNewModerationFlow)
     }
 }
 #endif
@@ -283,6 +296,7 @@ extension SettingsView {
     /// Controls that will appear when the app is built for STAGING.
     @MainActor private var stagingControls: some View {
         newMediaFeatureToggle
+        newModerationFlowToggle
     }
 }
 #endif
@@ -293,6 +307,7 @@ extension SettingsView {
     @MainActor private var debugControls: some View {
         Group {
             newMediaFeatureToggle
+            newModerationFlowToggle
 
             Text(.localizable.sampleDataInstructions)
                 .foregroundColor(.primaryTxt)

--- a/Nos/Views/Settings/SettingsView.swift
+++ b/Nos/Views/Settings/SettingsView.swift
@@ -266,8 +266,8 @@ extension SettingsView {
     /// Whether the new media display is enabled.
     private var isNewMediaDisplayEnabled: Binding<Bool> {
         Binding<Bool>(
-            get: { featureFlags.newMediaDisplayEnabled },
-            set: { featureFlags.setNewMediaDisplayEnabled($0) }
+            get: { featureFlags.isEnabled(.newMediaDisplay) },
+            set: { featureFlags.setEnabled(.newMediaDisplay, enabled: $0) }
         )
     }
     

--- a/NosTests/Service/MockFeatureFlags.swift
+++ b/NosTests/Service/MockFeatureFlags.swift
@@ -1,8 +1,16 @@
 /// A set of feature flag values used for testing that can be customized.
 class MockFeatureFlags: FeatureFlags {
-    var newMediaDisplayEnabled = false
+    /// A dictionary to store the mock values for feature flags.
+    private var featureFlags: [FeatureFlag: Bool] = [
+        .newMediaDisplay: false,
+        .newModerationFlow: false
+    ]
 
-    func setNewMediaDisplayEnabled(_ enabled: Bool) {
-        newMediaDisplayEnabled = enabled
+    func isEnabled(_ feature: FeatureFlag) -> Bool {
+        featureFlags[feature] ?? false
+    }
+    
+    func setEnabled(_ feature: FeatureFlag, enabled: Bool) {
+        featureFlags[feature] = enabled
     }
 }


### PR DESCRIPTION
## Issues covered
#1496 

## Description
This PR:
- Refactors the feature flag file to make it easy to add new feature flags
- Adds a feature flag toggle for “Enable new moderation flow” to Staging builds

## How to test
1. Build the app
2. Click the menu icon at the top left
3. Click the Settings option
4. Scroll down to the Debug section
5. Please check that you see the "enable new moderation" toggle

## Screenshots/Video

| Before | After |
|--------|-------|
| <img src="https://github.com/user-attachments/assets/ea01b257-6e74-4852-8b9e-9e073208842b" alt="Before" width="250"/> | <img src="https://github.com/user-attachments/assets/2eb5ba53-8f1b-4127-bed6-2aa5244cb9f1" alt="After" width="250"/> |
