### PR TITLE
publish empty metadata event and empty contact list on delete account #1530

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added Delete Account UI. [#80](https://github.com/planetary-social/nos/issues/80)
 - Fixed issue where search results weren't sorted properly. [#1485](https://github.com/planetary-social/nos/issues/1485)
 - Delete all user data when logging out. [#1534](https://github.com/planetary-social/nos/issues/1534)
+- Publish empty metadata event and empty contact list on delete account. [#1530](https://github.com/planetary-social/nos/issues/1530)
 
 ### Internal Changes
 - Use NIP-92 media metadata to display media in the proper orientation. Currently behind the “Enable new media display” feature flag. [#1172](https://github.com/planetary-social/nos/issues/1172)

--- a/Nos/Models/JSONEvent+Kinds.swift
+++ b/Nos/Models/JSONEvent+Kinds.swift
@@ -2,6 +2,24 @@ import Foundation
 
 extension JSONEvent {
     
+    /// An event that represents the user's contact list (who they are following) and their relays.
+    /// - Parameters:
+    ///   - pubKey: The pubkey of the user whose contact list and relays the event represents.
+    ///   - tags: The "p" tags of followed profiles.
+    ///   - relays: Relays the user wishes to associate with their profile.
+    /// - Returns: The ``JSONEvent`` of the contact list.
+    static func contactList(pubKey: String, tags: [[String]], relayAddresses: [String]) -> JSONEvent {
+        let relayStrings = relayAddresses.map { "\"\($0)\":{\"write\":true,\"read\":true}" }
+        let content = "{" + relayStrings.joined(separator: ",") + "}"
+        
+        return JSONEvent(
+            pubKey: pubKey,
+            kind: .contactList,
+            tags: tags,
+            content: content
+        )
+    }
+    
     /// An event that represents the user's request for all of their published notes to be removed from relays.
     /// - Parameters:
     ///   - pubKey: The public key of the user making the request.

--- a/Nos/Service/CurrentUser+PublishEvents.swift
+++ b/Nos/Service/CurrentUser+PublishEvents.swift
@@ -119,7 +119,7 @@ extension CurrentUser {
     
     @MainActor func publishContactList(tags: [[String]]) async {
         guard let keyPair else {
-            Log.debug("Error: no key pair")
+            Log.error("Error: Failed to publish contact list because there was no key pair")
             return
         }
         
@@ -196,7 +196,7 @@ extension CurrentUser {
     
     @MainActor func publishAccountDeletedMetadata() async throws {
         guard let author else {
-            Log.error("Error: no author")
+            Log.error("Error: Failed to publish account deleted metadata because there was no Author")
             return
         }
         
@@ -215,7 +215,7 @@ extension CurrentUser {
     
     @MainActor func publishEmptyFollowList() async throws {
         guard let author else {
-            Log.error("Error: no author")
+            Log.error("Error: Failed to publish empty follow list because there was no Author")
             return
         }
         

--- a/Nos/Service/CurrentUser.swift
+++ b/Nos/Service/CurrentUser.swift
@@ -313,7 +313,13 @@ extension CurrentUser {
     /// > Warning: This is a destructive action, so be sure that it is actually what the
     ///            user wants.
     func deleteAccount(appController: AppController) async throws {
+        try await publishAccountDeletedMetadata()
         try await publishRequestToVanish()
+        
+        // Note: Publishing the empty follow list must be last before logout because
+        //       it will remove the user's relays.
+        try await publishEmptyFollowList()
+        
         await logout(appController: appController)
     }
 }

--- a/NosTests/Models/JSONEventTests.swift
+++ b/NosTests/Models/JSONEventTests.swift
@@ -15,6 +15,52 @@ class JSONEventTests: XCTestCase {
         XCTAssertEqual(subject.replaceableID, replaceableID)
     }
     
+    func test_contactList_withRelays() {
+        let pTags = [
+            ["p", "91cf94e5ca", "wss://alicerelay.com/", "alice"],
+            ["p", "14aeb8dad4", "wss://bobrelay.com/nostr", "bob"],
+            ["p", "612aee610f", "ws://carolrelay.com/ws", "carol"]
+        ]
+        let relayAddresses = [
+            "wss://relay1.lol",
+            "wss://relay2.lol"
+        ]
+        
+        let event = JSONEvent.contactList(
+            pubKey: "",
+            tags: pTags,
+            relayAddresses: relayAddresses
+        )
+        
+        let expectedContent = """
+        {"wss://relay1.lol":{"write":true,"read":true},"wss://relay2.lol":{"write":true,"read":true}}
+        """
+        
+        XCTAssertEqual(event.kind, 3)
+        XCTAssertEqual(event.tags, pTags)
+        XCTAssertEqual(event.content, expectedContent)
+    }
+    
+    func test_contactList_withNoRelays() {
+        let pTags = [
+            ["p", "91cf94e5ca", "wss://alicerelay.com/", "alice"],
+            ["p", "14aeb8dad4", "wss://bobrelay.com/nostr", "bob"],
+            ["p", "612aee610f", "ws://carolrelay.com/ws", "carol"]
+        ]
+        
+        let event = JSONEvent.contactList(
+            pubKey: "",
+            tags: pTags,
+            relayAddresses: []
+        )
+        
+        let expectedContent = "{}"
+        
+        XCTAssertEqual(event.kind, 3)
+        XCTAssertEqual(event.tags, pTags)
+        XCTAssertEqual(event.content, expectedContent)
+    }
+    
     func test_requestToVanish_fromSpecificRelays() {
         let event = JSONEvent.requestToVanish(
             pubKey: "",


### PR DESCRIPTION
## Issues covered
#1530 

## Description
When the user deletes their account, we will now publish an empty metadata event (kind 0) that replaces their name with "Account deleted", and we'll publish an empty follow list event (kind 3).

## How to test
1. Create a new account.
2. Optionally post a note from that account.
3. Navigate to Settings.
4. Enable account deletion.
5. Tap Delete Account and tap Delete on the confirmation prompt.

## Screenshots/Video

In the video below, we delete the account we're using. Here are the events that get sent as the account is deleted (copied from the console):
```
JSONEvent(id: "", pubKey: "a3b2abbede868ce8f871ee429ebd70bcec132a45c417dda3d1df7cde9930cc20", createdAt: 1727208568, kind: 0, tags: [], content: "{\"about\":\"\",\"name\":\"Account deleted\",\"display_name\":\"Account deleted\",\"nip05\":\"\",\"uns_name\":\"\",\"website\":\"\",\"picture\":\"\"}", signature: Optional(""))

JSONEvent(id: "", pubKey: "a3b2abbede868ce8f871ee429ebd70bcec132a45c417dda3d1df7cde9930cc20", createdAt: 1727208568, kind: 62, tags: [["relay", "ALL_RELAYS"]], content: "", signature: Optional(""))

JSONEvent(id: "", pubKey: "a3b2abbede868ce8f871ee429ebd70bcec132a45c417dda3d1df7cde9930cc20", createdAt: 1727208568, kind: 3, tags: [], content: "{}", signature: Optional(""))
```

https://github.com/user-attachments/assets/a904cbff-9b76-4fb4-96ae-24e7ec22040b