### PR TITLE
Remove account deletion feature flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed image and video link text from notes. Now only the images and videos will appear, without the link. [#1487](https://github.com/planetary-social/nos/issues/1487)
 - Added new translations for the app so you can use it in Korean, Chinese Simplified, Swedish, and more! Thanks to alternative, 안마리 (everyscreennetwork), Andypsl8, Dženan (Dzenan), ObjectifMoon, ra5pvt1n, and everyone else who contributed translations on Crowdin!
 - Decreased the opacity on disabled buttons.
+- Added a Delete Account button to the Settings screen. [#80](https://github.com/planetary-social/nos/issues/80)
 
 ### Internal Changes
 - Fix the Crowdin GitHub integration by using the official GitHub action. [#1520](https://github.com/planetary-social/nos/issues/1520)

--- a/Nos/Service/FeatureFlags.swift
+++ b/Nos/Service/FeatureFlags.swift
@@ -7,9 +7,6 @@ enum FeatureFlag {
     /// Whether the new moderation flow should be enabled or not.
     /// - Note: See [#1489](https://github.com/planetary-social/nos/issues/1489) for details on the new moderation flow.
     case newModerationFlow
-    /// Whether delete account UI is enabled or not.
-    /// - Note: See [#80](https://github.com/planetary-social/nos/issues/80) for details on deleting accounts.
-    case deleteAccount
 }
 
 /// The set of feature flags used by the app.
@@ -34,7 +31,6 @@ protocol FeatureFlags {
     /// Feature flags and their values.
     private var featureFlags: [FeatureFlag: Bool] = [
         .newModerationFlow: false,
-        .deleteAccount: false
     ]
 
     /// Returns true if the feature is enabled.

--- a/Nos/Views/Settings/SettingsView.swift
+++ b/Nos/Views/Settings/SettingsView.swift
@@ -219,31 +219,27 @@ struct SettingsView: View {
             }
             .listRowGradientBackground()
             
-            #if STAGING || DEBUG
-            if isDeleteAccountEnabled.wrappedValue {
-                ActionButton(
-                    title: .localizable.deleteMyAccount,
-                    font: .clarityBold(.title3),
-                    padding: EdgeInsets(top: 16, leading: 0, bottom: 16, trailing: 0),
-                    depthEffectColor: .actionSecondaryDepthEffect,
-                    backgroundGradient: .verticalAccentSecondary,
-                    shouldFillHorizontalSpace: true
-                ) {
-                    alert = AlertState(
-                        title: { TextState(String(localized: .localizable.deleteAccount)) },
-                        actions: {
-                            ButtonState(role: .destructive, action: .send(.deleteAccount)) {
-                                TextState(String(localized: .localizable.delete))
-                            }
-                        },
-                        message: { TextState(String(localized: .localizable.deleteAccountDescription)) }
-                    )
-                }
-                .clipShape(Capsule())
-                .listRowBackground(Color.clear)
-                .listRowInsets(EdgeInsets())
+            ActionButton(
+                title: .localizable.deleteMyAccount,
+                font: .clarityBold(.title3),
+                padding: EdgeInsets(top: 16, leading: 0, bottom: 16, trailing: 0),
+                depthEffectColor: .actionSecondaryDepthEffect,
+                backgroundGradient: .verticalAccentSecondary,
+                shouldFillHorizontalSpace: true
+            ) {
+                alert = AlertState(
+                    title: { TextState(String(localized: .localizable.deleteAccount)) },
+                    actions: {
+                        ButtonState(role: .destructive, action: .send(.deleteAccount)) {
+                            TextState(String(localized: .localizable.delete))
+                        }
+                    },
+                    message: { TextState(String(localized: .localizable.deleteAccountDescription)) }
+                )
             }
-        #endif
+            .clipShape(Capsule())
+            .listRowBackground(Color.clear)
+            .listRowInsets(EdgeInsets())
         }
         .scrollContentBackground(.hidden)
         .background(Color.appBg)
@@ -288,19 +284,6 @@ extension SettingsView {
     private var newModerationFlowToggle: some View {
         NosToggle(isOn: isNewModerationFlowEnabled, labelText: .localizable.enableNewModerationFlow)
     }
-    
-    /// Whether account deletion is enabled.
-    private var isDeleteAccountEnabled: Binding<Bool> {
-        Binding<Bool>(
-            get: { featureFlags.isEnabled(.deleteAccount) },
-            set: { featureFlags.setFeature(.deleteAccount, enabled: $0) }
-        )
-    }
-    
-    /// A toggle for account deletion that allows the user to turn the feature on or off.
-    private var deleteAccountToggle: some View {
-        NosToggle(isOn: isDeleteAccountEnabled, labelText: .localizable.enableAccountDeletion)
-    }
 }
 #endif
 
@@ -322,7 +305,6 @@ extension SettingsView {
     @MainActor private var debugControls: some View {
         Group {
             newModerationFlowToggle
-            deleteAccountToggle
             Text(.localizable.sampleDataInstructions)
                 .foregroundColor(.primaryTxt)
             Button(String(localized: .localizable.loadSampleData)) {

--- a/NosTests/Service/MockFeatureFlags.swift
+++ b/NosTests/Service/MockFeatureFlags.swift
@@ -3,7 +3,6 @@ class MockFeatureFlags: FeatureFlags {
     /// Mock feature flags and their values.
     private var featureFlags: [FeatureFlag: Bool] = [
         .newModerationFlow: false,
-        .deleteAccount: false
     ]
 
     func isEnabled(_ feature: FeatureFlag) -> Bool {


### PR DESCRIPTION
## Issues covered
#80

## Description
This removes the account deletion feature flag to enable the functionality implemented so far. The only part that is unfinished is having the user type "DELETE ACCOUNT" to confirm deletion. But I want to go ahead and merge this so I can submit a build to App Store review. I ran it by Linda and she is ok with shipping this in two parts.

## How to test
1. Launch Nos
2. Open Settings from the side menu
3. Verify that the Delete Account button is present and there is no feature flag for it.

## Screenshots/Video
| Before | After |
|--------|--------|
|  ![simulator_screenshot_3C973AB7-B649-40C5-BD7C-EC84F01EE9B6](https://github.com/user-attachments/assets/0172a8a4-e13b-4255-a892-8cfec60f58e1)| ![simulator_screenshot_2A29ED8F-0253-4C98-9319-ABE7C9CE882A](https://github.com/user-attachments/assets/2ccc34d9-8fff-44a5-a35c-e1e92bec584b) |