### PR TITLE
Try harder to fix Crowdin GitHub integration

### DIFF
--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -18,6 +18,7 @@ jobs:
           upload_sources: true
           upload_translations: false
           download_translations: true
+          skip_untranslated_files: false
           localization_branch_name: l10n_crowdin_translations
           create_pull_request: true
           pull_request_title: 'New Crowdin Translations'


### PR DESCRIPTION
## Issues covered
#1520 

## Description
#1553 was a good start, but we need to do more, like download partially-translated files. At least, that seems to be one issue, based on this:

https://github.com/planetary-social/nos/actions/runs/11109870777/job/30871802506#step:4:44

> ⚠️  Couldn't find any file to download. Since you are using the 'Skip untranslated files' option, please make sure you have fully translated files

## How to test
Merge and see
