### PR TITLE
Tweaked the search results to prioritize follows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Refactored feature flag and added a feature flag toggle for “Enable new moderation flow” to Staging builds. [#1496](https://github.com/planetary-social/nos/issues/1496)
 - Refactored list row gradient background.
 - Added SwiftSoup to parse Open Graph metadata. [#1165](https://github.com/planetary-social/nos/issues/1165)
+- Tweaked search results to prioritize common follows [#1485](https://github.com/planetary-social/nos/issues/1485)
 
 ## [0.1.26] - 2024-09-09Z
 

--- a/Nos/Controller/SearchController.swift
+++ b/Nos/Controller/SearchController.swift
@@ -128,7 +128,7 @@ class SearchController: ObservableObject {
         guard let authors = try? Author.find(named: name, context: context) else {
             return []
         }
-        return authors
+        return authors.sorted(by: { $0.followers.count > $1.followers.count })
     }
     
     func clear() {


### PR DESCRIPTION
## Issues covered
[Add reference(s) to a related issue in your repository.
](https://github.com/planetary-social/nos/issues/1485)

## Description
Currently the author list is sorted by followers, but the author find function is not, and there seems to be a case where more authors are added to the result but those are not sorted properly. 
Adding an additional sort to the authors find function appears to remedy the issue. 

## How to test
1. Navigate to Discover
2. Tap the search bar 
3. Enter a letter that will show an account with a lot of shared followers

## Screenshots/Video

<img width="400" alt="Screenshot 2024-09-18 at 9 56 12 AM" src="https://github.com/user-attachments/assets/3616f48e-5e47-48dd-a78c-60c7ceb9d531">
