### PR TITLE
Fix a build error in staging builds

### DIFF
--- a/Nos/Views/Settings/SettingsView.swift
+++ b/Nos/Views/Settings/SettingsView.swift
@@ -283,8 +283,10 @@ extension SettingsView {
 extension SettingsView {
     /// Controls that will appear when the app is built for STAGING.
     @MainActor private var stagingControls: some View {
-        newMediaFeatureToggle
-        newModerationFlowToggle
+        Group {
+            newMediaFeatureToggle
+            newModerationFlowToggle
+        }
     }
 }
 #endif


### PR DESCRIPTION
## Issues covered
None

## Description
Staging builds started failing about a week ago. This fixes them.

## How to test
1. Select the NosStaging scheme
2. Build

Before this PR, it fails. After, it builds.

## Notes
The error, which you can find in the GitHub Action as well as the build logs if you build locally, is this:

```
.../SettingsView.swift:285:55: Function declares an opaque return type, but has no return statements in its body from which to infer an underlying type
```
