### PR TITLE
Remove reference to account deletion flag in staging builds

### DIFF
--- a/Nos/Views/Settings/SettingsView.swift
+++ b/Nos/Views/Settings/SettingsView.swift
@@ -293,7 +293,6 @@ extension SettingsView {
     @MainActor private var stagingControls: some View {
         Group {
             newModerationFlowToggle
-            deleteAccountToggle
         }
     }
 }


### PR DESCRIPTION
## Issues covered
A followup to https://github.com/planetary-social/nos/pull/1612

## Description
I forgot to remove a reference to the account deletion feature flag in a section of the code that only compiles for staging builds. I considered setting up a workflow to run the tests with the `STAGING` flag enabled, but that seems like a lot of work (and Github Actions time/money) for an edge case that should always be caught before it is deployed to users. So I'm ok with how things are but I'm open to discussing that.

## How to test
1. Build Nos with the Nos Staging scheme.
It should compile successfully.