### PR TITLE
Don’t require Crowdin bot to sign the CLA

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -32,7 +32,7 @@ jobs:
           path-to-document: 'https://github.com/planetary-social/nos/blob/main/CLA.md' # e.g. a CLA or a DCO document
           # branch should not be protected
           branch: 'cla-signatures'
-          #allowlist: user1,bot*
+          allowlist: crowdin-bot
 
          # the followings are the optional inputs - If the optional inputs are not given, then default values will be taken
           #remote-organization-name: enter the remote organization name where the signatures should be stored (Default is storing the signatures in the same repository)


### PR DESCRIPTION
## Issues covered
#1520 

## Description
The CLA Assistant was requiring a signature from the Crowdin bot, but that's ridiculous.

https://github.com/planetary-social/nos/pull/1573#issuecomment-2389687539

## How to test
1. Wait until Crowdin bot creates a new translation PR.
2. Make sure CLA Assistant doesn't request a signature.