### PR TITLE
Crowdin: use the GITHUB_TOKEN that’s magically there

### DIFF
--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -26,7 +26,7 @@ jobs:
           pull_request_base_branch_name: 'main'
         env:
           # A classic GitHub Personal Access Token with the 'repo' scope selected (the user should have write access to the repository).
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           
           # A numeric ID, found at https://crowdin.com/project/<projectName>/tools/api
           CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}


### PR DESCRIPTION
## Issues covered
#1520 

## Description
OK, so #1553 and #1564 didn't work, but this might, because there's a magic GITHUB_TOKEN that just exists and we shouldn't need to add a new GH_TOKEN to our Actions secrets.

## How to test
Merge and pray
