### PR TITLE
performance improvements for AuthorLabel #1458

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update Xcode to version 15.4, adding compatibility for Xcode 16.
 - Reduced spammy "Failed to parse Follow" log messages.
 - Upgraded fastlane to version 2.223.1.
+- Improve performance of AuthorLabel. [#1458](https://github.com/planetary-social/nos/issues/1458)
 
 ## [0.2.1] - 2024-10-01Z
 

--- a/Nos/Views/Components/Author/AuthorLabel.swift
+++ b/Nos/Views/Components/Author/AuthorLabel.swift
@@ -2,27 +2,38 @@ import SwiftUI
 
 struct AuthorLabel: View {
     
-    @ObservedObject var author: Author
-    var note: Event?
-    
-    private var attributedAuthor: AttributedString {
-        var authorName = AttributedString(author.safeName)
-        authorName.foregroundColor = .primaryTxt
-        authorName.font = .clarity(.semibold)
-        if let note {
-            let postedOrRepliedString = String(localized: note.isReply ? .reply.replied : .reply.posted)
-            var postedOrReplied = AttributedString(" " + postedOrRepliedString)
-            postedOrReplied.foregroundColor = .secondaryTxt
-            
-            authorName.append(postedOrReplied)
+    final class Cache: ObservableObject {
+        let attributedAuthor: AttributedString
+        
+        init(safeName: String, isReply: Bool?) {
+            var authorName = AttributedString(safeName)
+            authorName.foregroundColor = .primaryTxt
+            authorName.font = .clarity(.semibold)
+            if let isReply {
+                let postedOrRepliedString = String(localized: isReply ? "replied" : "posted")
+                var postedOrReplied = AttributedString(" " + postedOrRepliedString)
+                postedOrReplied.foregroundColor = .secondaryTxt
+                
+                authorName.append(postedOrReplied)
+            }
+            attributedAuthor = authorName
         }
-        return authorName
+    }
+    
+    let profilePhotoURL: URL?
+    
+    @StateObject var cache: Cache
+    
+    init(safeName: String, profilePhotoURL: URL?, isReply: Bool? = nil) {
+        self.profilePhotoURL = profilePhotoURL
+        
+        _cache = StateObject(wrappedValue: Cache(safeName: safeName, isReply: isReply))
     }
 
     var body: some View {
         HStack {
-            AvatarView(imageUrl: author.profilePhotoURL, size: 24)
-            Text(attributedAuthor)
+            AvatarView(imageUrl: profilePhotoURL, size: 24)
+            Text(cache.attributedAuthor)
                 .lineLimit(1)
                 .font(.clarity(.medium))
                 .multilineTextAlignment(.leading)
@@ -34,6 +45,10 @@ struct AuthorLabel: View {
 struct AuthorLabel_Previews: PreviewProvider {
     static var previewData = PreviewData()
     static var previews: some View {
-        AuthorLabel(author: previewData.previewAuthor)
+        let author = previewData.previewAuthor
+        return AuthorLabel(
+            safeName: author.safeName,
+            profilePhotoURL: author.profilePhotoURL
+        )
     }
 }

--- a/Nos/Views/Components/Button/NoteButton.swift
+++ b/Nos/Views/Components/Button/NoteButton.swift
@@ -99,7 +99,7 @@ struct NoteButton: View {
                     router.push(author)
                 }, label: { 
                     HStack(alignment: .center) {
-                        AuthorLabel(author: author)
+                        AuthorLabel(safeName: author.safeName, profilePhotoURL: author.profilePhotoURL)
                         Image.repostSymbol
                         if let elapsedTime = note.createdAt?.distanceString() {
                             Text(elapsedTime)

--- a/Nos/Views/Note/NoteCardHeader.swift
+++ b/Nos/Views/Note/NoteCardHeader.swift
@@ -2,12 +2,16 @@ import SwiftUI
 
 struct NoteCardHeader: View {
     
-    @ObservedObject var note: Event
-    @ObservedObject var author: Author
+    let note: Event
+    let author: Author
     
     var body: some View {
         HStack(alignment: .center) {
-            AuthorLabel(author: author, note: note)
+            AuthorLabel(
+                safeName: author.safeName,
+                profilePhotoURL: author.profilePhotoURL,
+                isReply: note.isReply
+            )
             Spacer()
             if let expirationTime = note.expirationDate?.distanceString() {
                 Image.disappearingMessages


### PR DESCRIPTION
## Issues covered
#1458 

## Description
This is a small step in improving the scroll performance of the app and is meant to be a pattern check for other devs. If these changes are acceptable, then we could implement similar changes widely.

My goal here was to identify and address one small performance issue. Here is the profiling scenario to repeat between changes:

## How to test
1. While signed in to the app build it for profiling by click-and-hold-ing on the Play button and dragging to select Profile.
2. When Instruments opens, select the SwiftUI instrument.
3. Click the red record button to begin profiling.
4. Once the app settles on the feed, do two strong flings to move down the feed.
5. Stop the recording.
6. Click and drag left to right to select the area of time during the two flings.
7. Select the "View body" instrument, and observe the results.
The "View body" instrument gives you the count and duration of SwiftUI view body methods for all the views in the app. If you sort the results by "Total Duration", you'll see the "worst performance offenders". The "Average Duration" is also very important to look at, but it must be considered in combination with the total number of redraws.

Here's how the ranking looks before the changes in this PR:
![before_changes](https://github.com/user-attachments/assets/88a91bb2-11d8-4844-8aa2-225331ebad4b)
Here you see that `AuthorLabel` was drawn 29 times for a total of 33.32ms. This is miserable performance. At 60Hz, a single frame *must* take less than 16.67ms overall, so we want individual views' times to be MUCH less than that.

After only removing the xcstringstool usage in `AuthorLabel` let's run the same test again:
![after string change](https://github.com/user-attachments/assets/af0d6fcf-e6a9-466d-9e70-aa430173f603)
This time you see around the same number of redraws, but each one takes 1/10th the time! This is a lot better, but we're still adding up to milliseconds here, and we'd prefer to get it lower.

The next big performance improvement is to cache the result of the `attributedAuthor` method, which is taking too long, in a view-scoped cache. I also made another change to pass only the relevant properties of `Author` to this view, rather than the entire object. This is good practice regardless of performance.
![after all changes](https://github.com/user-attachments/assets/118d098c-4ccc-445e-8b67-1898c611241b)
Now we see the performance we want to get from this view. Even with 22 redraws, the total time is on the order of hundreds of microseconds.
