### PR TITLE
performance improvements for NoteOptionsButton #1458

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update Xcode to version 15.4, adding compatibility for Xcode 16.
 - Reduced spammy "Failed to parse Follow" log messages.
 - Upgraded fastlane to version 2.223.1.
+- Improved performance of NoteOptionsButton. [#1458](https://github.com/planetary-social/nos/issues/1458)
 
 ## [0.2.1] - 2024-10-01Z
 

--- a/Nos/Views/Components/Button/NoteOptionsButton.swift
+++ b/Nos/Views/Components/Button/NoteOptionsButton.swift
@@ -28,51 +28,51 @@ struct NoteOptionsButton: View {
                     // This hack fixes a weird issue where the confirmationDialog wouldn't be shown sometimes. ¯\_(ツ)_/¯
                     .background(showingOptions == true ? .clear : .clear)
             }
-            .confirmationDialog(String(localized: .localizable.share), isPresented: $showingOptions) {
-                Button(String(localized: .localizable.copyNoteIdentifier)) {
+            .confirmationDialog("share", isPresented: $showingOptions) {
+                Button("copyNoteIdentifier") {
                     analytics.copiedNoteIdentifier()
                     copyMessageIdentifier()
                 }
-                Button(String(localized: .localizable.shareNote)) {
+                Button("shareNote") {
                     showingShare = true
                     analytics.sharedNoteLink()
                 }
                 if !note.isStub {
-                    Button(String(localized: .localizable.copyNoteText)) {
+                    Button("copyNoteText") {
                         analytics.copiedNoteText()
                         copyMessage()
                     }
-                    Button(String(localized: .localizable.viewSource)) {
+                    Button("viewSource") {
                         analytics.viewedNoteSource()
                         showingSource = true
                     }
                     if note.author != currentUser.author {
-                        Button(String(localized: .localizable.reportNote)) {
+                        Button("reportNote") {
                             showingReportMenu = true
                         }
                     }
                 }
                 if note.author == currentUser.author {
-                    Button(String(localized: .localizable.deleteNote), role: .destructive) {
+                    Button("deleteNote", role: .destructive) {
                         confirmDelete = true
                     }
                 }
             }
             .reportMenu($showingReportMenu, reportedObject: .note(note))
             .alert(
-                String(localized: .localizable.confirmDelete),
+                "confirmDelete",
                 isPresented: $confirmDelete,
                 actions: {
-                    Button(String(localized: .localizable.confirm), role: .destructive) {
+                    Button("confirm", role: .destructive) {
                         analytics.deletedNote()
                         Task { await deletePost() }
                     }
-                    Button(String(localized: .localizable.cancel), role: .cancel) {
+                    Button("cancel", role: .cancel) {
                         confirmDelete = false
                     }
                 },
                 message: {
-                    Text(.localizable.deleteNoteConfirmation)
+                    Text("deleteNoteConfirmation")
                 }
             )
             .sheet(isPresented: $showingSource) {


### PR DESCRIPTION
## Issues covered
#1458 

## Description
Simply by changing from xcstringstool's generated strings helpers to the localization mechanism, `NoteOptionsButton`'s body method now takes 1 / 70th of the amount of time!

## How to test

1. While signed in to the app build it for profiling by click-and-hold-ing on the Play button and dragging to select Profile.
2. When Instruments opens, select the SwiftUI instrument.
3. Click the red record button to begin profiling.
4. Once the app settles on the feed, do two strong flings to move down the feed.
5. Stop the recording.
6. Click and drag left to right to select the area of time during the two flings.
7. Select the "View body" instrument, and observe the results.
The "View body" instrument gives you the count and duration of SwiftUI view body methods for all the views in the app. If you sort the results by "Total Duration", you'll see the "worst performance offenders". The "Average Duration" is also very important to look at, but it must be considered in combination with the total number of redraws.

## Screenshots/Video
Before changes:
<img width="930" alt="before" src="https://github.com/user-attachments/assets/65b40dd5-7f38-42b8-b593-a22680e1bde9">

After changes:
<img width="889" alt="after" src="https://github.com/user-attachments/assets/d1f2cf31-b12c-490f-bf55-68d4a4f9de47">

Strings are still localized:
![Simulator Screenshot - iPhone 15 - 2024-10-07 at 06 37 17](https://github.com/user-attachments/assets/e84f3f55-a591-4a13-b817-a599a06fa3fa)


