### PR TITLE
added Delete Account UI #80

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed alert when uploading big files suggesting users pay for nostr.build. [#1321](https://github.com/planetary-social/nos/issues/1321)
 - Fixed issue where push notifications were not re-registered after account change. [#1501](https://github.com/planetary-social/nos/issues/1501)
 - Added support for NIP-62 Request to Vanish events. [#80](https://github.com/planetary-social/nos/issues/80)
+- Added Delete Account UI. [#80](https://github.com/planetary-social/nos/issues/80)
 
 ### Internal Changes
 - Use NIP-92 media metadata to display media in the proper orientation. Currently behind the “Enable new media display” feature flag. [#1172](https://github.com/planetary-social/nos/issues/1172)

--- a/Nos/Assets/Localization/Localizable.xcstrings
+++ b/Nos/Assets/Localization/Localizable.xcstrings
@@ -3771,6 +3771,17 @@
         }
       }
     },
+    "enableAccountDeletion" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enable account deletion"
+          }
+        }
+      }
+    },
     "enableNewMediaDisplay" : {
       "comment" : "Setting for new media feature flag",
       "extractionState" : "manual",

--- a/Nos/Assets/Localization/Localizable.xcstrings
+++ b/Nos/Assets/Localization/Localizable.xcstrings
@@ -3056,6 +3056,50 @@
         }
       }
     },
+    "delete" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Delete"
+          }
+        }
+      }
+    },
+    "deleteAccount" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Delete Account"
+          }
+        }
+      }
+    },
+    "deleteAccountDescription" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Deleting your account will delete all your data from Nos servers and ask all your relays to do the same."
+          }
+        }
+      }
+    },
+    "deleteMyAccount" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Delete my Account"
+          }
+        }
+      }
+    },
     "deleteNote" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/Nos/Service/FeatureFlags.swift
+++ b/Nos/Service/FeatureFlags.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Dependencies
+import SwiftUI
 
 /// Feature flags for enabling experimental or beta features.
 enum FeatureFlag {
@@ -27,7 +28,7 @@ protocol FeatureFlags {
 }
 
 /// The default set of feature flag values for the app.
-class DefaultFeatureFlags: FeatureFlags, DependencyKey {
+@Observable class DefaultFeatureFlags: FeatureFlags, DependencyKey {
     /// The one and only instance of `DefaultFeatureFlags`.
     static let liveValue = DefaultFeatureFlags()
 

--- a/Nos/Service/FeatureFlags.swift
+++ b/Nos/Service/FeatureFlags.swift
@@ -9,6 +9,9 @@ enum FeatureFlag {
     /// Whether the new moderation flow should be enabled or not.
     /// - Note: See [#1489](https://github.com/planetary-social/nos/issues/1489) for details on the new moderation flow.
     case newModerationFlow
+    /// Whether delete account UI is enabled or not.
+    /// - Note: See [#80](https://github.com/planetary-social/nos/issues/80) for details on deleting accounts.
+    case deleteAccount
 }
 
 /// The set of feature flags used by the app.
@@ -33,7 +36,8 @@ class DefaultFeatureFlags: FeatureFlags, DependencyKey {
     /// Feature flags and their values.
     private var featureFlags: [FeatureFlag: Bool] = [
         .newMediaDisplay: false,
-        .newModerationFlow: false
+        .newModerationFlow: false,
+        .deleteAccount: false
     ]
 
     /// Returns true if the feature is enabled.

--- a/Nos/Views/Components/Button/ActionButton.swift
+++ b/Nos/Views/Components/Button/ActionButton.swift
@@ -12,6 +12,7 @@ struct ActionButton: View {
     var font: Font = .clarity(.bold)
     var image: Image?
     var imageAlignment: ImageAlignment = .left
+    var padding = EdgeInsets(top: 8, leading: 13, bottom: 8, trailing: 13)
     var textColor = Color.white
     var depthEffectColor = Color.actionPrimaryDepthEffect
     var backgroundGradient = LinearGradient(
@@ -67,6 +68,7 @@ struct ActionButton: View {
         .buttonStyle(ActionButtonStyle(
             depthEffectColor: depthEffectColor,
             backgroundGradient: backgroundGradient,
+            padding: padding,
             textShadow: textShadow,
             shouldFillHorizontalSpace: shouldFillHorizontalSpace
         ))
@@ -107,6 +109,7 @@ struct ActionButtonStyle: ButtonStyle {
     let cornerRadius: CGFloat = 17
     let depthEffectColor: Color
     let backgroundGradient: LinearGradient
+    let padding: EdgeInsets
     var textShadow: Bool
     /// A flag used to fill the available horizontal space (centering the
     /// contents) or to fit the horizontal space to the contents of the action
@@ -125,8 +128,7 @@ struct ActionButtonStyle: ButtonStyle {
             configuration.label
                 .foregroundColor(.white)
                 .font(.body)
-                .padding(.vertical, 8)
-                .padding(.horizontal, 13)
+                .padding(padding)
                 .shadow(
                     color: textShadow ? Color.actionButtonTextShadow : .clear,
                     radius: 2,

--- a/Nos/Views/Settings/SettingsView.swift
+++ b/Nos/Views/Settings/SettingsView.swift
@@ -220,27 +220,31 @@ struct SettingsView: View {
             }
             .listRowGradientBackground()
             
-            ActionButton(
-                title: .localizable.deleteMyAccount,
-                font: .clarityBold(.title3),
-                padding: EdgeInsets(top: 16, leading: 0, bottom: 16, trailing: 0),
-                depthEffectColor: .actionSecondaryDepthEffect,
-                backgroundGradient: .verticalAccentSecondary,
-                shouldFillHorizontalSpace: true
-            ) {
-                alert = AlertState(
-                    title: { TextState(String(localized: .localizable.deleteAccount)) },
-                    actions: {
-                        ButtonState(role: .destructive, action: .send(.deleteAccount)) {
-                            TextState(String(localized: .localizable.delete))
-                        }
-                    },
-                    message: { TextState(String(localized: .localizable.deleteAccountDescription)) }
-                )
+            #if STAGING || DEBUG
+            if isDeleteAccountEnabled.wrappedValue {
+                ActionButton(
+                    title: .localizable.deleteMyAccount,
+                    font: .clarityBold(.title3),
+                    padding: EdgeInsets(top: 16, leading: 0, bottom: 16, trailing: 0),
+                    depthEffectColor: .actionSecondaryDepthEffect,
+                    backgroundGradient: .verticalAccentSecondary,
+                    shouldFillHorizontalSpace: true
+                ) {
+                    alert = AlertState(
+                        title: { TextState(String(localized: .localizable.deleteAccount)) },
+                        actions: {
+                            ButtonState(role: .destructive, action: .send(.deleteAccount)) {
+                                TextState(String(localized: .localizable.delete))
+                            }
+                        },
+                        message: { TextState(String(localized: .localizable.deleteAccountDescription)) }
+                    )
+                }
+                .clipShape(Capsule())
+                .listRowBackground(Color.clear)
+                .listRowInsets(EdgeInsets())
             }
-            .clipShape(Capsule())
-            .listRowBackground(Color.clear)
-            .listRowInsets(EdgeInsets())
+        #endif
         }
         .scrollContentBackground(.hidden)
         .background(Color.appBg)
@@ -307,6 +311,19 @@ extension SettingsView {
     private var newModerationFlowToggle: some View {
         NosToggle(isOn: isNewModerationFlowEnabled, labelText: .localizable.enableNewModerationFlow)
     }
+    
+    /// Whether account deletion is enabled.
+    private var isDeleteAccountEnabled: Binding<Bool> {
+        Binding<Bool>(
+            get: { featureFlags.isEnabled(.deleteAccount) },
+            set: { featureFlags.setFeature(.deleteAccount, enabled: $0) }
+        )
+    }
+    
+    /// A toggle for account deletion that allows the user to turn the feature on or off.
+    private var deleteAccountToggle: some View {
+        NosToggle(isOn: isDeleteAccountEnabled, labelText: .localizable.enableAccountDeletion)
+    }
 }
 #endif
 
@@ -316,6 +333,7 @@ extension SettingsView {
     @MainActor private var stagingControls: some View {
         newMediaFeatureToggle
         newModerationFlowToggle
+        deleteAccountToggle
     }
 }
 #endif
@@ -327,6 +345,7 @@ extension SettingsView {
         Group {
             newMediaFeatureToggle
             newModerationFlowToggle
+            deleteAccountToggle
             Text(.localizable.sampleDataInstructions)
                 .foregroundColor(.primaryTxt)
             Button(String(localized: .localizable.loadSampleData)) {

--- a/Nos/Views/Settings/SettingsView.swift
+++ b/Nos/Views/Settings/SettingsView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import Dependencies
+import Logger
 import SwiftUINavigation
 
 let showReportWarningsKey = "com.verse.nos.settings.showReportWarnings"
@@ -32,6 +33,7 @@ struct SettingsView: View {
 
     fileprivate enum AlertAction {
         case logout
+        case deleteAccount
     }
 
     fileprivate enum CopyButtonState {
@@ -217,6 +219,28 @@ struct SettingsView: View {
                     .padding(.vertical, 15)
             }
             .listRowGradientBackground()
+            
+            ActionButton(
+                title: .localizable.deleteMyAccount,
+                font: .clarityBold(.title3),
+                padding: EdgeInsets(top: 16, leading: 0, bottom: 16, trailing: 0),
+                depthEffectColor: .actionSecondaryDepthEffect,
+                backgroundGradient: .verticalAccentSecondary,
+                shouldFillHorizontalSpace: true
+            ) {
+                alert = AlertState(
+                    title: { TextState(String(localized: .localizable.deleteAccount)) },
+                    actions: {
+                        ButtonState(role: .destructive, action: .send(.deleteAccount)) {
+                            TextState(String(localized: .localizable.delete))
+                        }
+                    },
+                    message: { TextState(String(localized: .localizable.deleteAccountDescription)) }
+                )
+            }
+            .clipShape(Capsule())
+            .listRowBackground(Color.clear)
+            .listRowInsets(EdgeInsets())
         }
         .scrollContentBackground(.hidden)
         .background(Color.appBg)
@@ -236,6 +260,13 @@ struct SettingsView: View {
         switch action {
         case .logout:
             await logout()
+        case .deleteAccount:
+            do {
+                try await currentUser.publishRequestToVanish()
+                await logout()
+            } catch {
+                Log.error(error)
+            }
         }
     }
     


### PR DESCRIPTION
## Issues covered
#80 

## Description
Adds the UI associated with deleting a user's account.

## How to test
While signed in to an account that you don't mind being deleted...
1. Navigate to the Settings view.
2. Scroll to the bottom.
3. Tap the Delete Account button.
4. At the confirmation alert, tap the Delete button.

At this point, a NIP-62 Request to Vanish event will be published to all the user's relays and the account will be signed out locally.

## Screenshots/Video
![nos 80](https://github.com/user-attachments/assets/8b35d6bb-a77c-498b-9d20-351021059096)

![Simulator Screenshot - iPhone 15 - 2024-09-18 at 07 51 43](https://github.com/user-attachments/assets/b93e7929-4ea4-432c-b6b8-24c53b6abcbf)

