### PR TITLE
Radio button selection animation

### DIFF
--- a/Nos/Models/FlagOption.swift
+++ b/Nos/Models/FlagOption.swift
@@ -5,7 +5,7 @@ import Foundation
 /// - `description`: An optional description that provides more detail about the flagging option.
 /// - `info`: An optional message that will be displayed when the user has selected a particular flag.
 /// - `id`: A unique identifier for the flagging option, based on the `title`.
-struct FlagOption: Identifiable {
+struct FlagOption: Identifiable, Equatable {
     let title: String
     let description: String?
     let info: String?

--- a/Nos/Models/FlagOption.swift
+++ b/Nos/Models/FlagOption.swift
@@ -6,7 +6,7 @@ import Foundation
 /// - `info`: An optional message that will be displayed when the user has selected a particular flag.
 /// - `id`: A unique identifier for the flagging option, based on the `title`.
 
-struct FlagOption: Identifiable {
+struct FlagOption: Identifiable, Equatable {
     let title: String
     let description: String?
     let info: String?

--- a/Nos/Views/Moderation/ContentFlagView.swift
+++ b/Nos/Views/Moderation/ContentFlagView.swift
@@ -23,11 +23,13 @@ struct ContentFlagView: View {
                         title: String(localized: .localizable.flagContentSendTitle),
                         subtitle: nil
                     )
+                    .transition(.move(edge: .leading).combined(with: .opacity))
                 }
             }
         }
         .padding()
         .background(Color.appBg)
+        .animation(.easeInOut, value: selectedFlagOptionCategory)
     }
 }
 


### PR DESCRIPTION
## Issues covered
 [#1490](https://github.com/planetary-social/nos/issues/1490)
Part 3 of [#1489](https://github.com/planetary-social/nos/issues/1489)

## Description
This PR adds animation to the content flag view. Choosing a flag content category slides in the new categories underneath from the left.

## How to test
1. Build the app
2. Click the side menu
3. Click the Settings on the side menu
4. Scroll down to turn on the toggle for new moderation flow
5. Go back to the Feed screen by clicking the feed tab at the bottom of the screen
6. Click on the 3 dots on one of the notes.
7. Select `Flag this content` option. 
8. Select an option from the categories displayed.
9. Please confirm that new categories on how to flag a content shows up under the first category, and it slides in from the left.

## Screenshots/Video

https://github.com/user-attachments/assets/5f6e9f18-6f96-45f1-ad5d-ea6785148e2c

