### PR TITLE
delete all user data when logging out #1534

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed issue where push notifications were not re-registered after account change. [#1501](https://github.com/planetary-social/nos/issues/1501)
 - Added support for NIP-62 Request to Vanish events. [#80](https://github.com/planetary-social/nos/issues/80)
 - Added Delete Account UI. [#80](https://github.com/planetary-social/nos/issues/80)
+- Delete all user data when logging out. [#1534](https://github.com/planetary-social/nos/issues/1534)
 
 ### Internal Changes
 - Use NIP-92 media metadata to display media in the proper orientation. Currently behind the “Enable new media display” feature flag. [#1172](https://github.com/planetary-social/nos/issues/1172)

--- a/Nos.xcodeproj/project.pbxproj
+++ b/Nos.xcodeproj/project.pbxproj
@@ -155,6 +155,8 @@
 		508133CB2C79F78500DFBF75 /* AttributedString+Quotation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 508133CA2C79F78500DFBF75 /* AttributedString+Quotation.swift */; };
 		508133DB2C7A003600DFBF75 /* AttributedString+QuotationsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 508133DA2C7A003600DFBF75 /* AttributedString+QuotationsTests.swift */; };
 		508133DC2C7A007700DFBF75 /* AttributedString+Quotation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 508133CA2C79F78500DFBF75 /* AttributedString+Quotation.swift */; };
+		508B2B612C9EF65300C14034 /* NSPersistentContainer+Nos.swift in Sources */ = {isa = PBXBuildFile; fileRef = 508B2B602C9EF65300C14034 /* NSPersistentContainer+Nos.swift */; };
+		508B2B622C9EF65300C14034 /* NSPersistentContainer+Nos.swift in Sources */ = {isa = PBXBuildFile; fileRef = 508B2B602C9EF65300C14034 /* NSPersistentContainer+Nos.swift */; };
 		509532DF2C62360500E0BACA /* NotificationViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 509532DE2C62360500E0BACA /* NotificationViewModelTests.swift */; };
 		509533002C62535400E0BACA /* zap_request.json in Resources */ = {isa = PBXBuildFile; fileRef = 509532FF2C62535400E0BACA /* zap_request.json */; };
 		5095330B2C625B5D00E0BACA /* zap_request_one_sat.json in Resources */ = {isa = PBXBuildFile; fileRef = 509533092C625B5D00E0BACA /* zap_request_one_sat.json */; };
@@ -681,6 +683,7 @@
 		5045540C2C81E10C0044ECAE /* EditableAvatarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditableAvatarView.swift; sourceTree = "<group>"; };
 		508133CA2C79F78500DFBF75 /* AttributedString+Quotation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AttributedString+Quotation.swift"; sourceTree = "<group>"; };
 		508133DA2C7A003600DFBF75 /* AttributedString+QuotationsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AttributedString+QuotationsTests.swift"; sourceTree = "<group>"; };
+		508B2B602C9EF65300C14034 /* NSPersistentContainer+Nos.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSPersistentContainer+Nos.swift"; sourceTree = "<group>"; };
 		509532DE2C62360500E0BACA /* NotificationViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationViewModelTests.swift; sourceTree = "<group>"; };
 		509532FF2C62535400E0BACA /* zap_request.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = zap_request.json; sourceTree = "<group>"; };
 		509533092C625B5D00E0BACA /* zap_request_one_sat.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = zap_request_one_sat.json; sourceTree = "<group>"; };
@@ -1783,6 +1786,7 @@
 				C9F0BB6829A5039D000547FC /* Int+Bool.swift */,
 				C9ADB14029951CB10075E7F8 /* NSManagedObject+Nos.swift */,
 				C97A1C8D29E58EC7009D9E8D /* NSManagedObjectContext+Nos.swift */,
+				508B2B602C9EF65300C14034 /* NSPersistentContainer+Nos.swift */,
 				C93EC2F329C34C860012EE2A /* NSPredicate+Bool.swift */,
 				50E2EB712C86175900D4B360 /* NSRegularExpression+Replacement.swift */,
 				C93EC2F629C351470012EE2A /* Optional+Unwrap.swift */,
@@ -2483,6 +2487,7 @@
 				CD2CF390299E68BE00332116 /* NoteButton.swift in Sources */,
 				C9DC6CBA2C1739AD00E1CFB3 /* View+HandleURLsInRouter.swift in Sources */,
 				C93F48932AC5C9CE00900CEC /* UNSWizardIntroView.swift in Sources */,
+				508B2B612C9EF65300C14034 /* NSPersistentContainer+Nos.swift in Sources */,
 				5B79F6552BA123D4002DA9BE /* WizardSheetBadgeText.swift in Sources */,
 				C9DEC04D29894BED0078B43A /* Author+CoreDataClass.swift in Sources */,
 				C905B0772A619E99009B8A78 /* LinkPreview.swift in Sources */,
@@ -2586,6 +2591,7 @@
 				C9DEC04629894BED0078B43A /* Event+CoreDataClass.swift in Sources */,
 				C92E7F6B2C4EFF7200B80638 /* WebSocketConnection.swift in Sources */,
 				035729A02BE41653005FEE85 /* SocialGraphCacheTests.swift in Sources */,
+				508B2B622C9EF65300C14034 /* NSPersistentContainer+Nos.swift in Sources */,
 				03E9C6792C6FBBE400C9B843 /* ImageViewer.swift in Sources */,
 				03D1B4292C3C1AC9001778CD /* NostrIdentifier.swift in Sources */,
 				A32B6C7129A672BC00653FF5 /* CurrentUser.swift in Sources */,

--- a/Nos/Controller/PersistenceController.swift
+++ b/Nos/Controller/PersistenceController.swift
@@ -93,6 +93,10 @@ final class PersistenceController {
         }
     }
     
+    func deleteAll() async throws {
+        await container.deleteAllEntities()
+    }
+    
     private static func clearCoreData(store storeURL: URL, in container: NSPersistentContainer) {
         Log.info("Dropping Core Data...")
         do {

--- a/Nos/Extensions/NSPersistentContainer+Nos.swift
+++ b/Nos/Extensions/NSPersistentContainer+Nos.swift
@@ -1,0 +1,38 @@
+import CoreData
+import Logger
+
+extension NSPersistentContainer {
+    
+    /// Deletes all entities in this container.
+    ///
+    /// - Note: This function assumes that all contexts using the container have their
+    ///         `automaticallyMergesChangesFromParent` property set to true.
+    func deleteAllEntities() async {
+        assert(
+            viewContext.automaticallyMergesChangesFromParent,
+            "All associated contexts must automatically merge changes from their parent."
+        )
+        
+        let entityNames = managedObjectModel.entities.compactMap { $0.name }
+        
+        let context = newBackgroundContext()
+        await context.perform {
+            for entityName in entityNames {
+                let fetchRequest = NSFetchRequest<NSFetchRequestResult>(entityName: entityName)
+                let deleteRequest = NSBatchDeleteRequest(fetchRequest: fetchRequest)
+                deleteRequest.resultType = .resultTypeCount
+                
+                do {
+                    let result = try context.execute(deleteRequest) as? NSBatchDeleteResult
+                    Log.info("Deleted \(result?.result ?? 0) of type \(entityName)")
+                } catch {
+                    print("Failed to batch delete entity: \(entityName), error: \(error)")
+                }
+            }
+            
+            if context.hasChanges {
+                try? context.save()
+            }
+        }
+    }
+}

--- a/Nos/Service/CurrentUser.swift
+++ b/Nos/Service/CurrentUser.swift
@@ -12,6 +12,7 @@ import Dependencies
     @ObservationIgnored @Dependency(\.pushNotificationService) private var pushNotificationService
     @ObservationIgnored @Dependency(\.relayService) var relayService
     @ObservationIgnored @Dependency(\.keychain) private var keychain
+    @ObservationIgnored @Dependency(\.unsAPI) var unsAPI
     
     // TODO: it's time to cache this
     var keyPair: KeyPair? {
@@ -291,3 +292,19 @@ import Dependencies
     }
 }
 // swiftlint:enable type_body_length
+
+extension CurrentUser {
+    func logout(appController: AppController) async {
+        await setKeyPair(nil)
+        analytics.logout()
+        crashReporting.logout()
+        unsAPI.logout()
+        appController.configureCurrentState()
+        try? await persistenceController.deleteAll()
+    }
+    
+    func deleteAccount(appController: AppController) async throws {
+        try await publishRequestToVanish()
+        await logout(appController: appController)
+    }
+}

--- a/Nos/Views/Settings/SettingsView.swift
+++ b/Nos/Views/Settings/SettingsView.swift
@@ -7,7 +7,6 @@ let showReportWarningsKey = "com.verse.nos.settings.showReportWarnings"
 let showOutOfNetworkWarningKey = "com.verse.nos.settings.showOutOfNetworkWarning"
     
 struct SettingsView: View {
-    @Dependency(\.unsAPI) var unsAPI
     @Dependency(\.analytics) private var analytics
     @Dependency(\.crashReporting) private var crashReporting
     @Dependency(\.persistenceController) private var persistenceController
@@ -263,23 +262,14 @@ struct SettingsView: View {
     fileprivate func alertButtonTapped(_ action: AlertAction) async {
         switch action {
         case .logout:
-            await logout()
+            await currentUser.logout(appController: appController)
         case .deleteAccount:
             do {
-                try await currentUser.publishRequestToVanish()
-                await logout()
+                try await currentUser.deleteAccount(appController: appController)
             } catch {
                 Log.error(error)
             }
         }
-    }
-    
-    func logout() async {
-        await currentUser.setKeyPair(nil)
-        analytics.logout()
-        crashReporting.logout()
-        unsAPI.logout()
-        appController.configureCurrentState() 
     }
 }
 


### PR DESCRIPTION
## Issues covered
#1534 

## Description
When the user logs out, we should clear out all of their data.

## How to test
1. Sign in to an account.
2. Navigate around and make sure lots of events and authors get loaded.
3. Sign out.
4. Sign back in.
As you navigate around again, you should notice that data has to load again. It's not immediately there.

A unit test is also provided to confirm that the critical function actually removes all data.
