### PR TITLE
Account flagging

### DIFF
--- a/Nos.xcodeproj/project.pbxproj
+++ b/Nos.xcodeproj/project.pbxproj
@@ -111,6 +111,7 @@
 		03FE3F7C2C87AC9900D25810 /* Event+InlineMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03FE3F7B2C87AC9900D25810 /* Event+InlineMetadata.swift */; };
 		03FE3F7D2C87AC9900D25810 /* Event+InlineMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03FE3F7B2C87AC9900D25810 /* Event+InlineMetadata.swift */; };
 		03FE3F8C2C87BC9500D25810 /* text_note_multiple_media.json in Resources */ = {isa = PBXBuildFile; fileRef = 03FE3F8A2C87BC9500D25810 /* text_note_multiple_media.json */; };
+		041C56C42CA1B48E007D3BB2 /* AccountFlagView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 041C56C32CA1B48E007D3BB2 /* AccountFlagView.swift */; };
 		042406F32C907A15008F2A21 /* NosToggle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 042406F22C907A15008F2A21 /* NosToggle.swift */; };
 		04368D2B2C99A2C400DEAA2E /* FlagOption.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04368D2A2C99A2C400DEAA2E /* FlagOption.swift */; };
 		04368D312C99A78800DEAA2E /* NosRadioButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04368D302C99A78800DEAA2E /* NosRadioButton.swift */; };
@@ -653,6 +654,7 @@
 		03FE3F782C87A9D900D25810 /* EventError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventError.swift; sourceTree = "<group>"; };
 		03FE3F7B2C87AC9900D25810 /* Event+InlineMetadata.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Event+InlineMetadata.swift"; sourceTree = "<group>"; };
 		03FE3F8A2C87BC9500D25810 /* text_note_multiple_media.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = text_note_multiple_media.json; sourceTree = "<group>"; };
+		041C56C32CA1B48E007D3BB2 /* AccountFlagView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountFlagView.swift; sourceTree = "<group>"; };
 		042406F22C907A15008F2A21 /* NosToggle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NosToggle.swift; sourceTree = "<group>"; };
 		04368D2A2C99A2C400DEAA2E /* FlagOption.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlagOption.swift; sourceTree = "<group>"; };
 		04368D302C99A78800DEAA2E /* NosRadioButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NosRadioButton.swift; sourceTree = "<group>"; };
@@ -1411,6 +1413,7 @@
 			isa = PBXGroup;
 			children = (
 				04368D4A2C99CFC700DEAA2E /* ContentFlagView.swift */,
+				041C56C32CA1B48E007D3BB2 /* AccountFlagView.swift */,
 			);
 			path = Moderation;
 			sourceTree = "<group>";
@@ -2343,6 +2346,7 @@
 				C9F75AD22A02D41E005BBE45 /* ComposerActionBar.swift in Sources */,
 				2D06BB9D2AE249D70085F509 /* ThreadRootView.swift in Sources */,
 				C9DEBFD2298941000078B43A /* NosApp.swift in Sources */,
+				041C56C42CA1B48E007D3BB2 /* AccountFlagView.swift in Sources */,
 				5BFBB28B2BD9D79F002E909F /* URLParser.swift in Sources */,
 				C930055F2A6AF8320098CA9E /* LoadingContent.swift in Sources */,
 				5B79F6462BA11725002DA9BE /* WizardSheetVStack.swift in Sources */,

--- a/Nos/Views/Components/FlagOptionPicker.swift
+++ b/Nos/Views/Components/FlagOptionPicker.swift
@@ -40,6 +40,7 @@ struct FlagOptionPicker: View {
         }
         .background(LinearGradient.cardBackground)
         .clipShape(RoundedRectangle(cornerRadius: 15))
+        .mimicCardButtonStyle()
     }
 }
 

--- a/Nos/Views/Moderation/AccountFlagView.swift
+++ b/Nos/Views/Moderation/AccountFlagView.swift
@@ -15,7 +15,7 @@ struct AccountFlagView: View {
             Color.appBg.ignoresSafeArea()
             Group {
                 if showSuccessView {
-                    successView
+                    flagSuccessView
                 } else {
                     categoryView
                 }
@@ -91,27 +91,6 @@ struct AccountFlagView: View {
         }
         .animation(.easeInOut, value: selectedFlagOptionCategory)
         .animation(.easeInOut, value: selectedSendOptionCategory)
-    }
-
-    private var successView: some View {
-        VStack(spacing: 30) {
-            Image.circularCheckmark
-                .resizable()
-                .aspectRatio(contentMode: .fit)
-                .frame(height: 116)
-
-            Text(String(localized: .localizable.thanksForTag))
-                .foregroundColor(.primaryTxt)
-                .font(.clarity(.regular, textStyle: .title2))
-                .padding(.horizontal, 62)
-
-            Text(String(localized: .localizable.keepOnHelpingUs))
-                .padding(.horizontal, 68)
-                .foregroundColor(.secondaryTxt)
-                .multilineTextAlignment(.center)
-                .lineSpacing(6)
-                .font(.clarity(.regular, textStyle: .subheadline))
-        }
     }
 }
 

--- a/Nos/Views/Moderation/AccountFlagView.swift
+++ b/Nos/Views/Moderation/AccountFlagView.swift
@@ -1,0 +1,142 @@
+import SwiftUI
+
+/// Displays pickers for selecting account flag option category, with additional stages shown
+/// based on previous selections.
+struct AccountFlagView: View {
+    @Binding var selectedFlagOptionCategory: FlagOption?
+    @Binding var selectedSendOptionCategory: FlagOption?
+    @Binding var selectedVisibilityOptionCategory: FlagOption?
+    @Binding var showSuccessView: Bool
+    var sendAction: () -> Void
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        ZStack {
+            Color.appBg.ignoresSafeArea()
+            Group {
+                if showSuccessView {
+                    successView
+                } else {
+                    categoryView
+                }
+            }
+            .padding()
+            .nosNavigationBar(title: .localizable.flagContent)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button(action: {
+                        dismiss()
+                        resetSelections()
+                    }, label: {
+                        Text(.localizable.cancel)
+                            .foregroundColor(.primaryTxt)
+                    })
+                    .opacity(showSuccessView ? 0 : 1)
+                    .disabled(showSuccessView)
+                }
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    ActionButton(
+                        title: showSuccessView ? .localizable.done : .localizable.send,
+                        action: {
+                            if showSuccessView {
+                                dismiss()
+                            } else {
+                                sendAction()
+                            }
+                        }
+                    )
+                    .opacity(selectedVisibilityOptionCategory == nil ? 0.5 : 1)
+                    .disabled(selectedVisibilityOptionCategory == nil)
+                }
+            }
+        }
+    }
+
+    private func resetSelections() {
+        selectedFlagOptionCategory = nil
+        selectedSendOptionCategory = nil
+        selectedVisibilityOptionCategory = nil
+    }
+
+    private var categoryView: some View {
+        ScrollView(showsIndicators: false) {
+            VStack(spacing: 30) {
+                FlagOptionPicker(
+                    selectedOption: $selectedFlagOptionCategory,
+                    options: FlagOption.flagContentCategories,
+                    title: String(localized: .localizable.reportContent),
+                    subtitle: String(localized: .localizable.reportContentMessage)
+                )
+
+                if selectedFlagOptionCategory != nil {
+                    FlagOptionPicker(
+                        selectedOption: $selectedSendOptionCategory,
+                        options: FlagOption.flagAccountSendCategories,
+                        title: String(localized: .localizable.flagContentSendTitle),
+                        subtitle: nil
+                    )
+                    .transition(.move(edge: .leading).combined(with: .opacity))
+                }
+
+                if selectedSendOptionCategory != nil {
+                    FlagOptionPicker(
+                        selectedOption: $selectedVisibilityOptionCategory,
+                        options: FlagOption.flagAccountVisibilityCategories,
+                        title: String(localized: .localizable.flagAccountMuteCategoryTitle),
+                        subtitle: nil
+                    )
+                    .transition(.move(edge: .leading).combined(with: .opacity))
+                }
+            }
+        }
+        .animation(.easeInOut, value: selectedFlagOptionCategory)
+        .animation(.easeInOut, value: selectedSendOptionCategory)
+    }
+
+    private var successView: some View {
+        VStack(spacing: 30) {
+            Image.circularCheckmark
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .frame(height: 116)
+
+            Text(String(localized: .localizable.thanksForTag))
+                .foregroundColor(.primaryTxt)
+                .font(.clarity(.regular, textStyle: .title2))
+                .padding(.horizontal, 62)
+
+            Text(String(localized: .localizable.keepOnHelpingUs))
+                .padding(.horizontal, 68)
+                .foregroundColor(.secondaryTxt)
+                .multilineTextAlignment(.center)
+                .lineSpacing(6)
+                .font(.clarity(.regular, textStyle: .subheadline))
+        }
+    }
+}
+
+#Preview {
+    struct PreviewWrapper: View {
+        @State private var selectedFlagOptionCategory: FlagOption?
+        @State private var selectedSendOptionCategory: FlagOption?
+        @State private var selectedVisibilityOptionCategory: FlagOption?
+        @State private var showSuccessView = false
+
+        var body: some View {
+            NavigationStack {
+                AccountFlagView(
+                    selectedFlagOptionCategory: $selectedFlagOptionCategory,
+                    selectedSendOptionCategory: $selectedSendOptionCategory,
+                    selectedVisibilityOptionCategory: $selectedVisibilityOptionCategory,
+                    showSuccessView: $showSuccessView,
+                    sendAction: {}
+                )
+            }
+            .onAppear {
+                selectedFlagOptionCategory = nil
+            }
+            .background(Color.appBg)
+        }
+    }
+    return PreviewWrapper()
+}

--- a/Nos/Views/Moderation/AccountFlagView.swift
+++ b/Nos/Views/Moderation/AccountFlagView.swift
@@ -7,8 +7,14 @@ struct AccountFlagView: View {
     @Binding var selectedSendOptionCategory: FlagOption?
     @Binding var selectedVisibilityOptionCategory: FlagOption?
     @Binding var showSuccessView: Bool
+
+    /// The target of the report.
+    let flagTarget: ReportTarget
     var sendAction: () -> Void
+
     @Environment(\.dismiss) private var dismiss
+
+    @State private var flagCategories: [FlagOption] = []
 
     var body: some View {
         ZStack {
@@ -21,7 +27,7 @@ struct AccountFlagView: View {
                 }
             }
             .padding()
-            .nosNavigationBar(title: .localizable.flagContent)
+            .nosNavigationBar(title: .localizable.flagUserTitle)
             .toolbar {
                 ToolbarItem(placement: .navigationBarLeading) {
                     Button(action: {
@@ -40,6 +46,8 @@ struct AccountFlagView: View {
                         action: {
                             if showSuccessView {
                                 dismiss()
+                                resetSelections()
+                                showSuccessView = false
                             } else {
                                 sendAction()
                             }
@@ -50,6 +58,9 @@ struct AccountFlagView: View {
                 }
             }
         }
+        .onAppear {
+            flagCategories = FlagOption.createFlagCategories(for: flagTarget)
+        }
     }
 
     private func resetSelections() {
@@ -59,13 +70,13 @@ struct AccountFlagView: View {
     }
 
     private var categoryView: some View {
-        ScrollView(showsIndicators: false) {
+        ScrollView {
             VStack(spacing: 30) {
                 FlagOptionPicker(
                     selectedOption: $selectedFlagOptionCategory,
-                    options: FlagOption.flagContentCategories,
-                    title: String(localized: .localizable.reportContent),
-                    subtitle: String(localized: .localizable.reportContentMessage)
+                    options: flagCategories,
+                    title: String(localized: .localizable.flagAccountCategoryTitle),
+                    subtitle: String(localized: .localizable.flagAccountCategoryDescription)
                 )
 
                 if selectedFlagOptionCategory != nil {
@@ -100,6 +111,7 @@ struct AccountFlagView: View {
         @State private var selectedSendOptionCategory: FlagOption?
         @State private var selectedVisibilityOptionCategory: FlagOption?
         @State private var showSuccessView = false
+        let author = Author()
 
         var body: some View {
             NavigationStack {
@@ -108,6 +120,7 @@ struct AccountFlagView: View {
                     selectedSendOptionCategory: $selectedSendOptionCategory,
                     selectedVisibilityOptionCategory: $selectedVisibilityOptionCategory,
                     showSuccessView: $showSuccessView,
+                    flagTarget: .author(author),
                     sendAction: {}
                 )
             }

--- a/Nos/Views/Moderation/ContentFlagView.swift
+++ b/Nos/Views/Moderation/ContentFlagView.swift
@@ -14,7 +14,7 @@ struct ContentFlagView: View {
             Color.appBg.ignoresSafeArea()
             Group {
                 if showSuccessView {
-                    successView
+                    flagSuccessView
                 } else {
                     categoryView
                 }
@@ -81,26 +81,26 @@ struct ContentFlagView: View {
             }
         }
     }
+}
 
-    private var successView: some View {
-        VStack(spacing: 30) {
-            Image.circularCheckmark
-                .resizable()
-                .aspectRatio(contentMode: .fit)
-                .frame(height: 116)
+var flagSuccessView: some View {
+    VStack(spacing: 30) {
+        Image.circularCheckmark
+            .resizable()
+            .aspectRatio(contentMode: .fit)
+            .frame(height: 116)
 
-            Text(String(localized: .localizable.thanksForTag))
-                .foregroundColor(.primaryTxt)
-                .font(.clarity(.regular, textStyle: .title2))
-                .padding(.horizontal, 62)
+        Text(String(localized: .localizable.thanksForTag))
+            .foregroundColor(.primaryTxt)
+            .font(.clarity(.regular, textStyle: .title2))
+            .padding(.horizontal, 62)
 
-            Text(String(localized: .localizable.keepOnHelpingUs))
-                .padding(.horizontal, 68)
-                .foregroundColor(.secondaryTxt)
-                .multilineTextAlignment(.center)
-                .lineSpacing(6)
-                .font(.clarity(.regular, textStyle: .subheadline))
-        }
+        Text(String(localized: .localizable.keepOnHelpingUs))
+            .padding(.horizontal, 68)
+            .foregroundColor(.secondaryTxt)
+            .multilineTextAlignment(.center)
+            .lineSpacing(6)
+            .font(.clarity(.regular, textStyle: .subheadline))
     }
 }
 

--- a/Nos/Views/Modifiers/ReportMenuModifier.swift
+++ b/Nos/Views/Modifiers/ReportMenuModifier.swift
@@ -201,9 +201,8 @@ struct ReportMenuModifier: ViewModifier {
         }
     }
     
-    /// Determines the visibility status for a flagged account and applies the appropriate action, such as muting the account.
-    /// If the selected visibility category is `.mute`, the author of the `reportedObject` will be muted.
-    /// - Parameter completion: A closure that is executed once the visibility determination and actions (if any) are complete.
+    /// Determines the visibility status for a flagged account and applies the appropriate action.
+    /// - Parameter completion: A closure that is executed once the necessary actions are complete.
     private func determineFlaggedAccoutVisibility(completion: () -> Void) {
         if let author = reportedObject.author {
             if case .visibility(let visibilityCategory) = selectedVisibilityOptionCategory?.category,

--- a/Nos/Views/Modifiers/ReportMenuModifier.swift
+++ b/Nos/Views/Modifiers/ReportMenuModifier.swift
@@ -63,7 +63,8 @@ struct ReportMenuModifier: ViewModifier {
                             selectedFlagOptionCategory: $selectedFlagOption,
                             selectedSendOptionCategory: $selectedFlagSendOption,
                             selectedVisibilityOptionCategory: $selectedVisibilityOptionCategory,
-                            showSuccessView: $showFlagSuccessView,
+                            showSuccessView: $showFlagSuccessView, 
+                            flagTarget: reportedObject,
                             sendAction: {
                                 if let selectCategory = selectedVisibilityOptionCategory?.category {
                                     publishReportForNewModerationFlow(selectCategory)


### PR DESCRIPTION
## Issues covered
Part 2 of [#1493](https://github.com/planetary-social/nos/issues/1493)

## Description
This PR includes the new moderation flow to send a user flag publicly or privately, including muting/ unmuting a user.

## How to test
1. Build the app
2. Click the side menu
3. Click the Settings on the side menu
4. Scroll down to turn on the toggle for new moderation flow
5. Go back to the Feed screen by clicking the feed tab at the bottom of the screen
6. Find an account, Click on the 3 dots at the top right of the account.
7. Select `Flag this user` option. 
8. Select an option from the categories displayed.
9. Select an option on how to send the flag.
10. Select an option on whether to mute a user or not.
11. Click send.
12. Please confirm that:
    - The send button at the top right is disabled with opacity until the last selection is made.
    - The send button at the top right is enabled with no opacity when the last selection is made.
    - The send button at the top right changes to a done button when the success screen shows.
    - The cancel button at the top left is hidden when the success screen shows.
    - The right flag category, "how to send" and mute options are sent.

## Screenshots/Video

https://github.com/user-attachments/assets/8d31b133-bb2c-4db5-90a6-1f7f3cd858da
