### PR TITLE
Remove Martin (temporarily) from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # CODEOWNERS
 
 # The default owners for everything in the repo.
-* @mplorentz @martindsq @joshuatbrown
+* @mplorentz @joshuatbrown


### PR DESCRIPTION
## Issues covered
None

## Description
Since Martin is taking some time off for the next few months, this removes him from CODEOWNERS. This will mean he's not automatically requested for PR reviews.