### PR TITLE
Update flag views and NavigationBarTitle font

### DIFF
--- a/Nos/Views/Components/FlagOptionPicker.swift
+++ b/Nos/Views/Components/FlagOptionPicker.swift
@@ -166,6 +166,7 @@ private struct HeaderView: View {
             .lineSpacing(5)
             .foregroundColor(.primaryTxt)
             .font(.headline)
+            .fontWeight(.semibold)
             .padding(.bottom, 10)
     }
 }

--- a/Nos/Views/Components/FlagOptionPicker.swift
+++ b/Nos/Views/Components/FlagOptionPicker.swift
@@ -114,12 +114,12 @@ private struct FlagPickerRow: View {
             VStack(alignment: .leading, spacing: 8) {
                 Text(flag.title)
                     .foregroundColor(.primaryTxt)
-                    .font(.clarity(.regular))
+                    .font(.body)
 
                 if let description = flag.description {
                     Text(description)
                         .foregroundColor(.secondaryTxt)
-                        .font(.clarity(.regular, textStyle: .footnote))
+                        .font(.footnote)
                         .lineSpacing(8)
                         .multilineTextAlignment(.leading)
                         .fixedSize(horizontal: false, vertical: true) // this enables the text view expand as needed
@@ -141,7 +141,7 @@ private struct FlagPickerRow: View {
             VStack {
                 Text(text)
                     .foregroundColor(.primaryTxt)
-                    .font(.clarity(.regular, textStyle: .subheadline))
+                    .font(.subheadline)
                     .multilineTextAlignment(.leading)
                     .padding(EdgeInsets(
                         top: 13,
@@ -165,7 +165,7 @@ private struct HeaderView: View {
         Text(text)
             .lineSpacing(5)
             .foregroundColor(.primaryTxt)
-            .font(.clarity(.bold))
+            .font(.headline)
             .padding(.bottom, 10)
     }
 }

--- a/Nos/Views/Components/NosNavigationBar.swift
+++ b/Nos/Views/Components/NosNavigationBar.swift
@@ -10,7 +10,7 @@ struct NosNavigationBarModifier: ViewModifier {
             .toolbar {
                 ToolbarItem(placement: .principal) {
                     Text(title)
-                        .font(.clarity(.bold, textStyle: .title3))
+                        .font(.title3)
                         .foregroundColor(.primaryTxt)
                         .tint(.primaryTxt)
                         .allowsHitTesting(false)

--- a/Nos/Views/Components/NosNavigationBar.swift
+++ b/Nos/Views/Components/NosNavigationBar.swift
@@ -11,6 +11,7 @@ struct NosNavigationBarModifier: ViewModifier {
                 ToolbarItem(placement: .principal) {
                     Text(title)
                         .font(.title3)
+                        .fontWeight(.bold)
                         .foregroundColor(.primaryTxt)
                         .tint(.primaryTxt)
                         .allowsHitTesting(false)

--- a/Nos/Views/Moderation/FlagSuccessView.swift
+++ b/Nos/Views/Moderation/FlagSuccessView.swift
@@ -11,7 +11,7 @@ struct FlagSuccessView: View {
 
             Text(String(localized: .localizable.thanksForTag))
                 .foregroundColor(.primaryTxt)
-                .font(.clarity(.regular, textStyle: .title2))
+                .font(.title2)
                 .padding(.horizontal, 25)
 
             Text(String(localized: .localizable.keepOnHelpingUs))
@@ -19,7 +19,7 @@ struct FlagSuccessView: View {
                 .foregroundColor(.secondaryTxt)
                 .multilineTextAlignment(.center)
                 .lineSpacing(6)
-                .font(.clarity(.regular, textStyle: .subheadline))
+                .font(.body)
         }
     }
 }


### PR DESCRIPTION
## Issues covered
#1493
#1489

## Description
This PR updates the font in the Flag Views and `NavigationBarTitle` to use `SF Pro` font instead of `Clarity`.

## How to test
1.Build the app
2. Click the side menu
3. Click the Settings on the side menu
4. Scroll down to turn on the toggle for new moderation flow
5. Go back to the Feed screen by clicking the feed tab at the bottom of the screen
6. Find a user or note to flag.
7. Select `Flag this user` or `Flag this content` option. 
8. Select an option from the categories displayed.
9. Select an option on how to send the flag.
11. Click send.
12. Please confirm that:
      - The fonts are `SF Pro` and not `Clarity`
      - The navigation title is using the `SF Pro` font and not `Clarity`.

## Screenshots/Video
| Before | After |
|--------|-------|
| <img src="https://github.com/user-attachments/assets/79622135-580e-4119-bdbc-f506bafdeefe" alt="Before" width="250"/> | <img src="https://github.com/user-attachments/assets/0bcaef3a-4679-42ff-9f1b-20edb7501ad7" alt="After" width="250"/> |
| <img src="https://github.com/user-attachments/assets/d83cb5c4-943f-48e9-91c9-d428cf725946" alt="Before" width="250"/> | <img src="https://github.com/user-attachments/assets/ffb6d828-69ec-4e05-a43c-73c804e850d7" alt="After" width="250"/> |
