### PR TITLE
Run swift-format on all files

### DIFF
--- a/.swift-format
+++ b/.swift-format
@@ -1,0 +1,6 @@
+{
+    "lineLength": 120,
+    "indentation" : {
+        "spaces" : 4
+    }
+}

--- a/Nos/AppController.swift
+++ b/Nos/AppController.swift
@@ -1,25 +1,25 @@
-import Foundation
 import Dependencies
-import SwiftUI
+import Foundation
 import Logger
+import SwiftUI
 
 @Observable class AppController {
-    
+
     enum CurrentState {
         case onboarding
         case loggedIn
     }
-    
+
     private(set) var currentState: CurrentState?
-    
+
     @ObservationIgnored @Dependency(\.analytics) private var analytics
     @ObservationIgnored @Dependency(\.router) private var router
     @ObservationIgnored @Dependency(\.currentUser) private var currentUser
-    
+
     init() {
         Log.info("App Version: \(Bundle.current.versionAndBuild)")
     }
-    
+
     func configureCurrentState() {
         currentState = currentUser.keyPair == nil ? .onboarding : .loggedIn
         Task { @MainActor in
@@ -29,7 +29,7 @@ import Logger
             }
         }
     }
-    
+
     @MainActor func completeOnboarding() {
         router.sideMenuPath = NavigationPath()
         router.closeSideMenu()

--- a/Nos/AppDelegate.swift
+++ b/Nos/AppDelegate.swift
@@ -1,9 +1,9 @@
-import Foundation
-import UIKit
-import Logger
 import Dependencies
+import Foundation
+import Logger
 import SDWebImage
 import SDWebImageWebPCoder
+import UIKit
 
 class AppDelegate: NSObject, UIApplicationDelegate {
 

--- a/Nos/Controller/ContentWarningController.swift
+++ b/Nos/Controller/ContentWarningController.swift
@@ -5,25 +5,25 @@ enum ContentWarningType {
     case note
 }
 
-/// A class that takes a collection of content reports and generates a content warning string that can be 
+/// A class that takes a collection of content reports and generates a content warning string that can be
 /// displayed to the user.
 @Observable class ContentWarningController {
-    
+
     var reports: [Event]
     var type: ContentWarningType
-    
+
     init(reports: [Event] = [Event](), type: ContentWarningType = .note) {
         self.reports = reports
         self.type = type
     }
-    
+
     /// A warning that is generated based on the given `reports` and `types` explaining what this content was reported
     /// for and by whom.
     var localizedContentWarning: LocalizedStringResource {
         guard !reports.isEmpty else {
             return .localizable.anErrorOccurred
         }
-        
+
         switch type {
         case .author:
             if authorNames.count > 1 {
@@ -39,20 +39,21 @@ enum ContentWarningType {
             }
         }
     }
-    
+
     /// The names of the authors who made reports
     private var authorNames: [String] {
         Array(Set(reports.compactMap { $0.author?.name })).sorted()
     }
-    
+
     /// The name of the first author in the list of reports
     private var firstAuthorSafeName: String {
         authorNames.first ?? String(localized: .localizable.unknownAuthor)
     }
-    
+
     /// The string explaining the reason(s) for the reports.
     private var reason: String {
-        let reasons = uniqueReasons
+        let reasons =
+            uniqueReasons
             .filter { !$0.isEmpty }
             .sorted()
             .joined(separator: ", ")
@@ -62,7 +63,7 @@ enum ContentWarningType {
             return reasons
         }
     }
-    
+
     /// A set of all the reasons from all reports
     private var uniqueReasons: Set<String> {
         var reasons = [String]()
@@ -73,7 +74,7 @@ enum ContentWarningType {
         }
         return Set(reasons.map { $0.lowercased() })
     }
-    
+
     /// Extracts a human readable string explaining the reason for the given report `Event`.
     private func reasonString(from report: Event) -> String? {
         if let reportTags = report.allTags as? [[String]] {
@@ -81,13 +82,13 @@ enum ContentWarningType {
             for tag in reportTags where tag.count >= 2 {
                 let reasonCode = tag[1]
                 if reasonCode.hasPrefix("MOD>") {
-                    let codeSuffix = String(reasonCode.dropFirst(4)) // Drop "MOD>" prefix
+                    let codeSuffix = String(reasonCode.dropFirst(4))  // Drop "MOD>" prefix
                     if let reportCategory = ReportCategory.findCategory(from: codeSuffix) {
                         return reportCategory.displayName
                     }
-                } 
+                }
             }
-            
+
             // Look for report type
             for tag in reportTags where tag.count >= 2 {
                 var tagType: String
@@ -99,10 +100,10 @@ enum ContentWarningType {
                 }
                 if tag[safe: 0] == tagType, tag.count >= 3 {
                     return tag[2]
-                } 
+                }
             }
         }
-        
+
         // fall back to `content`
         if let contentReason = report.content, contentReason.isEmpty == false {
             return contentReason

--- a/Nos/Controller/FetchRequestPublisher.swift
+++ b/Nos/Controller/FetchRequestPublisher.swift
@@ -1,20 +1,20 @@
-import Foundation
 import Combine
 import CoreData
+import Foundation
 
 /// Create by passing in a FetchedResultsController
 /// This will perform the fetch request on the correct queue and publish the resutls on the
 /// publishers.
 /// source: https://gist.github.com/josephlord/0d6a9d0871bd2e1b3a3bdbf20c184f88
-/// 
+///
 final class FetchedResultsControllerPublisher<FetchType> where FetchType: NSFetchRequestResult {
-    
+
     private let internalFRCP: FetchedResultsControllerPublisherInternal<FetchType>
-    
+
     /// Pass in a configured fetchResults controller and this class will provide a choice of publishers
     /// for you depending on how you like your errors
     init(
-        fetchedResultsController: NSFetchedResultsController<FetchType>, 
+        fetchedResultsController: NSFetchedResultsController<FetchType>,
         performFetchNotRequired: Bool = false
     ) {
         self.internalFRCP = FetchedResultsControllerPublisherInternal(
@@ -22,7 +22,7 @@ final class FetchedResultsControllerPublisher<FetchType> where FetchType: NSFetc
             performFetch: !performFetchNotRequired
         )
     }
-    
+
     lazy var publisher: AnyPublisher<[FetchType], Never> = {
         self.internalFRCP.publisher.replaceError(with: []).eraseToAnyPublisher()
     }()
@@ -30,8 +30,8 @@ final class FetchedResultsControllerPublisher<FetchType> where FetchType: NSFetc
 
 // swiftlint:disable:next type_name
 private final class FetchedResultsControllerPublisherInternal<FetchType>: NSObject, NSFetchedResultsControllerDelegate
-    where FetchType: NSFetchRequestResult {
-    
+where FetchType: NSFetchRequestResult {
+
     let publisher: PassthroughSubject<[FetchType], Error>
     let fetchedResultsController: NSFetchedResultsController<FetchType>
     init(fetchedResultsController: NSFetchedResultsController<FetchType>, performFetch: Bool) {
@@ -50,7 +50,7 @@ private final class FetchedResultsControllerPublisherInternal<FetchType>: NSObje
             }
         }
     }
-    
+
     @objc func controllerDidChangeContent(_ controller: NSFetchedResultsController<NSFetchRequestResult>) {
         publisher.send(fetchedResultsController.fetchedObjects ?? [])
     }

--- a/Nos/Controller/NoteEditorController.swift
+++ b/Nos/Controller/NoteEditorController.swift
@@ -4,27 +4,27 @@ import UIKit
 
 /// A controller for Nostr note text that is being edited. This controller pairs with a `NoteUITextViewRepresentable`
 /// to help our SwiftUI views interact with a UITextView cleanly.
-/// 
+///
 /// To use: instantiate and pass into a `NoteTextEditor` view. You can retrieve the typed text via the `text` property
-/// when the user indicates they are ready to post it.  
+/// when the user indicates they are ready to post it.
 @Observable class NoteEditorController: NSObject, UITextViewDelegate {
 
-    /// The height that fits all entered text. This value will be updated by `NoteUITextViewRepresentable` 
-    /// automatically, and should be used to set the frame of `NoteUITextViewRepresentable` from SwiftUI. This is done 
+    /// The height that fits all entered text. This value will be updated by `NoteUITextViewRepresentable`
+    /// automatically, and should be used to set the frame of `NoteUITextViewRepresentable` from SwiftUI. This is done
     /// to work around some incompatibilities between UIKit and SwiftUI where the UITextView won't expand properly.
     var intrinsicHeight: CGFloat = 0
-    
+
     /// A variable that controls whether the mention autocomplete window should be shown. This window is triggered
     /// by typing an '@' symbol and allows the user to search for another user to mention in their note.
     var showMentionsAutocomplete = false
-    
+
     /// The view the user will use for editing. Should only be set by ``NoteTextEditor/NoteUITextViewRepresentable``.
     var textView: UITextView? {
         didSet {
             textView?.delegate = self
         }
     }
-    
+
     /// Whether the user has entered any text.
     var isEmpty = true
 
@@ -36,37 +36,37 @@ import UIKit
             return nil
         }
     }
-    
-    /// The attributed string attributes that should be applied to normal text the user types in the text field. 
+
+    /// The attributed string attributes that should be applied to normal text the user types in the text field.
     private var defaultStringAttributes: [NSAttributedString.Key: Any]
-    
+
     init(font: UIFont = .preferredFont(forTextStyle: .body), foregroundColor: UIColor = .primaryTxt) {
         self.defaultStringAttributes = [
             .font: font,
-            .foregroundColor: foregroundColor
+            .foregroundColor: foregroundColor,
         ]
     }
-    
+
     // MARK: - Mutating Text
-    
+
     /// Inserts the name of an author at the current cursor position with a nostr link attached as an attribute.
     func insertMention(of author: Author) {
         guard let textView else { return }
-        self.insertMention(of: author, at: textView.selectedRange) 
+        self.insertMention(of: author, at: textView.selectedRange)
     }
-    
+
     /// Appends the given string at the end of the text the user has entered.
     func append(text: String) {
         guard let textView else {
             return
         }
-        
+
         let range = NSRange(location: textView.attributedText.length, length: 0)
         let appendedAttributedString = NSAttributedString(
             string: text,
             attributes: defaultStringAttributes
         )
-        
+
         let attributedString = NSMutableAttributedString(attributedString: textView.attributedText)
         attributedString.replaceCharacters(in: range, with: appendedAttributedString)
         textView.attributedText = attributedString
@@ -76,35 +76,35 @@ import UIKit
         guard text == "@" else { return }
         showMentionsAutocomplete = true
     }
-    
-    /// Appends the given URL and adds the default link styling attributes. Will append a space before the link 
+
+    /// Appends the given URL and adds the default link styling attributes. Will append a space before the link
     /// if needed.
     func append(_ url: URL) {
         guard let text = textView?.attributedText else { return }
-        
+
         if let lastCharacter = text.string.last, !lastCharacter.isWhitespace {
             append(text: " ")
         }
-        
+
         let range = NSRange(location: text.length, length: 0)
         insert(text: url.absoluteString, link: url.absoluteString, at: range)
     }
-    
+
     // MARK: - UITextViewDelegate
-    
+
     func textViewDidChange(_ textView: UITextView) {
         updateIntrinsicHeight(view: textView)
         isEmpty = textView.attributedText.length == 0
     }
-        
+
     func textView(
-        _ textView: UITextView, 
-        primaryActionFor textItem: UITextItem, 
+        _ textView: UITextView,
+        primaryActionFor textItem: UITextItem,
         defaultAction: UIAction
     ) -> UIAction? {
         nil
     }
-    
+
     func textView(
         _ textView: UITextView,
         shouldChangeTextIn nsRange: NSRange,
@@ -115,7 +115,7 @@ import UIKit
             return false
         }
         textView.typingAttributes = defaultStringAttributes
-        
+
         if text == "@" {
             let showedAutocomplete = checkForMentionsAutocomplete(in: textView, at: nsRange)
             if showedAutocomplete {
@@ -126,55 +126,55 @@ import UIKit
             if insertedNostrLink {
                 return false
             }
-        } 
-        
+        }
+
         return true
     }
 
-    // MARK: - Helpers 
-    
-    /// Calculates the height that fits all entered text, and updates `intrinsicHeight` with this property. This is 
+    // MARK: - Helpers
+
+    /// Calculates the height that fits all entered text, and updates `intrinsicHeight` with this property. This is
     /// done to work around some incompatibilities between UIKit and SwiftUI where the UITextView won't expand properly.
     func updateIntrinsicHeight(view: UIView) {
         let newSize = view.sizeThatFits(CGSize(width: view.frame.width, height: .greatestFiniteMagnitude))
         guard intrinsicHeight != newSize.height else { return }
-        DispatchQueue.main.async { // call in next render cycle.
+        DispatchQueue.main.async {  // call in next render cycle.
             self.intrinsicHeight = newSize.height
         }
     }
-    
+
     /// Inserts the name of an author at the given range with a nostr link attached as an attribute. This function
     /// assumes the cursor is directly after an '@' and will replace that too.
     private func insertMention(of author: Author, at range: NSRange) {
         guard let textView, let url = author.uri else {
             return
         }
-        
+
         let rangeIncludingAmpersand = NSRange(
-            location: max(range.location - 1, 0), 
+            location: max(range.location - 1, 0),
             length: min(range.length + 1, textView.attributedText.length)
         )
         insert(text: "@\(author.safeName)", link: url.absoluteString, at: rangeIncludingAmpersand)
     }
-    
+
     /// Handles the user pasting an npub at the given range.
     private func insertMention(npub: String, range: NSRange) {
         insert(text: npub.prefix(10).appending("..."), link: "nostr:\(npub)", at: range)
     }
-    
-    /// Handles the user pasting an note link at the given range. 
+
+    /// Handles the user pasting an note link at the given range.
     private func insertMention(note: String, range: NSRange) {
         insert(text: note.prefix(10).appending("..."), link: "nostr:\(note)", at: range)
     }
-    
+
     /// Inserts a string at the given range and adds the link attribute with the given `link`.
     private func insert(text: String, link: String, at range: NSRange) {
         guard let textView else {
             return
         }
-        
+
         let linkAttributes = defaultStringAttributes.merging(
-            [NSAttributedString.Key.link: link], 
+            [NSAttributedString.Key.link: link],
             uniquingKeysWith: { _, key in key }
         )
         let link = NSMutableAttributedString(
@@ -183,20 +183,20 @@ import UIKit
         )
         let space = NSAttributedString(string: " ", attributes: defaultStringAttributes)
         link.append(space)
-        
+
         let attributedString = NSMutableAttributedString(attributedString: textView.attributedText)
         attributedString.replaceCharacters(in: range, with: link)
         textView.attributedText = attributedString
         textView.selectedRange.location = range.location + link.length
         isEmpty = false
     }
-    
-    /// Takes the same arguments as `textView(_:shouldChangeTextIn:replacementText:)` and detects the case where the 
-    /// user is typing inside a link (like a mention of another author). If this is the case we remove the link 
+
+    /// Takes the same arguments as `textView(_:shouldChangeTextIn:replacementText:)` and detects the case where the
+    /// user is typing inside a link (like a mention of another author). If this is the case we remove the link
     /// attribute from the link and insert the given `newText` and return true. Otherwise this will return `false`.
     private func removeLinkAttributesUnderCursor(
-        selectedRange: NSRange, 
-        in textView: UITextView, 
+        selectedRange: NSRange,
+        in textView: UITextView,
         newText: String
     ) -> Bool {
         let attributedText = textView.attributedText!
@@ -204,28 +204,28 @@ import UIKit
             var rangeOfLink = NSRange()
             let location = newText.isEmpty ? max(selectedRange.location, 0) : selectedRange.location
             let link = attributedText.attribute(
-                .link, 
-                at: location, 
-                longestEffectiveRange: &rangeOfLink, 
+                .link,
+                at: location,
+                longestEffectiveRange: &rangeOfLink,
                 in: NSRange(location: 0, length: attributedText.length)
             )
-            
+
             if link != nil {
                 let newAttributesString = NSMutableAttributedString(attributedString: attributedText)
                 newAttributesString.removeAttribute(.link, range: rangeOfLink)
                 newAttributesString.replaceCharacters(in: selectedRange, with: newText)
                 textView.attributedText = newAttributesString
                 textView.selectedRange = NSRange(
-                    location: selectedRange.location + (newText as NSString).length, 
+                    location: selectedRange.location + (newText as NSString).length,
                     length: 0
                 )
                 return true
             }
         }
-        
+
         return false
     }
-        
+
     /// Call this when the user has typed a '@' and it will trigger the mentions autocomplete to open if appropriate.
     /// - Returns: `true` if it opened the mentions autocomplete.
     private func checkForMentionsAutocomplete(in textView: UITextView, at range: NSRange) -> Bool {
@@ -241,9 +241,9 @@ import UIKit
         }
         return false
     }
-    
-    /// Checks to see if `text` is a valid `NostrIdentifier` and inserts it into the given `textView` as a link if 
-    /// it is. 
+
+    /// Checks to see if `text` is a valid `NostrIdentifier` and inserts it into the given `textView` as a link if
+    /// it is.
     /// - Returns: `true` if it inserted a link.
     private func handleNostrIdentifiers(in text: String, textView: UITextView) -> Bool {
         do {

--- a/Nos/Controller/PersistenceController.swift
+++ b/Nos/Controller/PersistenceController.swift
@@ -1,13 +1,13 @@
-import CoreData
-import Logger
-import Dependencies
 import BackgroundTasks
+import CoreData
+import Dependencies
+import Logger
 
 final class PersistenceController {
-    
+
     @Dependency(\.currentUser) var currentUser
     @Dependency(\.crashReporting) var crashReporting
-    
+
     /// Increment this to delete core data on update
     private static let version = 3
     private static let versionKey = "NosPersistenceControllerVersion"
@@ -17,20 +17,20 @@ final class PersistenceController {
         let viewContext = controller.viewContext
         return controller
     }()
-    
+
     static var empty: PersistenceController = {
         let result = PersistenceController(inMemory: true)
         let viewContext = result.viewContext
         return result
     }()
-    
+
     var viewContext: NSManagedObjectContext {
         container.viewContext
     }
-    
+
     /// A context for parsing Nostr events from relays.
     private(set) lazy var parseContext = newBackgroundContext()
-    
+
     /// A context for Views to do expensive queries that we want to keep off the viewContext.
     private(set) lazy var backgroundViewContext = newBackgroundContext()
 
@@ -49,21 +49,21 @@ final class PersistenceController {
         container = NSPersistentContainer(name: containerName, managedObjectModel: model)
         setUp(erasingPrevious: erase)
     }
-    
+
     private func setUp(erasingPrevious: Bool) {
         if inMemory {
             container.persistentStoreDescriptions.first!.url = URL(fileURLWithPath: "/dev/null")
-        } 
-        
+        }
+
         loadPersistentStores(from: container, erasingPrevious: erasingPrevious)
-        
+
         viewContext.automaticallyMergesChangesFromParent = true
         viewContext.mergePolicy = NSMergePolicy.mergeByPropertyStoreTrump
     }
-    
+
     private func loadPersistentStores(from container: NSPersistentContainer, erasingPrevious: Bool) {
         container.loadPersistentStores { storeDescription, error in
-            
+
             // Drop database if necessary
             if Self.loadVersionFromDisk() < Self.version || erasingPrevious {
                 guard let storeURL = storeDescription.url else {
@@ -75,17 +75,18 @@ final class PersistenceController {
                 self.loadPersistentStores(from: container, erasingPrevious: false)
                 return
             }
-            
+
             if let error = error as NSError? {
                 if error.domain == NSCocoaErrorDomain, error.code == 134_110 {
-                    Log.error("Could not migrate data model. Did you change the xcdatamodel and forget to make a " +
-                        "new version?")
+                    Log.error(
+                        "Could not migrate data model. Did you change the xcdatamodel and forget to make a "
+                            + "new version?")
                 }
                 fatalError("Could not initialize database \(error), \(error.userInfo)")
             }
         }
     }
-    
+
     @MainActor
     func saveAll() async throws {
         try viewContext.saveIfNeeded()
@@ -93,12 +94,12 @@ final class PersistenceController {
             try self.backgroundViewContext.saveIfNeeded()
         }
     }
-    
+
     /// Deletes all entities in this object's container.
     func deleteAll() async throws {
         await container.deleteAllEntities()
     }
-    
+
     private static func clearCoreData(store storeURL: URL, in container: NSPersistentContainer) {
         Log.info("Dropping Core Data...")
         do {
@@ -107,18 +108,18 @@ final class PersistenceController {
             fatalError("Could not erase database \(error.localizedDescription)")
         }
     }
-    
+
     func newBackgroundContext() -> NSManagedObjectContext {
         let context = container.newBackgroundContext()
         context.automaticallyMergesChangesFromParent = true
         context.mergePolicy = NSMergePolicy.mergeByPropertyStoreTrump
         return context
     }
-    
+
     private static func loadVersionFromDisk() -> Int {
         UserDefaults.standard.integer(forKey: Self.versionKey)
     }
-    
+
     private static func saveVersionToDisk(_ newVersion: Int) {
         UserDefaults.standard.set(newVersion, forKey: Self.versionKey)
     }
@@ -127,19 +128,19 @@ final class PersistenceController {
 // MARK: - Maintenance & Cleanup
 
 extension PersistenceController {
-    
+
     /// The ID of the background task that runs the `DatabaseCleaner`. Needs to match the value in Info.plist.
     static let cleanupBackgroundTaskID = "com.verse.nos.database-cleaner"
-    
+
     /// Cleans up unneeded entities from the database. Our local database is really just a cache, and we need to
     /// invalidate old items to keep it from growing indefinitely.
-    /// 
+    ///
     /// This should only be called once right at app launch.
     @MainActor func cleanupEntities() async {
         guard let authorKey = currentUser.author?.hexadecimalPublicKey else {
             return
         }
-        
+
         let context = newBackgroundContext()
         do {
             try await DatabaseCleaner.cleanupEntities(for: authorKey, in: context)
@@ -148,43 +149,43 @@ extension PersistenceController {
             crashReporting.report("Error in database cleanup: \(error.localizedDescription)")
         }
     }
-    
-    /// Tells iOS to wake our app up in the background to run `cleanupEntities()` periodically. This tends to run 
+
+    /// Tells iOS to wake our app up in the background to run `cleanupEntities()` periodically. This tends to run
     /// once a day when the device is connected to power.
     func scheduleBackgroundCleanupTask() {
         @Dependency(\.analytics) var analytics
         @Dependency(\.crashReporting) var crashReporting
         let scheduler = BGTaskScheduler.shared
-        
+
         scheduler.register(forTaskWithIdentifier: Self.cleanupBackgroundTaskID, using: nil) { task in
-            
+
             task.expirationHandler = {
                 analytics.databaseCleanupTaskExpired()
             }
-            
+
             Task {
                 await self.cleanupEntities()
                 task.setTaskCompleted(success: true)
             }
-        } 
-        
+        }
+
         let request = BGProcessingTaskRequest(identifier: Self.cleanupBackgroundTaskID)
-        request.requiresNetworkConnectivity = false  
+        request.requiresNetworkConnectivity = false
         request.requiresExternalPower = false
-        
+
         do {
             try scheduler.submit(request)
         } catch {
             crashReporting.report("Unable to schedule background task: \(error)")
         }
     }
-    
+
     static func databaseStatistics(from context: NSManagedObjectContext) async throws -> [(String, Int)] {
-        try await context.perform { 
+        try await context.perform {
             var statistics = [String: Int]()
             if let managedObjectModel = context.persistentStoreCoordinator?.managedObjectModel {
                 let entitiesByName = managedObjectModel.entitiesByName
-                
+
                 for entityName in entitiesByName.keys {
                     let fetchRequest = NSFetchRequest<NSFetchRequestResult>(entityName: entityName)
                     let count = try context.performAndWait {
@@ -193,7 +194,7 @@ extension PersistenceController {
                     statistics[entityName] = count
                 }
             }
-            
+
             return statistics.sorted(by: { $0.key < $1.key })
         }
     }
@@ -202,56 +203,56 @@ extension PersistenceController {
 // MARK: - Testing & Debug
 
 #if DEBUG
-extension PersistenceController {
-    func loadSampleData(context: NSManagedObjectContext) async throws {
-        guard let sampleFile = Bundle.current.url(forResource: "sample_data", withExtension: "json") else {
-            Log.error("Error: bad sample file location")
-            return
-        }
-    
-        guard let sampleData = try? Data(contentsOf: sampleFile) else {
-            print("Error: Debug data not found")
-            return
+    extension PersistenceController {
+        func loadSampleData(context: NSManagedObjectContext) async throws {
+            guard let sampleFile = Bundle.current.url(forResource: "sample_data", withExtension: "json") else {
+                Log.error("Error: bad sample file location")
+                return
+            }
+
+            guard let sampleData = try? Data(contentsOf: sampleFile) else {
+                print("Error: Debug data not found")
+                return
+            }
+
+            Event.deleteAll(context: context)
+            context.reset()
+
+            guard let events = try? EventProcessor.parse(jsonData: sampleData, from: nil, in: context) else {
+                print("Error: Could not parse events")
+                return
+            }
+
+            print("Successfully preloaded \(events.count) events")
+
+            let verifiedEvents = Event.all(context: context)
+            print("Successfully fetched \(verifiedEvents.count) events")
+
+            // Force follow sample data users; This will be wiped if you sync with a relay.
+            let authors = Author.all(context: context)
+            let follows = try context.fetch(Follow.followsRequest(sources: authors))
+
+            if let publicKey = currentUser.publicKeyHex {
+                let currentAuthor = try Author.findOrCreate(by: publicKey, context: context)
+                currentAuthor.follows = Set(follows)
+            }
         }
 
-        Event.deleteAll(context: context)
-        context.reset()
-        
-        guard let events = try? EventProcessor.parse(jsonData: sampleData, from: nil, in: context) else {
-            print("Error: Could not parse events")
-            return
-        }
-        
-        print("Successfully preloaded \(events.count) events")
-        
-        let verifiedEvents = Event.all(context: context)
-        print("Successfully fetched \(verifiedEvents.count) events")
-        
-        // Force follow sample data users; This will be wiped if you sync with a relay.
-        let authors = Author.all(context: context)
-        let follows = try context.fetch(Follow.followsRequest(sources: authors))
-        
-        if let publicKey = currentUser.publicKeyHex {
-            let currentAuthor = try Author.findOrCreate(by: publicKey, context: context)
-            currentAuthor.follows = Set(follows)
+        func resetForTesting() {
+            container = NSPersistentContainer(name: "Nos", managedObjectModel: model)
+            if !inMemory {
+                container.loadPersistentStores(completionHandler: { (storeDescription, _) in
+                    guard let storeURL = storeDescription.url else {
+                        Log.error("Could not get store URL")
+                        return
+                    }
+                    Self.clearCoreData(store: storeURL, in: self.container)
+                })
+            }
+            setUp(erasingPrevious: true)
+            viewContext.reset()
+            backgroundViewContext.reset()
+            parseContext.reset()
         }
     }
-    
-    func resetForTesting() {
-        container = NSPersistentContainer(name: "Nos", managedObjectModel: model)
-        if !inMemory {
-            container.loadPersistentStores(completionHandler: { (storeDescription, _) in
-                guard let storeURL = storeDescription.url else {
-                    Log.error("Could not get store URL")
-                    return
-                }
-                Self.clearCoreData(store: storeURL, in: self.container)
-            })
-        }
-        setUp(erasingPrevious: true)
-        viewContext.reset()
-        backgroundViewContext.reset()
-        parseContext.reset()
-    }
-}
 #endif

--- a/Nos/Controller/RawEventController.swift
+++ b/Nos/Controller/RawEventController.swift
@@ -3,19 +3,19 @@ import Logger
 
 /// A view model for the RawEventView
 @MainActor protocol RawEventViewModel: ObservableObject {
-    
+
     /// The raw message to display in screen
     var rawMessage: String? { get }
-    
+
     /// A loading message that should be displayed when it is not nil
     var loadingMessage: String? { get }
-    
+
     /// An error message that should be displayed when it is not nil
     var errorMessage: String? { get }
-    
+
     /// Called when the user dismisses the shown error message. Should clear `errorMessage`.
     func didDismissError()
-    
+
     /// Called when the user taps on the Cancel button
     func didDismiss()
 }
@@ -26,11 +26,11 @@ import Logger
     private var note: Event
 
     @Published var rawMessage: String?
-    
+
     @Published var loadingMessage: String?
 
     @Published var errorMessage: String?
-    
+
     private var dismissHandler: () -> Void
 
     init(note: Event, dismissHandler: @escaping () -> Void) {
@@ -43,7 +43,7 @@ import Logger
         errorMessage = nil
         didDismiss()
     }
-    
+
     func didDismiss() {
         dismissHandler()
     }
@@ -63,7 +63,7 @@ import Logger
                     withJSONObject: note.jsonRepresentation ?? [:],
                     options: [.prettyPrinted]
                 )
-                rawMessage = String(decoding: data, as: UTF8.self) 
+                rawMessage = String(decoding: data, as: UTF8.self)
             } catch {
                 rawMessage = errorMessage
             }

--- a/Nos/Controller/RefreshController.swift
+++ b/Nos/Controller/RefreshController.swift
@@ -7,7 +7,7 @@ import Foundation
 
     /// The last time the view was refreshed.
     var lastRefreshDate: Date
-    
+
     /// Initializes a refresh controller with the given parameters.
     /// - Parameters:
     ///   - startRefresh: Whether a refresh should start or not. Defaults to `false`.

--- a/Nos/Controller/SearchController.swift
+++ b/Nos/Controller/SearchController.swift
@@ -1,7 +1,7 @@
-import Foundation
 import Combine
-import Dependencies
 import CoreData
+import Dependencies
+import Foundation
 import Logger
 
 /// The current state of the search.
@@ -24,12 +24,12 @@ enum SearchState {
 
 /// Manages a search query and list of results.
 class SearchController: ObservableObject {
-    
+
     // MARK: - Properties
-    
+
     /// The search query string.
     @Published var query: String = ""
-    
+
     /// Any and all authors in the search results. As of this writing, _only_ authors appear in search results,
     /// so this contains all search results, period.
     @Published var authorResults = [Author]()
@@ -55,7 +55,7 @@ class SearchController: ObservableObject {
     private let stillLoadingTime: TimeInterval = 10
 
     // MARK: - Init
-    
+
     init() {
         $query
             .removeDuplicates()
@@ -107,9 +107,9 @@ class SearchController: ObservableObject {
         })
         .store(in: &cancellables)
     }
-    
+
     // MARK: - Internal
-    
+
     func author(fromPublicKey publicKeyString: String) -> Author? {
         let strippedString = publicKeyString.trimmingCharacters(
             in: NSCharacterSet.whitespacesAndNewlines
@@ -123,14 +123,14 @@ class SearchController: ObservableObject {
         try? context.saveIfNeeded()
         return author
     }
-    
+
     func authors(named name: String) -> [Author] {
         guard let authors = try? Author.find(named: name, context: context) else {
             return []
         }
         return authors.sorted(by: { $0.followers.count > $1.followers.count })
     }
-    
+
     func clear() {
         state = .noQuery
         searchSubscriptions.removeAll()
@@ -138,7 +138,7 @@ class SearchController: ObservableObject {
         query = ""
         authorResults = []
     }
-    
+
     private func note(fromPublicKey publicKeyString: String) -> Event? {
         let strippedString = publicKeyString.trimmingCharacters(
             in: NSCharacterSet.whitespacesAndNewlines
@@ -156,7 +156,7 @@ class SearchController: ObservableObject {
             return nil
         }
     }
-    
+
     /// Searches the relays and UNS for the given query.
     /// - Parameter query: The string to search for.
     ///
@@ -193,7 +193,7 @@ class SearchController: ObservableObject {
             self.searchSubscriptions.append(subscription)
         }
     }
-    
+
     func searchUNS(for query: String) {
         Task {
             do {
@@ -225,7 +225,7 @@ class SearchController: ObservableObject {
             }
         }
     }
-    
+
     /// Searches for the value in `query`. Only needed when the user taps the Search button since typeahead search
     /// handles other use cases.
     ///
@@ -233,9 +233,9 @@ class SearchController: ObservableObject {
     /// the relay service. If there's a match, shows the author.
     ///
     /// Second, checks to see if `query` matches an author's public key and if so, shows the author.
-    /// 
+    ///
     /// Third, checks to see if `query` matches a note's public key and if so, shows the note.
-    /// 
+    ///
     /// Finally, if all previous checks fail, searches the relays and UNS for the given query.
     func submitSearch(query: String) {
         searchSubscriptions.removeAll()

--- a/Nos/Extensions/AttributedString+Quotation.swift
+++ b/Nos/Extensions/AttributedString+Quotation.swift
@@ -1,19 +1,19 @@
 import Foundation
 
 extension AttributedString {
-    
+
     /// Wraps this AttributedString with localized quotation marks.
     /// - Parameter locale: The Locale to get the quotation marks from.
     /// - Returns: A new AttributedString, wrapped with localized quotation marks.
     func wrappingWithQuotationMarks(locale: Locale = .current) -> AttributedString {
         var content = self
-        
+
         let beginDelimiter = locale.quotationBeginDelimiter ?? "“"
         content.insert(AttributedString(beginDelimiter), at: content.startIndex)
-        
+
         let endDelimiter = locale.quotationEndDelimiter ?? "”"
         content.append(AttributedString(endDelimiter))
-        
+
         return content
     }
 }

--- a/Nos/Extensions/Bundle+Current.swift
+++ b/Nos/Extensions/Bundle+Current.swift
@@ -5,7 +5,7 @@ private class CurrentBundle {}
 extension Bundle {
 
     static let current = Bundle(for: CurrentBundle.self)
-    
+
     var version: String {
         let version = self.infoDictionary?["CFBundleShortVersionString"] as? String ?? ""
         return version

--- a/Nos/Extensions/Color+Hex.swift
+++ b/Nos/Extensions/Color+Hex.swift
@@ -7,13 +7,16 @@ extension Color {
         let hex = hex.trimmingCharacters(in: CharacterSet.alphanumerics.inverted)
         var int: UInt64 = 0
         Scanner(string: hex).scanHexInt64(&int)
-        let a, r, g, b: UInt64
+        let a: UInt64
+        let r: UInt64
+        let g: UInt64
+        let b: UInt64
         switch hex.count {
-        case 3: // RGB (12-bit)
+        case 3:  // RGB (12-bit)
             (a, r, g, b) = (255, (int >> 8) * 17, (int >> 4 & 0xF) * 17, (int & 0xF) * 17)
-        case 6: // RGB (24-bit)
+        case 6:  // RGB (24-bit)
             (a, r, g, b) = (255, int >> 16, int >> 8 & 0xFF, int & 0xFF)
-        case 8: // ARGB (32-bit)
+        case 8:  // ARGB (32-bit)
             (a, r, g, b) = (int >> 24, int >> 16 & 0xFF, int >> 8 & 0xFF, int & 0xFF)
         default:
             (a, r, g, b) = (1, 1, 1, 0)

--- a/Nos/Extensions/Data+Encoding.swift
+++ b/Nos/Extensions/Data+Encoding.swift
@@ -9,16 +9,16 @@ extension Data {
         let hexDigits = Array("0123456789abcdef".utf16)
         var hexChars = [UTF16.CodeUnit]()
         hexChars.reserveCapacity(bytes.count * 2)
-    
+
         for byte in self {
             let (index1, index2) = Int(byte).quotientAndRemainder(dividingBy: 16)
             hexChars.append(hexDigits[index1])
             hexChars.append(hexDigits[index2])
         }
-        
+
         return String(utf16CodeUnits: hexChars, count: hexChars.count)
     }
-    
+
     /// Converts base two bytes to base 5
     var base5: Data {
         var outputSize = (count * 8) / 5
@@ -31,17 +31,17 @@ extension Data {
             let remainder = (i * 5) % 8
             var element = self[quotient] << remainder
             element >>= 3
-            
+
             if (remainder > 3) && (i + 1 < outputSize) {
                 element = element | (self[quotient + 1] >> (8 - remainder + 3))
             }
-            
+
             outputArray.append(element)
         }
-        
+
         return Data(outputArray)
     }
-    
+
     func base8FromBase5() throws -> Data {
         let destinationBase = 8
         let startingBase = 5
@@ -49,7 +49,7 @@ extension Data {
         var value: UInt32 = 0
         var bits: Int = 0
         var output = Data()
-        
+
         for i in (0..<count) {
             value = (value << startingBase) | UInt32(self[i])
             bits += startingBase
@@ -58,11 +58,11 @@ extension Data {
                 output.append(UInt8((value >> bits) & maxValueMask))
             }
         }
-        
+
         if ((value << (destinationBase - bits)) & maxValueMask) != 0 || bits >= startingBase {
             throw DataError.generic
         }
-        
+
         return output
     }
 }

--- a/Nos/Extensions/Data+Sha.swift
+++ b/Nos/Extensions/Data+Sha.swift
@@ -1,5 +1,5 @@
-import Foundation
 import CommonCrypto
+import Foundation
 
 extension Data {
     var sha256: String {

--- a/Nos/Extensions/Date+Elapsed.swift
+++ b/Nos/Extensions/Date+Elapsed.swift
@@ -59,13 +59,17 @@ extension Date {
         dateComponentsFormatter.maximumUnitCount = 1
         dateComponentsFormatter.allowedUnits = unitFlags
 
-        if let day = components.day, day >= 1, let formattedDate =
-            dateComponentsFormatter.string(from: DateComponents(calendar: calendar, day: day)) {
+        if let day = components.day, day >= 1,
+            let formattedDate =
+                dateComponentsFormatter.string(from: DateComponents(calendar: calendar, day: day))
+        {
             return formattedDate
         }
 
-        if let hour = components.hour, hour >= 1, let formattedDate =
-            dateComponentsFormatter.string(from: DateComponents(calendar: calendar, hour: hour)) {
+        if let hour = components.hour, hour >= 1,
+            let formattedDate =
+                dateComponentsFormatter.string(from: DateComponents(calendar: calendar, hour: hour))
+        {
             return formattedDate
         }
 

--- a/Nos/Extensions/Font+Clarity.swift
+++ b/Nos/Extensions/Font+Clarity.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 // https://stackoverflow.com/a/74416073
 extension Font {
-    
+
     static func clarity(
         _ fontWeight: Font.Weight,
         textStyle: Font.TextStyle = .body
@@ -17,7 +17,7 @@ extension Font {
     static func clarityRegular(_ textStyle: Font.TextStyle) -> Font {
         clarity(.regular, textStyle: textStyle)
     }
-    
+
     static func clarityBold(_ textStyle: Font.TextStyle) -> Font {
         clarity(.bold, textStyle: textStyle)
     }
@@ -26,35 +26,35 @@ extension Font {
 extension Font.Weight {
     var clarityFontName: String {
         switch self {
-        case .medium:   "ClarityCity-Medium"
+        case .medium: "ClarityCity-Medium"
         case .semibold: "ClarityCity-SemiBold"
-        case .bold:     "ClarityCity-Bold"
-        default:        "ClarityCity-Regular"
+        case .bold: "ClarityCity-Bold"
+        default: "ClarityCity-Regular"
         }
     }
 }
 
-fileprivate extension Font.TextStyle {
-    var uiFontTextStyle: UIFont.TextStyle {
+extension Font.TextStyle {
+    fileprivate var uiFontTextStyle: UIFont.TextStyle {
         switch self {
-        case .largeTitle:       .largeTitle
-        case .title:            .title1
-        case .title2:           .title2
-        case .title3:           .title3
-        case .headline:         .headline
-        case .subheadline:      .subheadline
-        case .body:             .body
-        case .callout:          .callout
-        case .footnote:         .footnote
-        case .caption:          .caption1
-        case .caption2:         .caption2
-        case .extraLargeTitle:  .extraLargeTitle
+        case .largeTitle: .largeTitle
+        case .title: .title1
+        case .title2: .title2
+        case .title3: .title3
+        case .headline: .headline
+        case .subheadline: .subheadline
+        case .body: .body
+        case .callout: .callout
+        case .footnote: .footnote
+        case .caption: .caption1
+        case .caption2: .caption2
+        case .extraLargeTitle: .extraLargeTitle
         case .extraLargeTitle2: .extraLargeTitle2
-        @unknown default:       UIFont.TextStyle.body
+        @unknown default: UIFont.TextStyle.body
         }
     }
-    
-    var defaultSize: CGFloat {
+
+    fileprivate var defaultSize: CGFloat {
         UIFont.preferredFont(
             forTextStyle: uiFontTextStyle,
             compatibleWith: UITraitCollection(preferredContentSizeCategory: .large)

--- a/Nos/Extensions/NSManagedObject+Nos.swift
+++ b/Nos/Extensions/NSManagedObject+Nos.swift
@@ -2,12 +2,12 @@ import CoreData
 import Logger
 
 public class NosManagedObject: NSManagedObject {
-    
+
     // Not sure why this is necessary, but SwiftUI previews crash on NSManagedObject.init(context:) otherwise.
     convenience init(context: NSManagedObjectContext) {
         self.init(entity: Self.entityDescription(in: context), insertInto: context)
     }
-    
+
     class func entityDescription(in context: NSManagedObjectContext) -> NSEntityDescription {
         if let entity = NSEntityDescription.entity(forEntityName: String(describing: Self.self), in: context) {
             return entity

--- a/Nos/Extensions/NSManagedObjectContext+Nos.swift
+++ b/Nos/Extensions/NSManagedObjectContext+Nos.swift
@@ -1,5 +1,5 @@
-import Foundation
 import CoreData
+import Foundation
 
 extension NSManagedObjectContext {
     func saveIfNeeded() throws {

--- a/Nos/Extensions/NSPersistentContainer+Nos.swift
+++ b/Nos/Extensions/NSPersistentContainer+Nos.swift
@@ -2,7 +2,7 @@ import CoreData
 import Logger
 
 extension NSPersistentContainer {
-    
+
     /// Deletes all entities in this container.
     ///
     /// - Note: This function assumes that all contexts using the container have their
@@ -12,16 +12,16 @@ extension NSPersistentContainer {
             viewContext.automaticallyMergesChangesFromParent,
             "All associated contexts must automatically merge changes from their parent."
         )
-        
+
         let entityNames = managedObjectModel.entities.compactMap { $0.name }
-        
+
         let context = newBackgroundContext()
         await context.perform {
             for entityName in entityNames {
                 let fetchRequest = NSFetchRequest<NSFetchRequestResult>(entityName: entityName)
                 let deleteRequest = NSBatchDeleteRequest(fetchRequest: fetchRequest)
                 deleteRequest.resultType = .resultTypeCount
-                
+
                 do {
                     let result = try context.execute(deleteRequest) as? NSBatchDeleteResult
                     Log.info("Deleted \(result?.result ?? 0) of type \(entityName)")
@@ -29,7 +29,7 @@ extension NSPersistentContainer {
                     print("Failed to batch delete entity: \(entityName), error: \(error)")
                 }
             }
-            
+
             if context.hasChanges {
                 try? context.save()
             }

--- a/Nos/Extensions/NSRegularExpression+Replacement.swift
+++ b/Nos/Extensions/NSRegularExpression+Replacement.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 extension NSRegularExpression {
-    
+
     /// Helper function to perform replacements using NSRegularExpression.
     /// - Parameters:
     ///   - string: The input string.
@@ -17,14 +17,14 @@ extension NSRegularExpression {
     ) -> String {
         var result = ""
         var lastRangeEnd = string.startIndex
-        
+
         for match in matches(in: string, options: options, range: range) {
             guard let matchRange = Range(match.range, in: string) else { continue }
             result += string[lastRangeEnd..<matchRange.lowerBound]
             result += transform(match)
             lastRangeEnd = matchRange.upperBound
         }
-        
+
         result += string[lastRangeEnd..<string.endIndex]
         return result
     }

--- a/Nos/Extensions/String+Empty.swift
+++ b/Nos/Extensions/String+Empty.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-extension Optional<String> {
+extension String? {
     var isEmptyOrNil: Bool {
         self == nil || self?.isEmpty == true
     }

--- a/Nos/Extensions/String+Hex.swift
+++ b/Nos/Extensions/String+Hex.swift
@@ -1,11 +1,11 @@
-import Foundation
 import CryptoKit
+import Foundation
 
 extension String {
-    
+
     var hexDecoded: Data? {
         guard self.count.isMultiple(of: 2) else { return nil }
-        
+
         // https://stackoverflow.com/a/62517446/982195
         let stringArray = Array(self)
         var data = Data()
@@ -20,7 +20,7 @@ extension String {
         }
         return data
     }
-    
+
     var isValidHexadecimal: Bool {
         let regex = "^[0-9a-fA-F]+$"
         return range(of: regex, options: .regularExpression) != nil

--- a/Nos/Extensions/String+Lorem.swift
+++ b/Nos/Extensions/String+Lorem.swift
@@ -17,7 +17,7 @@ extension String {
             """
             Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est \
             laborum.
-            """
+            """,
         ]
         return lines.prefix(numberOfLines).joined(separator: " ")
     }

--- a/Nos/Extensions/Task+Timeout.swift
+++ b/Nos/Extensions/Task+Timeout.swift
@@ -2,12 +2,12 @@ import Foundation
 
 // https://gist.github.com/swhitty/9be89dfe97dbb55c6ef0f916273bbb97
 extension Task where Failure == Error {
-    
-    // Start a new Task with a timeout. If the timeout expires before the operation is 
+
+    // Start a new Task with a timeout. If the timeout expires before the operation is
     // completed then the task is cancelled and an error is thrown.
     init(
-        priority: TaskPriority? = nil, 
-        timeout: TimeInterval, 
+        priority: TaskPriority? = nil,
+        timeout: TimeInterval,
         operation: @escaping @Sendable () async throws -> Success
     ) {
         self = Task(priority: priority) {

--- a/Nos/Extensions/URL+Extensions.swift
+++ b/Nos/Extensions/URL+Extensions.swift
@@ -42,7 +42,7 @@ extension URL {
         }
         return string
     }
-    
+
     /// Returns a Markdown-formatted link that can be used for display. The display portion of the Markdown string will
     /// not contain the URL scheme, path, or path extension. In place of the path and path extension, an ellipsis will
     /// appear. For example, with a URL like `https://www.nos.social/about`, this will return
@@ -53,11 +53,11 @@ extension URL {
         guard var host = url.host() else {
             return "[\(url.absoluteString)](\(url.absoluteString))"
         }
-        
+
         if host.hasPrefix("www.") {
             host = String(host.dropFirst(4))
         }
-        
+
         if url.path().isEmpty {
             return "[\(host)](\(url.absoluteString))"
         } else {

--- a/Nos/Extensions/WebSocket+Nos.swift
+++ b/Nos/Extensions/WebSocket+Nos.swift
@@ -5,7 +5,7 @@ extension WebSocket {
     var host: String {
         self.request.url?.host ?? "unknown relay"
     }
-    
+
     var url: URL? {
         self.request.url
     }
@@ -15,7 +15,7 @@ extension WebSocketClient {
     var host: String {
         (self as? WebSocket)?.host ?? "unkown relay"
     }
-    
+
     var url: URL? {
         (self as? WebSocket)?.url
     }

--- a/Nos/Models/AppDestination.swift
+++ b/Nos/Models/AppDestination.swift
@@ -8,7 +8,7 @@ enum AppDestination: Hashable, Equatable {
     case notifications
     case noteComposer(String?)
     case profile
-    
+
     var destinationString: String {
         switch self {
         case .home:
@@ -23,7 +23,7 @@ enum AppDestination: Hashable, Equatable {
             return String(localized: .localizable.profileTitle)
         }
     }
-    
+
     func hash(into hasher: inout Hasher) {
         hasher.combine(destinationString)
     }

--- a/Nos/Models/CoreData/AuthorReference+CoreDataClass.swift
+++ b/Nos/Models/CoreData/AuthorReference+CoreDataClass.swift
@@ -1,9 +1,9 @@
-import Foundation
 import CoreData
+import Foundation
 
 @objc(AuthorReference)
 public class AuthorReference: NosManagedObject {
-    
+
     /// Retreives all the AuthorReferences whose referencing Event has been deleted.
     static func orphanedRequest() -> NSFetchRequest<AuthorReference> {
         let fetchRequest = NSFetchRequest<AuthorReference>(entityName: "AuthorReference")

--- a/Nos/Models/CoreData/Event+CoreDataClass.swift
+++ b/Nos/Models/CoreData/Event+CoreDataClass.swift
@@ -1,8 +1,8 @@
+import CoreData
+import Dependencies
+import Logger
 // swiftlint:disable file_length
 import secp256k1
-import CoreData
-import Logger
-import Dependencies
 
 @objc(Event)
 @Observable
@@ -13,10 +13,10 @@ public class Event: NosManagedObject, VerifiableEvent {
 
     /// Event identifier for the note created by ``NoteComposer`` when displaying previews.
     static let previewIdentifier = "preview"
-    
+
     class func all(context: NSManagedObjectContext) -> [Event] {
         let allRequest = Event.allPostsRequest()
-        
+
         do {
             let results = try context.fetch(allRequest)
             return results
@@ -25,10 +25,10 @@ public class Event: NosManagedObject, VerifiableEvent {
             return []
         }
     }
-    
+
     class func unpublishedEvents(for user: Author, context: NSManagedObjectContext) -> [Event] {
         let allRequest = Event.unpublishedEventsRequest(for: user)
-        
+
         do {
             let results = try context.fetch(allRequest)
             return results
@@ -37,7 +37,7 @@ public class Event: NosManagedObject, VerifiableEvent {
             return []
         }
     }
-    
+
     class func find(by identifier: RawEventID, context: NSManagedObjectContext) -> Event? {
         if let existingEvent = try? context.fetch(Event.event(by: identifier)).first {
             return existingEvent
@@ -45,12 +45,12 @@ public class Event: NosManagedObject, VerifiableEvent {
 
         return nil
     }
-    
+
     // MARK: - Creating
 
     static func createIfNecessary(
         jsonEvent: JSONEvent,
-        relay: Relay?, 
+        relay: Relay?,
         context: NSManagedObjectContext
     ) throws -> Event? {
         // Optimization: check that no record exists before doing any fetching
@@ -86,7 +86,7 @@ public class Event: NosManagedObject, VerifiableEvent {
     /// Fetches the event with the given ID out of the database, and otherwise creates a stubbed Event.
     /// A stubbed event created here only has an `identifier`. We know an event with this identifier exists but we don't
     /// have its content or tags yet.
-    ///  
+    ///
     /// - Parameters:
     ///   - id: The hexadecimal Nostr ID of the event.
     /// - Returns: The Event model with the given ID.
@@ -130,7 +130,7 @@ public class Event: NosManagedObject, VerifiableEvent {
     }
 
     func markSeen(on relay: Relay) {
-        seenOnRelays.insert(relay) 
+        seenOnRelays.insert(relay)
     }
 
     /// Tries to parse a new event out of the given jsonEvent's `content` field.
@@ -144,26 +144,26 @@ public class Event: NosManagedObject, VerifiableEvent {
             Log.error("Could not parse content for jsonEvent: \(jsonEvent)")
         }
     }
-    
+
     // MARK: - Preloading and Caching
     // Probably should refactor this stuff into a view model
-    
+
     @MainActor var loadingViewData = false
     @MainActor var attributedContent = LoadingContent<AttributedString>.loading
     @MainActor var contentLinks = [URL]()
     @MainActor private(set) var quotedNoteID: RawEventID?
     @MainActor var relaySubscriptions = SubscriptionCancellables()
-    
+
     /// Instructs this event to load supplementary data like author name and photo, reference events, and produce
     /// formatted `content` and cache it on this object. Idempotent.
     @MainActor func loadViewData() async {
         guard !loadingViewData else {
             return
         }
-        
+
         loadingViewData = true
         Log.debug("\(identifier ?? "null") loading view data")
-        
+
         await withTaskGroup(of: Void.self) { group in
             if isStub {
                 group.addTask {
@@ -181,12 +181,12 @@ public class Event: NosManagedObject, VerifiableEvent {
                     await self.loadAttributedContent()
                 }
             }
-            
+
             await group.waitForAll()
         }
         loadingViewData = false
     }
-    
+
     /// Tries to download this event from relays.
     @MainActor private func loadContent() async {
         @Dependency(\.relayService) var relayService
@@ -204,29 +204,30 @@ public class Event: NosManagedObject, VerifiableEvent {
         @Dependency(\.relayService) var relayService
         @Dependency(\.persistenceController) var persistenceController
         let backgroundContext = persistenceController.backgroundViewContext
-        relaySubscriptions.append(await Event.requestAuthorsMetadataIfNeeded(
-            noteID: identifier, 
-            using: relayService, 
-            in: backgroundContext
-        ))
+        relaySubscriptions.append(
+            await Event.requestAuthorsMetadataIfNeeded(
+                noteID: identifier,
+                using: relayService,
+                in: backgroundContext
+            ))
     }
-    
+
     /// Tries to load the note this note is reposting or replying to from relays.
     @MainActor private func loadReferencedNote() async {
         let referencedNote = referencedNote() ?? rootNote()
         await referencedNote?.loadViewData()
     }
-    
+
     @MainActor private var loadingAttributedContent = false
-    
-    /// Processes the note `content` to populate mentions and extract links. The results are saved in 
+
+    /// Processes the note `content` to populate mentions and extract links. The results are saved in
     /// `attributedContent` and `contentLinks`. Idempotent.
     @MainActor func loadAttributedContent() async {
         guard !loadingAttributedContent else {
             return
         }
         loadingAttributedContent = true
-        
+
         @Dependency(\.persistenceController) var persistenceController
         let backgroundContext = persistenceController.backgroundViewContext
         if let components = await Event.parsedComponents(
@@ -242,26 +243,26 @@ public class Event: NosManagedObject, VerifiableEvent {
         }
         loadingAttributedContent = false
     }
-    
+
     @MainActor func loadFirstQuotedNote() async {
         guard let quotedNoteID else {
             return
         }
-        
+
         @Dependency(\.persistenceController) var persistenceController
         let context = persistenceController.backgroundViewContext
-        
+
         await context.perform {
             _ = try? Event.findOrCreateStubBy(id: quotedNoteID, context: context)
             try? context.save()
         }
-        
+
         @Dependency(\.relayService) var relayService
         relaySubscriptions.append(await relayService.requestEvent(with: quotedNoteID))
     }
-    
+
     // MARK: - Helpers
-    
+
     var serializedEventForSigning: [Any?] {
         [
             0,
@@ -269,10 +270,10 @@ public class Event: NosManagedObject, VerifiableEvent {
             Int64(createdAt!.timeIntervalSince1970),
             kind,
             allTags,
-            content
+            content,
         ]
     }
-    
+
     func calculateIdentifier() throws -> String {
         let serializedEventData = try JSONSerialization.data(
             withJSONObject: serializedEventForSigning,
@@ -280,7 +281,7 @@ public class Event: NosManagedObject, VerifiableEvent {
         )
         return serializedEventData.sha256
     }
-    
+
     func sign(withKey privateKey: KeyPair) throws {
         if allTags == nil {
             allTags = [[String]]() as NSObject
@@ -293,7 +294,7 @@ public class Event: NosManagedObject, VerifiableEvent {
             Log.error("Couldn't calculate identifier when signing a private key")
         }
     }
-    
+
     var jsonRepresentation: [String: Any]? {
         if let jsonEvent = codable {
             do {
@@ -303,29 +304,31 @@ public class Event: NosManagedObject, VerifiableEvent {
                 print("Error encoding event as JSON: \(error.localizedDescription)\n\(self)")
             }
         }
-        
+
         return nil
     }
-    
+
     var jsonString: String? {
-        guard let jsonRepresentation,  
-            let data = try? JSONSerialization.data(withJSONObject: jsonRepresentation) else {
+        guard let jsonRepresentation,
+            let data = try? JSONSerialization.data(withJSONObject: jsonRepresentation)
+        else {
             return nil
         }
         return String(decoding: data, as: UTF8.self)
     }
-    
+
     var codable: JSONEvent? {
         guard let identifier = identifier,
             let pubKey = author?.hexadecimalPublicKey,
             let createdAt = createdAt,
             let content = content,
-            let signature = signature else {
+            let signature = signature
+        else {
             return nil
         }
-        
+
         let allTags = (allTags as? [[String]]) ?? []
-        
+
         return JSONEvent(
             id: identifier,
             pubKey: pubKey,
@@ -336,19 +339,20 @@ public class Event: NosManagedObject, VerifiableEvent {
             signature: signature
         )
     }
-    
+
     var bech32NoteID: String? {
         guard let identifier = self.identifier,
-            let identifierBytes = try? identifier.bytes else {
+            let identifierBytes = try? identifier.bytes
+        else {
             return nil
         }
         return Bech32.encode(NostrIdentifierPrefix.note, baseEightData: Data(identifierBytes))
     }
-    
+
     var seenOnRelayURLs: [String] {
         seenOnRelays.compactMap { $0.addressURL?.absoluteString }
     }
-    
+
     class func attributedContent(
         noteID: String?,
         noteParser: NoteParser = NoteParser(),
@@ -357,10 +361,11 @@ public class Event: NosManagedObject, VerifiableEvent {
         guard let noteID else {
             return AttributedString()
         }
-        
+
         return await context.perform {
             guard let note = try? Event.findOrCreateStubBy(id: noteID, context: context),
-                let content = note.content else {
+                let content = note.content
+            else {
                 return AttributedString()
             }
             try? context.saveIfNeeded()
@@ -372,17 +377,17 @@ public class Event: NosManagedObject, VerifiableEvent {
             )
         }
     }
-   
+
     /// This function formats an Event's content for display in the UI. It does things like replacing raw npub links
     /// with the author's name, and extracting any URLs so that previews can be displayed for them.
     ///
     /// The given note should be initialized in a main queue NSManagedObjectContext (probably viewContext).
-    /// 
+    ///
     /// - Parameter note: the note whose content should be processed.
     /// - Parameter context: the context to use for database queries - this does not need to be the same context that
     ///     `note` is in.
     /// - Returns: A tuple where the first object is the note content formatted for display, and the second is a list
-    ///     of HTTP links found in the note's context.  
+    ///     of HTTP links found in the note's context.
     @MainActor class func parsedComponents(
         note: Event,
         noteParser: NoteParser = NoteParser(),
@@ -392,29 +397,29 @@ public class Event: NosManagedObject, VerifiableEvent {
             return nil
         }
         let tags = note.allTags as? [[String]] ?? []
-        
+
         return await context.perform {
             noteParser.components(from: content, tags: tags, context: context)
         }
     }
-    
+
     class func deleteAll(context: NSManagedObjectContext) {
         let deleteRequest = Event.deleteAllEvents()
-        
+
         do {
             try context.execute(deleteRequest)
         } catch let error as NSError {
             print("Failed to delete events. Error: \(error.description)")
         }
     }
-    
+
     /// Returns true if this event tagged the given author.
     func references(author: Author) -> Bool {
         authorReferences.contains(where: { element in
             (element as? AuthorReference)?.pubkey == author.hexadecimalPublicKey
         })
     }
-    
+
     /// Returns true if this event is a reply to an event by the given author.
     func isReply(to author: Author) -> Bool {
         eventReferences.contains(where: { element in
@@ -422,12 +427,12 @@ public class Event: NosManagedObject, VerifiableEvent {
             return rootEvent?.author?.hexadecimalPublicKey == author.hexadecimalPublicKey
         })
     }
-    
+
     /// Returns true if this event is a zap request targeting the given author.
     func isProfileZap(to author: Author) -> Bool {
         kind == EventKind.zapRequest.rawValue && references(author: author)
     }
-    
+
     var isReply: Bool {
         rootNote() != nil || referencedNote() != nil
     }
@@ -446,63 +451,68 @@ public class Event: NosManagedObject, VerifiableEvent {
             return false
         }
     }
-    
+
     /// Returns the event this note is directly replying to, or nil if there isn't one.
     func referencedNote() -> Event? {
         if let rootReference = eventReferences.first(where: {
             ($0 as? EventReference)?.type == .reply
         }) as? EventReference,
-            let referencedNote = rootReference.referencedEvent {
+            let referencedNote = rootReference.referencedEvent
+        {
             return referencedNote
         }
-        
+
         if let lastReference = eventReferences.lastObject as? EventReference,
             lastReference.marker == nil,
-            let referencedNote = lastReference.referencedEvent {
+            let referencedNote = lastReference.referencedEvent
+        {
             return referencedNote
         }
         return nil
     }
-    
+
     /// Returns the root event of the thread that this note is replying to, or nil if there isn't one.
     func rootNote() -> Event? {
-        let rootReference = eventReferences.first(where: {
-            ($0 as? EventReference)?.type == .root
-        }) as? EventReference
-        
+        let rootReference =
+            eventReferences.first(where: {
+                ($0 as? EventReference)?.type == .root
+            }) as? EventReference
+
         if let rootReference, let rootNote = rootReference.referencedEvent {
             return rootNote
         }
         return nil
     }
-    
+
     /// Returns the event this note is reposting, if this note is a kind 6 repost.
     func repostedNote() -> Event? {
         guard kind == EventKind.repost.rawValue else {
             return nil
         }
-        
+
         if let reference = eventReferences.firstObject as? EventReference,
-            let repostedNote = reference.referencedEvent {
+            let repostedNote = reference.referencedEvent
+        {
             return repostedNote
         }
-        
+
         return nil
     }
-    
+
     /// This tracks which relays this event is deleted on. Hide posts with deletedOn.count > 0
     func trackDelete(on relay: Relay, context: NSManagedObjectContext) throws {
         if EventKind(rawValue: kind) == .delete, let eTags = allTags as? [[String]] {
             for deletedEventId in eTags.map({ $0[1] }) {
                 if let deletedEvent = Event.find(by: deletedEventId, context: context),
-                    deletedEvent.author?.hexadecimalPublicKey == author?.hexadecimalPublicKey {
+                    deletedEvent.author?.hexadecimalPublicKey == author?.hexadecimalPublicKey
+                {
                     print("\(deletedEvent.identifier ?? "n/a") was deleted on \(relay.address ?? "unknown")")
                     deletedEvent.deletedOn.insert(relay)
                 }
             }
         }
     }
-    
+
     class func requestAuthorsMetadataIfNeeded(
         noteID: RawEventID?,
         using relayService: RelayService,
@@ -511,47 +521,49 @@ public class Event: NosManagedObject, VerifiableEvent {
         guard let noteID else {
             return SubscriptionCancellable(subscriptionIDs: [], relayService: relayService)
         }
-        
+
         let requestData: [(RawAuthorID?, Date?)] = await context.perform {
             guard let note = try? Event.findOrCreateStubBy(id: noteID, context: context),
-                let authorKey = note.author?.hexadecimalPublicKey else {
+                let authorKey = note.author?.hexadecimalPublicKey
+            else {
                 return []
             }
-        
+
             var requestData = [(RawAuthorID?, Date?)]()
-            
+
             guard let author = try? Author.findOrCreate(by: authorKey, context: context) else {
                 Log.debug("Author not found when requesting metadata of a note's author")
                 return []
             }
-            
+
             if author.needsMetadata {
                 requestData.append((author.hexadecimalPublicKey, author.lastUpdatedMetadata))
             }
-            
+
             note.authorReferences.forEach { reference in
                 if let reference = reference as? AuthorReference,
                     let pubKey = reference.pubkey,
                     let author = try? Author.findOrCreate(by: pubKey, context: context),
-                    author.needsMetadata {
+                    author.needsMetadata
+                {
                     requestData.append((author.hexadecimalPublicKey, author.lastUpdatedMetadata))
                 }
             }
-            
+
             try? context.saveIfNeeded()
             return requestData
         }
-        
+
         var cancellables = [SubscriptionCancellable]()
         for requestDatum in requestData {
             let authorKey = requestDatum.0
             let sinceDate = requestDatum.1
             cancellables.append(await relayService.requestMetadata(for: authorKey, since: sinceDate))
         }
-        
+
         return SubscriptionCancellable(cancellables: cancellables, relayService: relayService)
     }
-    
+
     var webLink: String {
         if let bech32NoteID {
             return "https://njump.me/\(bech32NoteID)"
@@ -560,13 +572,13 @@ public class Event: NosManagedObject, VerifiableEvent {
             return "https://njump.me"
         }
     }
-    
+
     /// Returns true if this event doesn't have content. Usually this means we saw it referenced by another event
     /// but we haven't actually downloaded it yet.
     var isStub: Bool {
         author == nil || createdAt == nil || identifier == nil
     }
-    
+
     /// Converts an event back to a stubbed event by resetting most properties and leaving the `identifier` in place.
     func resetToStub() {
         allTags = nil

--- a/Nos/Models/CoreData/Event+Fetching.swift
+++ b/Nos/Models/CoreData/Event+Fetching.swift
@@ -1,28 +1,28 @@
 import CoreData
 
 extension Event {
-    
+
     @nonobjc public class func allEventsRequest() -> NSFetchRequest<Event> {
         let fetchRequest = NSFetchRequest<Event>(entityName: "Event")
         fetchRequest.sortDescriptors = [
             NSSortDescriptor(keyPath: \Event.createdAt, ascending: true),
-            NSSortDescriptor(keyPath: \Event.receivedAt, ascending: true)
+            NSSortDescriptor(keyPath: \Event.receivedAt, ascending: true),
         ]
         return fetchRequest
     }
-    
+
     @nonobjc public class func allPostsRequest(_ eventKind: EventKind = .text) -> NSFetchRequest<Event> {
         let fetchRequest = NSFetchRequest<Event>(entityName: "Event")
         fetchRequest.sortDescriptors = [NSSortDescriptor(keyPath: \Event.createdAt, ascending: false)]
         fetchRequest.predicate = NSPredicate(format: "kind = %i", eventKind.rawValue)
         return fetchRequest
     }
-    
+
     @nonobjc public class func allMentionsPredicate(for user: Author) -> NSPredicate {
         guard let publicKey = user.hexadecimalPublicKey, !publicKey.isEmpty else {
             return NSPredicate.false
         }
-        
+
         return NSPredicate(
             format: "kind = %i AND ANY authorReferences.pubkey = %@ AND deletedOn.@count = 0",
             EventKind.text.rawValue,
@@ -34,34 +34,33 @@ extension Event {
         let fetchRequest = NSFetchRequest<Event>(entityName: "Event")
         fetchRequest.sortDescriptors = [NSSortDescriptor(keyPath: \Event.createdAt, ascending: false)]
         fetchRequest.predicate = NSPredicate(
-            format: "author.hexadecimalPublicKey = %@ AND " +
-            "SUBQUERY(shouldBePublishedTo, $relay, TRUEPREDICATE).@count > " +
-            "SUBQUERY(publishedTo, $relay, TRUEPREDICATE).@count AND " +
-            "deletedOn.@count = 0",
+            format: "author.hexadecimalPublicKey = %@ AND "
+                + "SUBQUERY(shouldBePublishedTo, $relay, TRUEPREDICATE).@count > "
+                + "SUBQUERY(publishedTo, $relay, TRUEPREDICATE).@count AND " + "deletedOn.@count = 0",
             user.hexadecimalPublicKey ?? ""
         )
         return fetchRequest
     }
-    
+
     @nonobjc public class func allRepliesPredicate(for user: Author) -> NSPredicate {
         NSPredicate(
             format: "kind = 1 AND ANY eventReferences.referencedEvent.author = %@ AND deletedOn.@count = 0",
             user
         )
     }
-    
+
     @nonobjc public class func allZapsPredicate(for user: Author) -> NSPredicate {
         guard let publicKey = user.hexadecimalPublicKey, !publicKey.isEmpty else {
             return NSPredicate.false
         }
-        
+
         return NSPredicate(
             format: "kind = %i AND ANY authorReferences.pubkey = %@ AND deletedOn.@count = 0",
             EventKind.zapRequest.rawValue,
             publicKey
         )
     }
-    
+
     /// A request for all events that the given user should receive a notification for.
     /// - Parameters:
     ///   - user: the author you want to view notifications for.
@@ -78,7 +77,7 @@ extension Event {
         if let limit {
             fetchRequest.fetchLimit = limit
         }
-        
+
         let mentionsPredicate = allMentionsPredicate(for: user)
         let repliesPredicate = allRepliesPredicate(for: user)
         let zapsPredicate = allZapsPredicate(for: user)
@@ -93,10 +92,10 @@ extension Event {
             andPredicates.append(sincePredicate)
         }
         fetchRequest.predicate = NSCompoundPredicate(andPredicateWithSubpredicates: andPredicates)
-        
+
         return fetchRequest
     }
-    
+
     @nonobjc public class func lastReceived(for user: Author) -> NSFetchRequest<Event> {
         let fetchRequest = NSFetchRequest<Event>(entityName: "Event")
         fetchRequest.predicate = NSPredicate(format: "author != %@", user)
@@ -104,20 +103,19 @@ extension Event {
         fetchRequest.sortDescriptors = [NSSortDescriptor(keyPath: \Event.receivedAt, ascending: false)]
         return fetchRequest
     }
-    
+
     @nonobjc public class func allReplies(to rootEvent: Event) -> NSFetchRequest<Event> {
         allReplies(toNoteWith: rootEvent.identifier)
     }
-        
+
     @nonobjc public class func allReplies(toNoteWith noteID: String?) -> NSFetchRequest<Event> {
         guard let noteID else {
             return emptyRequest()
         }
-        
-        let replyNoteReferences = "kind = 1 " +
-            "AND ANY eventReferences.referencedEvent.identifier == %@ " +
-            "AND author.muted = false"
-        
+
+        let replyNoteReferences =
+            "kind = 1 " + "AND ANY eventReferences.referencedEvent.identifier == %@ " + "AND author.muted = false"
+
         let fetchRequest = NSFetchRequest<Event>(entityName: "Event")
         fetchRequest.sortDescriptors = [NSSortDescriptor(keyPath: \Event.receivedAt, ascending: false)]
         fetchRequest.predicate = NSPredicate(
@@ -135,13 +133,13 @@ extension Event {
     /// building a set of author avatars.
     @nonobjc public class func replies(to noteID: RawEventID) -> NSFetchRequest<Event> {
         let format = """
-            SUBQUERY(
-                eventReferences,
-                $e,
-                $e.referencedEvent.identifier = %@ AND
-                    ($e.marker = 'reply' OR $e.marker = 'root')
-            ).@count > 0
-        """
+                SUBQUERY(
+                    eventReferences,
+                    $e,
+                    $e.referencedEvent.identifier = %@ AND
+                        ($e.marker = 'reply' OR $e.marker = 'root')
+                ).@count > 0
+            """
 
         let predicate = NSCompoundPredicate(
             andPredicateWithSubpredicates: [
@@ -152,7 +150,7 @@ extension Event {
                     noteID
                 ),
                 NSPredicate(format: "deletedOn.@count = 0"),
-                NSPredicate(format: "author.muted = false")
+                NSPredicate(format: "author.muted = false"),
             ]
         )
 
@@ -177,28 +175,28 @@ extension Event {
     /// - Parameter user: The Author record for the currently logged in user. Special treatment is given to their data.
     @nonobjc public class func cleanupRequest(before date: Date, for user: Author) -> NSFetchRequest<Event> {
         let oldStoryCutoff = Calendar.current.date(byAdding: .day, value: -2, to: .now) ?? .now
-        
+
         let request = NSFetchRequest<Event>(entityName: "Event")
         request.sortDescriptors = [NSSortDescriptor(keyPath: \Event.receivedAt, ascending: true)]
         let oldUnreferencedEventsClause = "(receivedAt < %@ OR receivedAt == nil) AND referencingEvents.@count = 0"
         let notOwnEventClause = "(author != %@)"
         let readStoryClause = "(isRead = 1 AND receivedAt > %@)"
-        let userReportClause = "(kind == \(EventKind.report.rawValue) AND " +
-        "authorReferences.@count > 0 AND eventReferences.@count == 0)"
-        let clauses = "\(oldUnreferencedEventsClause) AND" +
-        "\(notOwnEventClause) AND " +
-        "NOT \(readStoryClause) AND " +
-        "NOT \(userReportClause)"
+        let userReportClause =
+            "(kind == \(EventKind.report.rawValue) AND "
+            + "authorReferences.@count > 0 AND eventReferences.@count == 0)"
+        let clauses =
+            "\(oldUnreferencedEventsClause) AND" + "\(notOwnEventClause) AND " + "NOT \(readStoryClause) AND "
+            + "NOT \(userReportClause)"
         request.predicate = NSPredicate(
             format: clauses,
             date as CVarArg,
             user,
             oldStoryCutoff as CVarArg
         )
-        
+
         return request
     }
-    
+
     /// This constructs a predicate for events that should be protected from deletion when we are purging the database.
     /// - Parameter user: The Author record for the currently logged in user. Special treatment is given to their data.
     /// - Parameter asSubquery: If true then each attribute in the predicate will prefixed with "$event." so the
@@ -210,39 +208,39 @@ extension Event {
         guard let userKey = user.hexadecimalPublicKey else {
             return NSPredicate.false
         }
-        
+
         // The string we use to reference the current event if we are constructing this predicate to be used in a
         // subquery
         let eventReference = asSubquery ? "$event." : ""
-        
+
         // protect all events authored by the current user
         let userEventsPredicate = NSPredicate(format: "\(eventReference)author.hexadecimalPublicKey = '\(userKey)'")
-        
+
         // protect stories that were read recently, so we don't redownload and show them as unread again
         let oldStoryCutoffDate = Calendar.current.date(byAdding: .day, value: -2, to: .now) ?? .now
         let recentlyReadStoriesPredicate = NSPredicate(
             format: "(\(eventReference)isRead = 1 AND \(eventReference)receivedAt > %@)",
             oldStoryCutoffDate as CVarArg
         )
-        
+
         // keep author reports from people we follow
         let userReportPredicate = NSPredicate(
-            format: "(\(eventReference)kind == \(EventKind.report.rawValue) AND " +
-                "SUBQUERY(\(eventReference)authorReferences, $references, TRUEPREDICATE).@count > 0 AND " +
-                "SUBQUERY(\(eventReference)eventReferences, $references, TRUEPREDICATE).@count == 0 AND " +
-                "ANY \(eventReference)author.followers.source.hexadecimalPublicKey == %@)",
+            format: "(\(eventReference)kind == \(EventKind.report.rawValue) AND "
+                + "SUBQUERY(\(eventReference)authorReferences, $references, TRUEPREDICATE).@count > 0 AND "
+                + "SUBQUERY(\(eventReference)eventReferences, $references, TRUEPREDICATE).@count == 0 AND "
+                + "ANY \(eventReference)author.followers.source.hexadecimalPublicKey == %@)",
             userKey
         )
-        
+
         return NSCompoundPredicate(
             orPredicateWithSubpredicates: [
                 userEventsPredicate,
                 recentlyReadStoriesPredicate,
-                userReportPredicate
+                userReportPredicate,
             ]
         )
     }
-    
+
     @nonobjc public class func expiredRequest() -> NSFetchRequest<Event> {
         let fetchRequest = NSFetchRequest<Event>(entityName: "Event")
         fetchRequest.predicate = NSPredicate(format: "expirationDate <= %@", Date.now as CVarArg)
@@ -267,7 +265,7 @@ extension Event {
         fetchRequest.fetchLimit = 1
         return fetchRequest
     }
-    
+
     @nonobjc public class func event(
         by replaceableID: RawReplaceableID,
         author: Author,
@@ -284,7 +282,7 @@ extension Event {
         fetchRequest.fetchLimit = 1
         return fetchRequest
     }
-    
+
     @nonobjc public class func hydratedEvent(by identifier: String) -> NSFetchRequest<Event> {
         let fetchRequest = NSFetchRequest<Event>(entityName: "Event")
         fetchRequest.predicate = NSPredicate(
@@ -293,12 +291,12 @@ extension Event {
         fetchRequest.fetchLimit = 1
         return fetchRequest
     }
-    
+
     @nonobjc public class func event(by identifier: String, seenOn relay: Relay) -> NSFetchRequest<Event> {
         guard let relayAddress = relay.address else {
             return Event.emptyRequest()
         }
-        
+
         let fetchRequest = NSFetchRequest<Event>(entityName: "Event")
         fetchRequest.predicate = NSPredicate(
             format: "identifier = %@ AND ANY seenOnRelays.address = %@",
@@ -309,7 +307,7 @@ extension Event {
         fetchRequest.fetchLimit = 1
         return fetchRequest
     }
-    
+
     /// Returns a predicate that can be used to fetch the given user's home feed.
     /// - Parameters:
     ///   - user: The user whose home feed should appear.
@@ -326,16 +324,13 @@ extension Event {
         let kind1Predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [
             NSPredicate(format: "kind = 1"),
             NSPredicate(
-                format: "SUBQUERY(" +
-                "eventReferences, $reference, $reference.marker = 'root'" +
-                " OR $reference.marker = 'reply'" +
-                " OR $reference.marker = nil" +
-                ").@count = 0"
+                format: "SUBQUERY(" + "eventReferences, $reference, $reference.marker = 'root'"
+                    + " OR $reference.marker = 'reply'" + " OR $reference.marker = nil" + ").@count = 0"
             ),
             NSPredicate(
                 format: "identifier != %@",
                 Event.previewIdentifier as CVarArg
-            )
+            ),
         ])
         let kind6Predicate = NSPredicate(format: "kind = 6")
         let kind30023Predicate = NSPredicate(format: "kind = 30023")
@@ -343,7 +338,7 @@ extension Event {
         let kindsPredicate = NSCompoundPredicate(orPredicateWithSubpredicates: [
             kind1Predicate,
             kind6Predicate,
-            kind30023Predicate
+            kind30023Predicate,
         ])
 
         let notMutedPredicate = NSPredicate(format: "author.muted = 0")
@@ -397,40 +392,42 @@ extension Event {
         fetchRequest.sortDescriptors = [NSSortDescriptor(keyPath: \Event.createdAt, ascending: false)]
         let noteIsLikedByUserPredicate = NSPredicate(
             // swiftlint:disable line_length
-            format: "kind = \(String(EventKind.like.rawValue)) AND SUBQUERY(eventReferences, $reference, $reference.eventId = %@).@count > 0 AND deletedOn.@count = 0",
+            format:
+                "kind = \(String(EventKind.like.rawValue)) AND SUBQUERY(eventReferences, $reference, $reference.eventId = %@).@count > 0 AND deletedOn.@count = 0",
             // swiftlint:enable line_length
             noteID
         )
         fetchRequest.predicate = noteIsLikedByUserPredicate
         return fetchRequest
     }
-    
+
     @nonobjc public class func reposts(noteID: String) -> NSFetchRequest<Event> {
         let fetchRequest = NSFetchRequest<Event>(entityName: "Event")
         fetchRequest.sortDescriptors = [NSSortDescriptor(keyPath: \Event.createdAt, ascending: false)]
         let noteIsLikedByUserPredicate = NSPredicate(
             // swiftlint:disable line_length
-            format: "kind = \(String(EventKind.repost.rawValue)) AND SUBQUERY(eventReferences, $reference, $reference.eventId = %@).@count > 0 AND deletedOn.@count = 0",
+            format:
+                "kind = \(String(EventKind.repost.rawValue)) AND SUBQUERY(eventReferences, $reference, $reference.eventId = %@).@count > 0 AND deletedOn.@count = 0",
             // swiftlint:enable line_length
             noteID
         )
         fetchRequest.predicate = noteIsLikedByUserPredicate
         return fetchRequest
     }
-    
+
     @nonobjc public class func emptyRequest() -> NSFetchRequest<Event> {
         let fetchRequest = NSFetchRequest<Event>(entityName: "Event")
         fetchRequest.sortDescriptors = [NSSortDescriptor(keyPath: \Event.createdAt, ascending: true)]
         fetchRequest.predicate = NSPredicate.false
         return fetchRequest
     }
-    
+
     @nonobjc public class func deleteAllEvents() -> NSBatchDeleteRequest {
         let fetchRequest: NSFetchRequest<NSFetchRequestResult> = NSFetchRequest(entityName: "Event")
         let deleteRequest = NSBatchDeleteRequest(fetchRequest: fetchRequest)
         return deleteRequest
     }
-    
+
     @nonobjc public class func deleteAllPosts(by author: Author) -> NSBatchDeleteRequest {
         let fetchRequest: NSFetchRequest<NSFetchRequestResult> = NSFetchRequest(entityName: "Event")
         let kind = EventKind.text.rawValue
@@ -439,7 +436,7 @@ extension Event {
         let deleteRequest = NSBatchDeleteRequest(fetchRequest: fetchRequest)
         return deleteRequest
     }
-    
+
     func reportsRequest() -> NSFetchRequest<Event> {
         let request = NSFetchRequest<Event>(entityName: "Event")
         request.predicate = NSPredicate(

--- a/Nos/Models/CoreData/Event+Hydration.swift
+++ b/Nos/Models/CoreData/Event+Hydration.swift
@@ -2,11 +2,11 @@ import CoreData
 import Logger
 
 extension Event {
-    
+
     /// Populates an event stub (with only its ID set) using the data in the given JSON.
     func hydrate(from jsonEvent: JSONEvent, relay: Relay?, in context: NSManagedObjectContext) throws {
         assert(isStub, "Tried to hydrate an event that isn't a stub. This is a programming error")
-        
+
         // if this stub was created with a replaceableIdentifier and author, it won't have an identifier yet
         identifier = jsonEvent.id
 
@@ -19,58 +19,60 @@ extension Event {
         kind = jsonEvent.kind
         signature = jsonEvent.signature
         sendAttempts = 0
-        
+
         // Tags
         allTags = jsonEvent.tags as NSObject
         for tag in jsonEvent.tags {
             if tag[safe: 0] == "expiration",
                 let expirationDateString = tag[safe: 1],
                 let expirationDateUnix = TimeInterval(expirationDateString),
-                expirationDateUnix != 0 {
+                expirationDateUnix != 0
+            {
                 let expirationDate = Date(timeIntervalSince1970: expirationDateUnix)
                 self.expirationDate = expirationDate
                 if isExpired {
                     throw EventError.expiredEvent
                 }
             } else if tag[safe: 0] == "d",
-                let dTag = tag[safe: 1] {
+                let dTag = tag[safe: 1]
+            {
                 replaceableIdentifier = dTag
             }
         }
-        
+
         // Author
         guard let newAuthor = try? Author.findOrCreate(by: jsonEvent.pubKey, context: context) else {
             throw EventError.missingAuthor
         }
-        
+
         author = newAuthor
-        
+
         // Relay
         relay.unwrap { markSeen(on: $0) }
-        
+
         guard let eventKind = EventKind(rawValue: kind) else {
             throw EventError.unrecognizedKind
         }
-        
+
         switch eventKind {
         case .contactList:
             hydrateContactList(from: jsonEvent, author: newAuthor, context: context)
-            
+
         case .metaData:
             hydrateMetaData(from: jsonEvent, author: newAuthor, context: context)
-            
+
         case .mute:
             hydrateMuteList(from: jsonEvent, context: context)
         case .repost:
-            
+
             hydrateDefault(from: jsonEvent, context: context)
             parseContent(from: jsonEvent, context: context)
-            
+
         default:
             hydrateDefault(from: jsonEvent, context: context)
         }
     }
-    
+
     private func hydrateContactList(
         from jsonEvent: JSONEvent,
         author newAuthor: Author,
@@ -79,7 +81,7 @@ extension Event {
         guard createdAt! > newAuthor.lastUpdatedContactList ?? Date.distantPast else {
             return
         }
-        
+
         newAuthor.lastUpdatedContactList = Date(timeIntervalSince1970: TimeInterval(jsonEvent.createdAt))
 
         // Put existing follows into a dictionary so we can avoid doing a fetch request to look up each one.
@@ -89,11 +91,12 @@ extension Event {
                 originalFollows[pubKey] = follow
             }
         }
-        
+
         var newFollows = Set<Follow>()
         for jsonTag in jsonEvent.tags where jsonTag[safe: 0] == "p" {
             if let followedKey = jsonTag[safe: 1],
-                let existingFollow = originalFollows[followedKey] {
+                let existingFollow = originalFollows[followedKey]
+            {
                 // We already have a Core Data Follow model for this user
                 newFollows.insert(existingFollow)
             } else {
@@ -104,20 +107,21 @@ extension Event {
                 }
             }
         }
-        
+
         // Did we unfollow someone? If so, remove them from core data
         let removedFollows = Set(originalFollows.values).subtracting(newFollows)
         if !removedFollows.isEmpty {
             Log.info("Removing \(removedFollows.count) follows")
             Follow.deleteFollows(in: removedFollows, context: context)
         }
-        
+
         newAuthor.follows = newFollows
-        
+
         // Get the user's active relays out of the content property
         if let data = jsonEvent.content.data(using: .utf8, allowLossyConversion: false),
             let relayEntries = try? JSONSerialization.jsonObject(with: data, options: .mutableContainers),
-            let relays = (relayEntries as? [String: Any])?.keys {
+            let relays = (relayEntries as? [String: Any])?.keys
+        {
             newAuthor.relays = Set()
 
             for address in relays {
@@ -127,7 +131,7 @@ extension Event {
             }
         }
     }
-    
+
     private func hydrateDefault(from jsonEvent: JSONEvent, context: NSManagedObjectContext) {
         let newEventReferences = NSMutableOrderedSet()
         let newAuthorReferences = NSMutableOrderedSet()
@@ -151,13 +155,13 @@ extension Event {
         eventReferences = newEventReferences
         authorReferences = newAuthorReferences
     }
-    
+
     private func hydrateMetaData(from jsonEvent: JSONEvent, author newAuthor: Author, context: NSManagedObjectContext) {
         guard createdAt! > newAuthor.lastUpdatedMetadata ?? Date.distantPast else {
             // This is old data
             return
         }
-        
+
         if let contentData = jsonEvent.content.data(using: .utf8) {
             newAuthor.lastUpdatedMetadata = Date(timeIntervalSince1970: TimeInterval(jsonEvent.createdAt))
             // There may be unsupported metadata. Store it to send back later in metadata publishes.
@@ -165,7 +169,7 @@ extension Event {
 
             do {
                 let metadata = try JSONDecoder().decode(MetadataEventJSON.self, from: contentData)
-                
+
                 // Every event has an author created, so it just needs to be populated
                 newAuthor.name = metadata.name
                 newAuthor.displayName = metadata.displayName
@@ -179,12 +183,12 @@ extension Event {
             }
         }
     }
-    
+
     private func hydrateMuteList(from jsonEvent: JSONEvent, context: NSManagedObjectContext) {
         let mutedKeys = jsonEvent.tags.map { $0[1] }
-        
+
         let request = Author.allAuthorsRequest(muted: true)
-        
+
         // Un-Mute anyone (locally only) who is muted but not in the mutedKeys
         if let authors = try? context.fetch(request) {
             for author in authors where !mutedKeys.contains(author.hexadecimalPublicKey!) {
@@ -192,7 +196,7 @@ extension Event {
                 print("Parse-Un-Muted \(author.hexadecimalPublicKey ?? "")")
             }
         }
-        
+
         // Mute anyone (locally only) in the mutedKeys
         for key in mutedKeys {
             if let author = try? Author.find(by: key, context: context) {
@@ -200,7 +204,7 @@ extension Event {
                 print("Parse-Muted \(author.hexadecimalPublicKey ?? "")")
             }
         }
-        
+
         // Force ensure current user never was muted
         Task { @MainActor in
             currentUser.author?.muted = false

--- a/Nos/Models/CoreData/Event+InlineMetadata.swift
+++ b/Nos/Models/CoreData/Event+InlineMetadata.swift
@@ -32,7 +32,7 @@ struct InlineMetadataTag {
             return .landscape
         }
     }
-    
+
     /// Initializes an ``InlineMetadataTag`` with the given URL and dimensions.
     /// - Parameters:
     ///   - url: The URL of the media described by this metadata.
@@ -46,7 +46,8 @@ struct InlineMetadataTag {
     /// - Parameter imetaTag: The `imeta` tag from the JSON.
     init?(imetaTag: [String]) {
         guard let urlPair = imetaTag.first(where: { $0.starts(with: "url") }),
-            let url = urlPair.components(separatedBy: " ").last else {
+            let url = urlPair.components(separatedBy: " ").last
+        else {
             return nil
         }
         self.url = url
@@ -58,7 +59,8 @@ struct InlineMetadataTag {
             let width = components.first,
             let height = components.last,
             let widthValue = Double(width),
-            let heightValue = Double(height) {
+            let heightValue = Double(height)
+        {
             self.dimensions = CGSize(width: widthValue, height: heightValue)
         } else {
             self.dimensions = nil

--- a/Nos/Models/CoreData/EventReference+CoreDataClass.swift
+++ b/Nos/Models/CoreData/EventReference+CoreDataClass.swift
@@ -1,37 +1,37 @@
-import Foundation
 import CoreData
+import Foundation
 
-/// Tag markers for event references that describe what type of reference this is. 
+/// Tag markers for event references that describe what type of reference this is.
 /// See [NIP-10](https://github.com/nostr-protocol/nips/blob/master/10.md)
 enum EventReferenceMarker: String {
-    
+
     /// Marks the event being replied to.
     case reply
-    
-    /// Marks the event at the root of the reply chain. 
+
+    /// Marks the event at the root of the reply chain.
     case root
-    
+
     /// Marks a quoted or reposted event.
     case mention
 }
 
 @objc(EventReference)
 public class EventReference: NosManagedObject {
-    
+
     var type: EventReferenceMarker? {
         marker.unwrap { EventReferenceMarker(rawValue: $0) }
     }
-    
-    /// Retreives all the EventReferences 
+
+    /// Retreives all the EventReferences
     static func all() -> NSFetchRequest<EventReference> {
         let fetchRequest = NSFetchRequest<EventReference>(entityName: "EventReference")
         fetchRequest.sortDescriptors = [NSSortDescriptor(keyPath: \EventReference.eventId, ascending: false)]
         return fetchRequest
     }
-    
+
     /// This fetches all the references that can be deleted during the `DatabaseCleaner` routine. It takes care
     /// to only select references before a given date that are not referenced by events we are keeping, and it also
-    /// accounts for "protected events" from `Event.protectedFromCleanupPredicate(...)` to make sure we keep 
+    /// accounts for "protected events" from `Event.protectedFromCleanupPredicate(...)` to make sure we keep
     /// events published by the current user etc.
     static func cleanupRequest(before date: Date, user: Author) -> NSFetchRequest<EventReference> {
         let fetchRequest = NSFetchRequest<EventReference>(entityName: "EventReference")
@@ -51,12 +51,12 @@ public class EventReference: NosManagedObject {
         fetchRequest.predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [
             referencedEventIsNotProtected,
             referencingEventIsNotProtected,
-            eventsAreOld
+            eventsAreOld,
         ])
-        
+
         return fetchRequest
     }
-    
+
     /// Retreives all the EventReferences whose referencing Event has been deleted.
     static func orphanedRequest() -> NSFetchRequest<EventReference> {
         let fetchRequest = NSFetchRequest<EventReference>(entityName: "EventReference")
@@ -64,10 +64,11 @@ public class EventReference: NosManagedObject {
         fetchRequest.predicate = NSPredicate(format: "referencingEvent = nil")
         return fetchRequest
     }
-    
+
     convenience init(jsonTag: [String], context: NSManagedObjectContext) throws {
         guard jsonTag[safe: 0] == "e",
-            let eventID = jsonTag[safe: 1] else {
+            let eventID = jsonTag[safe: 1]
+        else {
             throw EventError.invalidETag(jsonTag)
         }
         self.init(context: context)

--- a/Nos/Models/CoreData/Follow+CoreDataClass.swift
+++ b/Nos/Models/CoreData/Follow+CoreDataClass.swift
@@ -1,5 +1,5 @@
-import Foundation
 import CoreData
+import Foundation
 import Logger
 
 typealias Followed = [Follow]
@@ -22,7 +22,7 @@ extension Array where Element == String {
 
 @objc(Follow)
 public class Follow: NosManagedObject {
-    
+
     // swiftlint:disable:next function_body_length
     class func upsert(
         by author: Author,
@@ -69,32 +69,32 @@ public class Follow: NosManagedObject {
         } else {
             follow = Follow(context: context)
         }
-        
+
         follow.source = author
 
         let followedAuthor = try Author.findOrCreate(by: followedKey, context: context)
         follow.destination = followedAuthor
-        
+
         if jsonTag.count > 2, !jsonTag[2].isEmpty {
             if let relay = try? Relay.findOrCreate(by: jsonTag[2], context: context) {
                 author.add(relay: relay)
             }
         }
-        
+
         if jsonTag.count > 3 {
             follow.petName = jsonTag[3]
         }
-        
+
         return follow
     }
-    
+
     @nonobjc public class func followsRequest(sources authors: [Author]) -> NSFetchRequest<Follow> {
         let fetchRequest = NSFetchRequest<Follow>(entityName: "Follow")
         fetchRequest.sortDescriptors = [NSSortDescriptor(keyPath: \Follow.petName, ascending: true)]
         fetchRequest.predicate = NSPredicate(format: "source IN %@", authors)
         return fetchRequest
     }
-    
+
     @nonobjc public class func followsRequest(source: Author, destination: Author) -> NSFetchRequest<Follow> {
         let fetchRequest = NSFetchRequest<Follow>(entityName: "Follow")
         fetchRequest.sortDescriptors = [NSSortDescriptor(keyPath: \Follow.petName, ascending: true)]
@@ -108,7 +108,7 @@ public class Follow: NosManagedObject {
         fetchRequest.predicate = NSPredicate(format: "destination IN %@", authors)
         return fetchRequest
     }
-    
+
     @nonobjc public class func allFollowsRequest() -> NSFetchRequest<Follow> {
         let fetchRequest = NSFetchRequest<Follow>(entityName: "Follow")
         fetchRequest.sortDescriptors = [
@@ -125,35 +125,35 @@ public class Follow: NosManagedObject {
         fetchRequest.predicate = NSPredicate(format: "source = nil")
         return fetchRequest
     }
-    
+
     class func follows(source: Author, destination: Author, context: NSManagedObjectContext) -> [Follow] {
         let fetchRequest = Follow.followsRequest(source: source, destination: destination)
-        
+
         do {
             return try context.fetch(fetchRequest)
         } catch let error as NSError {
             Log.error("Failed to fetch follows. Error: \(error.description)")
         }
-        
+
         return []
     }
-    
+
     class func deleteFollows(in follows: Set<Follow>, context: NSManagedObjectContext) {
         for follow in follows {
             context.delete(follow)
         }
     }
-    
+
     class func find(source: Author, destination: Author, context: NSManagedObjectContext) throws -> Follow? {
         let fetchRequest = Follow.followsRequest(source: source, destination: destination)
         fetchRequest.fetchLimit = 1
         if let follow = try context.fetch(fetchRequest).first {
             return follow
         }
-        
+
         return nil
     }
-    
+
     class func findOrCreate(source: Author, destination: Author, context: NSManagedObjectContext) throws -> Follow {
         if let follow = try? Follow.find(source: source, destination: destination, context: context) {
             return follow

--- a/Nos/Models/CoreData/Generated/Author+CoreDataProperties.swift
+++ b/Nos/Models/CoreData/Generated/Author+CoreDataProperties.swift
@@ -1,5 +1,5 @@
-import Foundation
 import CoreData
+import Foundation
 
 extension Author {
 

--- a/Nos/Models/CoreData/Generated/AuthorReference+CoreDataProperties.swift
+++ b/Nos/Models/CoreData/Generated/AuthorReference+CoreDataProperties.swift
@@ -1,5 +1,5 @@
-import Foundation
 import CoreData
+import Foundation
 
 extension AuthorReference {
 

--- a/Nos/Models/CoreData/Generated/Event+CoreDataProperties.swift
+++ b/Nos/Models/CoreData/Generated/Event+CoreDataProperties.swift
@@ -1,5 +1,5 @@
-import Foundation
 import CoreData
+import Foundation
 
 extension Event {
 

--- a/Nos/Models/CoreData/Generated/EventReference+CoreDataProperties.swift
+++ b/Nos/Models/CoreData/Generated/EventReference+CoreDataProperties.swift
@@ -1,5 +1,5 @@
-import Foundation
 import CoreData
+import Foundation
 
 extension EventReference {
 

--- a/Nos/Models/CoreData/Generated/Follow+CoreDataProperties.swift
+++ b/Nos/Models/CoreData/Generated/Follow+CoreDataProperties.swift
@@ -1,5 +1,5 @@
-import Foundation
 import CoreData
+import Foundation
 
 extension Follow {
 

--- a/Nos/Models/CoreData/Generated/NosNotification+CoreDataProperties.swift
+++ b/Nos/Models/CoreData/Generated/NosNotification+CoreDataProperties.swift
@@ -1,5 +1,5 @@
-import Foundation
 import CoreData
+import Foundation
 
 extension NosNotification {
 

--- a/Nos/Models/CoreData/Generated/Relay+CoreDataProperties.swift
+++ b/Nos/Models/CoreData/Generated/Relay+CoreDataProperties.swift
@@ -1,5 +1,5 @@
-import Foundation
 import CoreData
+import Foundation
 
 extension Relay {
 

--- a/Nos/Models/CoreData/NosNotification+CoreDataClass.swift
+++ b/Nos/Models/CoreData/NosNotification+CoreDataClass.swift
@@ -1,7 +1,7 @@
-import Foundation
 import CoreData
+import Foundation
 
-/// Represents a notification we will display to the user. We save records of them to the database in order to 
+/// Represents a notification we will display to the user. We save records of them to the database in order to
 /// de-duplicate them and keep track of whether they have been seen by the user.
 @objc(NosNotification)
 public class NosNotification: NSManagedObject {
@@ -26,16 +26,16 @@ public class NosNotification: NSManagedObject {
             return notification
         }
     }
-    
+
     static func find(by eventID: RawEventID, in context: NSManagedObjectContext) throws -> NosNotification? {
         let fetchRequest = request(by: eventID)
         if let notification = try context.fetch(fetchRequest).first {
             return notification
         }
-        
+
         return nil
     }
-    
+
     static func request(by eventID: RawEventID) -> NSFetchRequest<NosNotification> {
         let fetchRequest = NSFetchRequest<NosNotification>(entityName: String(describing: NosNotification.self))
         fetchRequest.predicate = NSPredicate(format: "eventID = %@", eventID)
@@ -43,13 +43,13 @@ public class NosNotification: NSManagedObject {
         fetchRequest.sortDescriptors = [NSSortDescriptor(keyPath: \NosNotification.eventID, ascending: false)]
         return fetchRequest
     }
-    
+
     static func unreadCount(in context: NSManagedObjectContext) throws -> Int {
         let fetchRequest = NSFetchRequest<NosNotification>(entityName: String(describing: NosNotification.self))
         fetchRequest.predicate = NSPredicate(format: "isRead != 1")
         return try context.count(for: fetchRequest)
     }
-    
+
     // TODO: user is unused; is this a bug?
     static func markAllAsRead(in context: NSManagedObjectContext) async throws {
         try await context.perform {
@@ -59,7 +59,7 @@ public class NosNotification: NSManagedObject {
             for notification in unreadNotifications {
                 notification.isRead = true
             }
-            
+
             try? context.saveIfNeeded()
         }
     }

--- a/Nos/Models/CoreData/Relay+CoreDataClass.swift
+++ b/Nos/Models/CoreData/Relay+CoreDataClass.swift
@@ -1,5 +1,5 @@
-import Foundation
 import CoreData
+import Foundation
 
 enum RelayError: Error {
     case invalidAddress
@@ -12,41 +12,41 @@ public class Relay: NosManagedObject {
 
     static var recommended: [String] {
         [
-        nosAddress.absoluteString,
-        "wss://relay.damus.io",
-        "wss://purplepag.es",
-        "wss://nos.lol",
+            nosAddress.absoluteString,
+            "wss://relay.damus.io",
+            "wss://purplepag.es",
+            "wss://nos.lol",
         ]
     }
-    
+
     static var allKnown: [String] {
         [
-        "wss://eden.nostr.land",
-        "wss://nostr.fmt.wiz.biz",
-        "wss://relay.damus.io",
-        "wss://nostr-pub.wellorder.net",
-        "wss://relay.nostr.info",
-        "wss://offchain.pub",
-        "wss://nos.lol",
-        "wss://brb.io",
-        "wss://relay.snort.social",
-        "wss://relay.current.fyi",
-        "wss://nostr.relayer.se",
-        "wss://e.nos.lol",
-        "wss://purplepag.es",
-        "wss://soloco.nl",
-        "wss://relayable.org",
-        nosAddress.absoluteString,
-        "wss://relay.causes.com",
+            "wss://eden.nostr.land",
+            "wss://nostr.fmt.wiz.biz",
+            "wss://relay.damus.io",
+            "wss://nostr-pub.wellorder.net",
+            "wss://relay.nostr.info",
+            "wss://offchain.pub",
+            "wss://nos.lol",
+            "wss://brb.io",
+            "wss://relay.snort.social",
+            "wss://relay.current.fyi",
+            "wss://nostr.relayer.se",
+            "wss://e.nos.lol",
+            "wss://purplepag.es",
+            "wss://soloco.nl",
+            "wss://relayable.org",
+            nosAddress.absoluteString,
+            "wss://relay.causes.com",
         ]
     }
 
     /// Relays that should be used for NIP-50 search and will be excluded from other requests.
     /// In the future we should use the kind 10007 search relays list instead of this hardcoded list.
-    static var searchOnly: [URL] = { 
-        ["wss://relay.nostr.band"].compactMap { URL(string: $0) } 
+    static var searchOnly: [URL] = {
+        ["wss://relay.nostr.band"].compactMap { URL(string: $0) }
     }()
-    
+
     // swiftlint:disable:next force_unwrapping
     static var nosAddress = URL(string: "wss://relay.nos.social")!
 
@@ -57,29 +57,29 @@ public class Relay: NosManagedObject {
         fetchRequest.fetchLimit = 1
         return fetchRequest
     }
-    
+
     @nonobjc public class func relays(for user: Author) -> NSFetchRequest<Relay> {
         let fetchRequest = NSFetchRequest<Relay>(entityName: "Relay")
         fetchRequest.predicate = NSPredicate(format: "ANY authors = %@", user)
         fetchRequest.sortDescriptors = [NSSortDescriptor(keyPath: \Relay.address, ascending: true)]
         return fetchRequest
     }
-    
+
     /// Retreives all the Relays that are no longer referenced by anyone in the db.
     static func orphanedRequest() -> NSFetchRequest<Relay> {
         let fetchRequest = NSFetchRequest<Relay>(entityName: "Relay")
         fetchRequest.sortDescriptors = [NSSortDescriptor(keyPath: \Relay.address, ascending: false)]
         fetchRequest.predicate = NSPredicate(
-            format: "SUBQUERY(authors, $a, TRUEPREDICATE).@count = 0 AND " +
-                "SUBQUERY(deletedEvents, $d, TRUEPREDICATE).@count = 0 AND " +
-                "SUBQUERY(events, $e, TRUEPREDICATE).@count = 0 AND " +
-                "SUBQUERY(publishedEvents, $e, TRUEPREDICATE).@count = 0 AND " +
-                "SUBQUERY(shouldBePublishedEvents, $r, TRUEPREDICATE).@count = 0"
+            format: "SUBQUERY(authors, $a, TRUEPREDICATE).@count = 0 AND "
+                + "SUBQUERY(deletedEvents, $d, TRUEPREDICATE).@count = 0 AND "
+                + "SUBQUERY(events, $e, TRUEPREDICATE).@count = 0 AND "
+                + "SUBQUERY(publishedEvents, $e, TRUEPREDICATE).@count = 0 AND "
+                + "SUBQUERY(shouldBePublishedEvents, $r, TRUEPREDICATE).@count = 0"
         )
-            
+
         return fetchRequest
     }
-    
+
     @discardableResult
     class func findOrCreate(by address: String, context: NSManagedObjectContext) throws -> Relay {
         if let existingRelay = try context.fetch(Relay.relay(by: address)).first {
@@ -115,10 +115,11 @@ public class Relay: NosManagedObject {
 
     private convenience init(context: NSManagedObjectContext, address: String, author: Author? = nil) throws {
         guard let addressURL = URL(string: address),
-            addressURL.scheme == "wss" else {
+            addressURL.scheme == "wss"
+        else {
             throw RelayError.invalidAddress
         }
-        
+
         self.init(context: context)
         self.address = addressURL.strippingTrailingSlash()
         self.createdAt = Date.now
@@ -127,14 +128,14 @@ public class Relay: NosManagedObject {
             author.add(relay: self)
         }
     }
-    
+
     var addressURL: URL? {
         if let address {
             return URL(string: address)
         }
         return nil
     }
-    
+
     var host: String? {
         addressURL?.host
     }

--- a/Nos/Models/EventKind.swift
+++ b/Nos/Models/EventKind.swift
@@ -35,7 +35,7 @@ public enum EventKind: Int64, CaseIterable, Hashable {
 
     /// Request to Vanish
     case requestToVanish = 62
-    
+
     /// Gift Wrap
     case giftWrap = 1059
 
@@ -50,16 +50,16 @@ public enum EventKind: Int64, CaseIterable, Hashable {
 
     /// Zap Request
     case zapRequest = 9734
-    
+
     /// Zap Receipt
     case zapReceipt = 9735
-    
+
     /// Mute List
     case mute = 10_000
 
     /// NIP-98 HTTP Authentication
     case httpAuth = 27_235
-    
+
     // NIP-42 Relay Authentication
     case relayAuth = 22_242
 

--- a/Nos/Models/ExpirationTimeOption.swift
+++ b/Nos/Models/ExpirationTimeOption.swift
@@ -2,17 +2,17 @@ import Foundation
 
 /// Options for expiring messages - each of these represents a length of time before a message expires.
 enum ExpirationTimeOption: Double, Identifiable, CaseIterable {
-    
+
     // Raw value is the number of seconds until this message expires
     case oneHour = 3600
     case oneDay = 86_400
     case sevenDays = 604_800
-    case oneYear = 31_536_000 
-    
+    case oneYear = 31_536_000
+
     var id: TimeInterval {
         rawValue
     }
-    
+
     // The text that will be displayed at the top of a button representing this option.
     var topText: String {
         switch self {
@@ -26,7 +26,7 @@ enum ExpirationTimeOption: Double, Identifiable, CaseIterable {
             return "365"
         }
     }
-    
+
     // The text that will be displayed below `topText`, representing the unit of time this option uses.
     var unit: String {
         switch self {
@@ -40,11 +40,11 @@ enum ExpirationTimeOption: Double, Identifiable, CaseIterable {
             return String(localized: .localizable.daysAbbreviated)
         }
     }
-    
+
     var timeInterval: TimeInterval {
         rawValue
     }
-    
+
     var accessibilityLabel: String {
         "\(topText) \(unit)"
     }

--- a/Nos/Models/FlagOption.swift
+++ b/Nos/Models/FlagOption.swift
@@ -13,7 +13,7 @@ struct FlagOption: Identifiable, Equatable {
     /// and inserts it into a localizable string to provide additional context or details for the current flag.
     /// This message is shown in the info box based on the current selection.
     /// - Parameter String?: The title of the previously selected flag, if available.
-    /// - Returns: A message related to the current flag based on the previous selection, 
+    /// - Returns: A message related to the current flag based on the previous selection,
     /// or `nil` if no message is provided.
     let info: ((String?) -> String?)?
 
@@ -50,7 +50,7 @@ struct FlagOption: Identifiable, Equatable {
             description: String(localized: .localizable.flagPubliclyDescription),
             info: nil,
             category: .privacy(.publicly)
-        )
+        ),
     ]
 
     /// `FlagOption` instances representing different categories of how a user can be flagged.
@@ -69,7 +69,7 @@ struct FlagOption: Identifiable, Equatable {
             description: String(localized: .localizable.flagPubliclyDescription),
             info: nil,
             category: .privacy(.publicly)
-        )
+        ),
     ]
 
     /// `FlagOption` instances representing different categories of the visibility of a flagged user.
@@ -85,7 +85,7 @@ struct FlagOption: Identifiable, Equatable {
             description: String(localized: .localizable.flagUserDontMuteDescription),
             info: nil,
             category: .visibility(.dontMute)
-        )
+        ),
     ]
 
     static func == (lhs: FlagOption, rhs: FlagOption) -> Bool {
@@ -100,7 +100,7 @@ extension FlagOption {
         info: nil,
         category: .report(ReportCategory.spam)
     )
-    
+
     static let harassment = FlagOption(
         title: String(localized: .localizable.flagContentHarassmentTitle),
         description: String(localized: .localizable.flagContentHarassmentDescription),

--- a/Nos/Models/JSONEvent+Kinds.swift
+++ b/Nos/Models/JSONEvent+Kinds.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 extension JSONEvent {
-    
+
     /// An event that represents the user's contact list (who they are following) and their relays.
     /// - Parameters:
     ///   - pubKey: The pubkey of the user whose contact list and relays the event represents.
@@ -11,7 +11,7 @@ extension JSONEvent {
     static func contactList(pubKey: String, tags: [[String]], relayAddresses: [String]) -> JSONEvent {
         let relayStrings = relayAddresses.map { "\"\($0)\":{\"write\":true,\"read\":true}" }
         let content = "{" + relayStrings.joined(separator: ",") + "}"
-        
+
         return JSONEvent(
             pubKey: pubKey,
             kind: .contactList,
@@ -19,7 +19,7 @@ extension JSONEvent {
             content: content
         )
     }
-    
+
     /// An event that represents the user's request for all of their published notes to be removed from relays.
     /// - Parameters:
     ///   - pubKey: The public key of the user making the request.
@@ -34,7 +34,7 @@ extension JSONEvent {
         } else {
             tags = [["relay", "ALL_RELAYS"]]
         }
-        
+
         return JSONEvent(
             pubKey: pubKey,
             kind: .requestToVanish,

--- a/Nos/Models/JSONEvent.swift
+++ b/Nos/Models/JSONEvent.swift
@@ -1,9 +1,9 @@
-import secp256k1
 import Foundation
 import Logger
+import secp256k1
 
 struct JSONEvent: Codable, Hashable, VerifiableEvent {
-    
+
     var id: String
     var pubKey: String
     var createdAt: Int64
@@ -22,7 +22,7 @@ struct JSONEvent: Codable, Hashable, VerifiableEvent {
         case content
         case signature = "sig"
     }
-    
+
     internal init(
         id: String,
         pubKey: String,
@@ -40,7 +40,7 @@ struct JSONEvent: Codable, Hashable, VerifiableEvent {
         self.content = content
         self.signature = signature
     }
-    
+
     internal init(
         pubKey: RawAuthorID,
         createdAt: Date = .now,
@@ -100,23 +100,23 @@ struct JSONEvent: Codable, Hashable, VerifiableEvent {
         guard let jsonData = json.data(using: .utf8) else {
             return nil
         }
-        
+
         let decoder = JSONDecoder()
         return try? decoder.decode(JSONEvent.self, from: jsonData)
     }
-    
+
     func toJSON() throws -> String? {
         let encoder = JSONEncoder()
         let data = try encoder.encode(self)
         return String(decoding: data, as: UTF8.self)
     }
-    
+
     mutating func sign(withKey privateKey: KeyPair) throws {
         id = try calculateIdentifier()
         var serializedBytes = try id.bytes
         signature = try privateKey.sign(bytes: &serializedBytes)
     }
-    
+
     var serializedEventForSigning: [Any?] {
         [
             0,
@@ -124,10 +124,10 @@ struct JSONEvent: Codable, Hashable, VerifiableEvent {
             createdAt,
             kind,
             tags,
-            content
+            content,
         ]
     }
-    
+
     func calculateIdentifier() throws -> String {
         let serializedEventData = try JSONSerialization.data(
             withJSONObject: serializedEventForSigning,
@@ -135,7 +135,7 @@ struct JSONEvent: Codable, Hashable, VerifiableEvent {
         )
         return serializedEventData.sha256
     }
-    
+
     var dictionary: [String: Any] {
         [
             "id": id,
@@ -147,7 +147,7 @@ struct JSONEvent: Codable, Hashable, VerifiableEvent {
             "sig": signature ?? "",
         ]
     }
-    
+
     var createdDate: Date {
         Date(timeIntervalSince1970: TimeInterval(createdAt))
     }
@@ -164,7 +164,7 @@ struct JSONEvent: Codable, Hashable, VerifiableEvent {
     func buildPublishRequest() throws -> String {
         let request: [Any] = ["EVENT", dictionary]
         let requestData = try JSONSerialization.data(withJSONObject: request)
-        return String(decoding: requestData, as: UTF8.self) 
+        return String(decoding: requestData, as: UTF8.self)
     }
 }
 
@@ -176,15 +176,18 @@ struct MetadataEventJSON: Codable {
     var about: String?
     var website: String?
     var picture: String?
-    
+
     var profilePhotoURL: URL? {
         URL(string: picture ?? "")
     }
-    
+
     private enum CodingKeys: String, CodingKey {
-        case displayName = "display_name", name, nip05, uns = "uns_name", about, website, picture
+        case displayName = "display_name"
+        case name, nip05
+        case uns = "uns_name"
+        case about, website, picture
     }
-    
+
     var dictionary: [String: String] {
         [
             "display_name": displayName ?? "",

--- a/Nos/Models/LoadingContent.swift
+++ b/Nos/Models/LoadingContent.swift
@@ -1,5 +1,6 @@
 import Foundation
 
 enum LoadingContent<Content: Equatable>: Equatable {
-    case loading, loaded(Content)
+    case loading
+    case loaded(Content)
 }

--- a/Nos/Models/OpenGraph/OpenGraphMetatdata.swift
+++ b/Nos/Models/OpenGraph/OpenGraphMetatdata.swift
@@ -25,7 +25,7 @@ struct OpenGraphMedia: Equatable {
 
     /// The height of the media.
     let height: Double?
-    
+
     /// Initializes an `OpenGraphMedia` with the given parameters. Returns `nil` if all parameter values are `nil`.
     /// - Parameters:
     ///   - url: The URL of the media.

--- a/Nos/Models/OpenGraph/SoupOpenGraphParser.swift
+++ b/Nos/Models/OpenGraph/SoupOpenGraphParser.swift
@@ -49,7 +49,7 @@ extension SoupOpenGraphParser {
 
         return OpenGraphMedia(url: url, width: width, height: height)
     }
-    
+
     /// Gets the Open Graph type metadata from the given HTML document.
     /// - Parameter document: The HTML document.
     /// - Returns: The Open Graph type metadata, or `nil` if none is found

--- a/Nos/Models/ParseQueue.swift
+++ b/Nos/Models/ParseQueue.swift
@@ -1,21 +1,21 @@
+import DequeModule
 import Foundation
 import Starscream
-import DequeModule
 
-/// An actor that queues up received Event JSON for parsing. 
+/// An actor that queues up received Event JSON for parsing.
 actor ParseQueue {
     private var events = Deque<(JSONEvent, WebSocket)>()
-    
+
     func push(_ event: JSONEvent, from socket: WebSocket) {
         events.append((event, socket))
     }
-    
+
     func pop(_ count: Int) -> [(JSONEvent, WebSocket)] {
         let poppedEvents = Array(events.prefix(count))
         events.removeFirst(min(events.count, count))
         return poppedEvents
     }
-    
+
     var count: Int {
         events.count
     }

--- a/Nos/Models/PublicKey.swift
+++ b/Nos/Models/PublicKey.swift
@@ -4,7 +4,7 @@ import secp256k1_bindings
 
 enum KeyError: Error {
     case invalidPubKey
-    
+
     var description: String? {
         switch self {
         case .invalidPubKey:
@@ -19,7 +19,7 @@ struct PublicKey {
     var hex: RawAuthorID
     let npub: String
     let bytes: [UInt8]
-     
+
     private let underlyingKey: secp256k1.Signing.XonlyKey
 
     static func build(npubOrHex: String) -> PublicKey? {
@@ -35,7 +35,7 @@ struct PublicKey {
             return nil
         }
     }
-    
+
     init?(npub: String) {
         do {
             let identifier = try NostrIdentifier.decode(bech32String: npub)

--- a/Nos/Models/RawNostrID.swift
+++ b/Nos/Models/RawNostrID.swift
@@ -3,13 +3,13 @@ import Foundation
 // swiftlint:disable line_length
 
 /// A unique ID for either a Nostr user or event. In the case of a user this is their hex-encoded public key. If it's
-/// an event it is the hex-encoded sha256 of the serialized event data. See [NIP-01](https://github.com/nostr-protocol/nips/blob/master/01.md)) 
+/// an event it is the hex-encoded sha256 of the serialized event data. See [NIP-01](https://github.com/nostr-protocol/nips/blob/master/01.md))
 /// for details.
 ///
-/// These IDs are widely used at the protocol level, but should never be displayed to users. When displaying IDs to 
+/// These IDs are widely used at the protocol level, but should never be displayed to users. When displaying IDs to
 /// users they should be bech-32 formatted strings as described by [NIP-19](https://github.com/nostr-protocol/nips/blob/master/19.md)
-/// 
-/// For now we are modeling this as a String because it's easy and can be stored natively in Core Data but it could be 
+///
+/// For now we are modeling this as a String because it's easy and can be stored natively in Core Data but it could be
 /// refactored to be its own type.
 public typealias RawNostrID = String
 // swiftlint:enable line_length
@@ -21,14 +21,14 @@ public typealias RawEventID = RawNostrID
 public typealias RawAuthorID = RawNostrID
 
 extension RawNostrID {
-    
+
     /// Verifies that this ID is the right length and is a hexadecimal string. It cannot check that this refers to a
     /// real Nostr user or event.
     var isValid: Bool {
         if count != 64 {
             return false
         }
-        
+
         return isValidHexadecimal
     }
 }

--- a/Nos/Models/RelaySubscription.swift
+++ b/Nos/Models/RelaySubscription.swift
@@ -1,44 +1,44 @@
+import Combine
 import Foundation
 import Logger
-import Combine
 
-/// Models a request to a relay for Nostr Events. 
+/// Models a request to a relay for Nostr Events.
 class RelaySubscription: Identifiable, Hashable {
-    
-    var id: String 
-    
+
+    var id: String
+
     let filter: Filter
-    
+
     /// The relay this Filter should be sent to.
     let relayAddress: URL
-    
+
     /// The date this Filter was opened as a subscription on relays. Used to close stale subscriptions
     var subscriptionStartDate: Date?
-    
+
     /// The number of events that have been returned for this subscription
     var receivedEventCount = 0
-    
+
     /// The number of objects using this filter. This is incremented and decremented by the RelayService to determine
     /// when a filter can be closed.
     var referenceCount: Int = 0
-    
-    /// An observable stream of events that should emit every event downloaded on this subscription 
+
+    /// An observable stream of events that should emit every event downloaded on this subscription
     let events = PassthroughSubject<JSONEvent, Never>()
-    
+
     var isActive: Bool {
         subscriptionStartDate != nil
     }
-    
+
     /// Whether this RelaySubscription should close the subscription to the
     /// filter after receiving a response.
     var closesAfterResponse: Bool {
         !filter.keepSubscriptionOpen
     }
-    
+
     internal init(
-        filter: Filter, 
-        relayAddress: URL, 
-        subscriptionStartDate: Date? = nil, 
+        filter: Filter,
+        relayAddress: URL,
+        subscriptionStartDate: Date? = nil,
         referenceCount: Int = 0
     ) {
         self.filter = filter
@@ -48,16 +48,13 @@ class RelaySubscription: Identifiable, Hashable {
         self.subscriptionStartDate = subscriptionStartDate
         self.referenceCount = referenceCount
     }
-    
+
     static func == (lhs: RelaySubscription, rhs: RelaySubscription) -> Bool {
-        lhs.id == rhs.id &&
-        lhs.filter == rhs.filter &&
-        lhs.relayAddress == rhs.relayAddress &&
-        lhs.subscriptionStartDate == rhs.subscriptionStartDate &&
-        lhs.referenceCount == rhs.referenceCount &&
-        lhs.isActive == rhs.isActive
+        lhs.id == rhs.id && lhs.filter == rhs.filter && lhs.relayAddress == rhs.relayAddress
+            && lhs.subscriptionStartDate == rhs.subscriptionStartDate && lhs.referenceCount == rhs.referenceCount
+            && lhs.isActive == rhs.isActive
     }
-    
+
     func hash(into hasher: inout Hasher) {
         hasher.combine(id)
         hasher.combine(filter)

--- a/Nos/Models/ReportCategory.swift
+++ b/Nos/Models/ReportCategory.swift
@@ -7,20 +7,20 @@ struct ReportCategory: Identifiable, Equatable {
     var displayName: String {
         String(localized: name)
     }
-    
+
     var name: LocalizedStringResource
-    
+
     /// The machine-readable code corresponding to this category.
     var code: String
-    
+
     /// A code matching a NIP-56 category, for backwards compatibility
     var nip56Code: NIP56Code
-    
+
     /// A list of all sub-categories that narrow this one down.
     var subCategories: [ReportCategory]?
-    
+
     var id: String { code }
-    
+
     static func findCategory(from code: String) -> ReportCategory? {
         var searchForCategoryByCode: ((String, [ReportCategory]) -> ReportCategory?)?
         searchForCategoryByCode = { (code: String, categories: [ReportCategory]) -> ReportCategory? in
@@ -33,10 +33,10 @@ struct ReportCategory: Identifiable, Equatable {
                     }
                 }
             }
-            
+
             return nil
         }
-        
+
         return searchForCategoryByCode?(code, ReportCategory.allCategories)
     }
 }
@@ -51,7 +51,7 @@ extension ReportCategory {
         code: "CL",
         nip56Code: .profanity
     )
-    
+
     static let likelyToCauseHarm = ReportCategory(
         name: .moderation.likelyToCauseHarm,
         code: "HC",
@@ -69,7 +69,7 @@ extension ReportCategory {
         code: "IH",
         nip56Code: .other
     )
-    
+
     static let illegal = ReportCategory(
         name: .moderation.illegal,
         code: "IL",
@@ -91,7 +91,7 @@ extension ReportCategory {
         code: "NW",
         nip56Code: .nudity
     )
-    
+
     static let impersonation = ReportCategory(
         name: .moderation.impersonation,
         code: "IM",
@@ -108,7 +108,7 @@ extension ReportCategory {
             ReportSubCategoryType.sex,
         ]
     )
-    
+
     static let pornography = ReportCategory(
         name: .moderation.pornography,
         code: "PN",
@@ -122,7 +122,7 @@ extension ReportCategory {
             ReportSubCategoryType.genderFluidNonBinaryPorn,
         ]
     )
-    
+
     static let spam = ReportCategory(name: .moderation.spam, code: "SP", nip56Code: .spam)
 
     static let violence = ReportCategory(
@@ -178,7 +178,7 @@ enum ReportSubCategoryType {
         code: "IL-cop",
         nip56Code: .illegal
     )
-    
+
     static let childSexualAbuse = ReportCategory(
         name: .moderation.childSexualAbuse,
         code: "IL-csa",
@@ -189,98 +189,98 @@ enum ReportSubCategoryType {
         code: "IL-drg",
         nip56Code: .illegal
     )
-    
+
     static let fraudAndScams = ReportCategory(
         name: .moderation.fraudAndScams,
         code: "IL-frd",
         nip56Code: .illegal
     )
-    
+
     static let harassmentStalkingOrDoxxing = ReportCategory(
         name: .moderation.harassmentStalkingOrDoxxing,
         code: "IL-har",
         nip56Code: .illegal
     )
-    
+
     static let prostitution = ReportCategory(
         name: .moderation.prostitution,
         code: "IL-swk",
         nip56Code: .illegal
     )
-    
+
     static let impersonation = ReportCategory(
         name: .moderation.impersonation,
         code: "IL-idt",
         nip56Code: .illegal
     )
-    
+
     static let malware = ReportCategory(
         name: .moderation.malware,
         code: "IL-mal",
         nip56Code: .illegal
     )
-    
+
     static let casualNudity = ReportCategory(
         name: .moderation.casualNudity,
         code: "NS-nud",
         nip56Code: .nudity
     )
-    
+
     static let erotica = ReportCategory(
         name: .moderation.erotica,
         code: "NS-ero",
         nip56Code: .nudity
     )
-    
+
     // swiftlint:disable:next identifier_name
     static let sex = ReportCategory(
         name: .moderation.sex,
         code: "NS-sex",
         nip56Code: .nudity
     )
-    
+
     static let heterosexualPorn = ReportCategory(
         name: .moderation.heterosexualPorn,
         code: "PN-het",
         nip56Code: .nudity
     )
-    
+
     static let gayMalePorn = ReportCategory(
         name: .moderation.gayMalePorn,
         code: "PN-gay",
         nip56Code: .nudity
     )
-    
+
     static let lesbianPorn = ReportCategory(
         name: .moderation.lesbianPorn,
         code: "PN-les",
         nip56Code: .nudity
     )
-    
+
     static let bisexualPorn = ReportCategory(
         name: .moderation.bisexualPorn,
         code: "PN-bis",
         nip56Code: .nudity
     )
-    
+
     static let transsexualPorn = ReportCategory(
         name: .moderation.transsexualPorn,
         code: "PN-trn",
         nip56Code: .nudity
     )
-    
+
     static let genderFluidNonBinaryPorn = ReportCategory(
         name: .moderation.genderFluidNonBinaryPorn,
         code: "PN-fnb",
         nip56Code: .nudity
     )
-    
+
     static let violenceTowardsAHumanBeing = ReportCategory(
         name: .moderation.violenceTowardsAHumanBeing,
         code: "VI-hum",
         nip56Code: .other
     )
-    
+
     static let violenceTowardsASentientAnimal = ReportCategory(
         name: .moderation.violenceTowardsASentientAnimal,
         code: "VI-ani",

--- a/Nos/Models/ReportTarget.swift
+++ b/Nos/Models/ReportTarget.swift
@@ -2,10 +2,10 @@ import Foundation
 
 /// The types of objects that can be reported.
 enum ReportTarget {
-    
+
     case note(Event)
     case author(Author)
-    
+
     /// The author who owns the content being reported.
     var author: Author? {
         switch self {
@@ -15,7 +15,7 @@ enum ReportTarget {
             return author
         }
     }
-    
+
     var analyticsString: String {
         switch self {
         case .note:
@@ -24,9 +24,9 @@ enum ReportTarget {
             return "profile"
         }
     }
-    
+
     /// Creates tags referencing this target that can be attached to a report event.
-    ///  - Parameter reportType: the NIP-56 report_type (spam, illegal, etc.) 
+    ///  - Parameter reportType: the NIP-56 report_type (spam, illegal, etc.)
     func tags(for reportType: String) -> [[String]] {
         var tags = [[String]]()
         switch self {
@@ -42,7 +42,7 @@ enum ReportTarget {
                 tags.append(["p", pubKey])
             }
         }
-        
+
         return tags
     }
 }

--- a/Nos/Models/SubscriptionCancellable.swift
+++ b/Nos/Models/SubscriptionCancellable.swift
@@ -1,35 +1,35 @@
 import Foundation
 
-/// A handle that holds references to one or more `RelaySubscription`s and provides the ability to cancel these 
+/// A handle that holds references to one or more `RelaySubscription`s and provides the ability to cancel these
 /// subscriptions. Will auto-cancel them when it is deallocated. Modeled after Combine's `Cancellable`.
 class SubscriptionCancellable {
     private var subscriptionIDs: [RelaySubscription.ID]
     private var subscriptionCancellables = [SubscriptionCancellable]()
     private weak var relayService: RelayService?
-    
+
     init(subscriptionIDs: [RelaySubscription.ID], relayService: RelayService) {
         self.subscriptionIDs = subscriptionIDs
         self.relayService = relayService
     }
-    
+
     init(cancellables: [SubscriptionCancellable], relayService: RelayService) {
         self.subscriptionCancellables = cancellables
         self.subscriptionIDs = []
         self.relayService = relayService
     }
-    
+
     private init() {
         self.subscriptionIDs = []
     }
-    
+
     deinit {
         cancel()
     }
-    
+
     static func empty() -> SubscriptionCancellable {
         SubscriptionCancellable()
     }
-    
+
     func cancel() {
         relayService?.decrementSubscriptionCount(for: subscriptionIDs)
     }

--- a/Nos/Models/URLParser.swift
+++ b/Nos/Models/URLParser.swift
@@ -7,13 +7,15 @@ struct URLParser {
     /// A regular expression pattern for matching URLs.
     /// - Note: Uses rules from the [Domain Name System](https://en.wikipedia.org/wiki/Domain_Name_System#Domain_name_syntax,_internationalization)
     ///         page on Wikipedia.
-    static let urlRegex = "(\\s*)(?<url>((https?://){1}|(?<![\\w@.]))([a-zA-Z0-9][-a-zA-Z0-9]{0,62}\\.){1,127}[a-z]{2,63}\\b[-a-zA-Z0-9@:%_\\+.~#?&/=]*(?<![.,!?\\)\\]]))"
+    static let urlRegex =
+        "(\\s*)(?<url>((https?://){1}|(?<![\\w@.]))([a-zA-Z0-9][-a-zA-Z0-9]{0,62}\\.){1,127}[a-z]{2,63}\\b[-a-zA-Z0-9@:%_\\+.~#?&/=]*(?<![.,!?\\)\\]]))"
     // swiftlint:enable line_length
 
     /// Returns an array with all unformatted urls
     func findUnformattedURLs(in content: String) throws -> [URL] {
         // swiftlint:disable line_length
-        let regex = "((http|https)?:\\/\\/.)?(www\\.)?[-a-zA-Z0-9@:%._\\+~#=]{2,256}\\.[a-z]{2,6}\\b([-a-zA-Z0-9@:%_\\+.~#?&//=]*)"
+        let regex =
+            "((http|https)?:\\/\\/.)?(www\\.)?[-a-zA-Z0-9@:%._\\+~#=]{2,256}\\.[a-z]{2,6}\\b([-a-zA-Z0-9@:%_\\+.~#?&//=]*)"
         // swiftlint:enable line_length
 
         var links = [URL]()
@@ -52,7 +54,7 @@ struct URLParser {
 
         return (mutableString as String, urls)
     }
-    
+
     /// Replaces raw URLs with Markdown links in the given `mutableString`. Removes media URLs (image and video) from
     /// `mutableString` and converts all other URLs to pretty Markdown links for display.
     /// - Parameter mutableString: The mutable string that may contain URLs and will be modified for display.

--- a/Nos/Models/VerifiableEvent.swift
+++ b/Nos/Models/VerifiableEvent.swift
@@ -5,7 +5,7 @@ protocol VerifiableEvent {
     var pubKey: String { get }
     var signature: String? { get }
     var identifier: RawEventID? { get }
-    
+
     func verifySignature(for pubkey: PublicKey) throws -> Bool
     func calculateIdentifier() throws -> String
 }
@@ -14,11 +14,11 @@ extension VerifiableEvent {
     func verifySignature(for pubkey: PublicKey) throws -> Bool {
         // Verify that identifier matches contents
         let calculatedIdentifier = try self.calculateIdentifier()
-        
+
         guard calculatedIdentifier == self.identifier else {
             return false
         }
-        
+
         let signedBytes = try calculatedIdentifier.bytes
         let schnorrSignature = try secp256k1.Schnorr.SchnorrSignature(dataRepresentation: try self.signature!.bytes)
         var rawPubKey = secp256k1_xonly_pubkey()
@@ -26,7 +26,7 @@ extension VerifiableEvent {
         guard secp256k1_xonly_pubkey_parse(contextPointer, &rawPubKey, pubkey.bytes).boolValue else {
             throw KeyError.invalidPubKey
         }
-        
+
         let signatureIsValid = secp256k1_schnorrsig_verify(
             contextPointer,
             schnorrSignature.dataRepresentation.bytes,
@@ -34,17 +34,17 @@ extension VerifiableEvent {
             signedBytes.count,
             &rawPubKey
         ).boolValue
-        
+
         return signatureIsValid
     }
-    
+
     func verifySignature(for rawAuthorId: RawAuthorID) throws -> Bool {
         guard let publicKey = PublicKey(hex: rawAuthorId) else {
             return false
         }
-        
+
         return try self.verifySignature(for: publicKey)
     }
-    
+
     func verifySignature() throws -> Bool { try self.verifySignature(for: self.pubKey) }
 }

--- a/Nos/Models/WebSockets/WebSocketConnection.swift
+++ b/Nos/Models/WebSockets/WebSocketConnection.swift
@@ -3,8 +3,8 @@ import Starscream
 /// Represents a connection to a websocket with state tracking. Utilizes a Starscream WebSocket under the hood.
 class WebSocketConnection {
     let socket: WebSocket
-    var state: WebSocketState 
-    
+    var state: WebSocketState
+
     init(socket: WebSocket, state: WebSocketState = .disconnected) {
         self.socket = socket
         self.state = state

--- a/Nos/Models/WebSockets/WebSocketErrorEvent.swift
+++ b/Nos/Models/WebSockets/WebSocketErrorEvent.swift
@@ -5,7 +5,7 @@ import Foundation
 struct WebSocketErrorEvent: Equatable {
     var retryCounter: Int = 1
     var nextRetry: Date = .now
-    
+
     mutating func trackRetry() {
         self.retryCounter += 1
         let delaySeconds = NSDecimalNumber(

--- a/Nos/Models/WebSockets/WebSocketState.swift
+++ b/Nos/Models/WebSockets/WebSocketState.swift
@@ -1,19 +1,19 @@
-/// The states a WebSocketConnection can be in. These states are used by `RelaySubscriptionManager` to move each 
+/// The states a WebSocketConnection can be in. These states are used by `RelaySubscriptionManager` to move each
 /// socket to the `connected` state where we can start executing requests, taking into account time to connect, errors
 /// and authentication.
 enum WebSocketState: Equatable {
     /// This socket is disconnected.
-    case disconnected 
-    
+    case disconnected
+
     /// The socket is in the process of connecting.
     case connecting
-    
+
     /// The socket has requested authentication from us.
-    case authenticating(RawEventID) 
-    
+    case authenticating(RawEventID)
+
     /// The socket is connected and ready to receive requests.
-    case connected 
-    
+    case connected
+
     /// This socket has closed on an error. We record this and do exponential backoff before retrying.
     case errored(WebSocketErrorEvent)
 }

--- a/Nos/NosApp.swift
+++ b/Nos/NosApp.swift
@@ -1,10 +1,10 @@
-import SwiftUI
-import Logger
 import Dependencies
+import Logger
+import SwiftUI
 
 @main
 struct NosApp: App {
-    
+
     @Dependency(\.crashReporting) private var crashReporting
     @Dependency(\.persistenceController) private var persistenceController
     @Dependency(\.relayService) private var relayService
@@ -14,16 +14,16 @@ struct NosApp: App {
     private let appController = AppController()
     @Environment(\.scenePhase) private var scenePhase
     @UIApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
-    
+
     init() {
-        _ = crashReporting // force crash reporting init as early as possible
-        
+        _ = crashReporting  // force crash reporting init as early as possible
+
         // hack to fix confirmationDialog color issue
         // https://github.com/planetary-social/nos/issues/1064
         UIView.appearance(whenContainedInInstancesOf: [UIAlertController.self]).tintColor = .systemBlue
         persistenceController.scheduleBackgroundCleanupTask()
     }
-    
+
     var body: some Scene {
         WindowGroup {
             AppView()

--- a/Nos/Router.swift
+++ b/Nos/Router.swift
@@ -1,8 +1,8 @@
-import SwiftUI
 import Combine
 import CoreData
-import Logger
 import Dependencies
+import Logger
+import SwiftUI
 
 // Manages the app's navigation state.
 @MainActor class Router: ObservableObject {
@@ -18,7 +18,7 @@ import Dependencies
     @Dependency(\.relayService) private var relayService
     @Dependency(\.crashReporting) private var crashReporting
 
-    /// The `NavigationPath` of the tab (or side menu) the user currently has open. 
+    /// The `NavigationPath` of the tab (or side menu) the user currently has open.
     /// This has to be a two-way binding, but really the only things that should be modifying it are the `Router`
     /// or a `NavigationStack`. Don't mutate it directly outside this class.
     var currentPath: Binding<NavigationPath> {
@@ -47,12 +47,12 @@ import Dependencies
     func push<D: Hashable>(_ destination: D) {
         currentPath.wrappedValue.append(destination)
     }
-    
+
     /// Pushes a view displaying the object wrapped in a `NosNavigationDestination`.
     func push(_ destination: NosNavigationDestination) {
         currentPath.wrappedValue.append(destination)
     }
-    
+
     /// Pushes a detail view for the given note.
     func push(_ note: Event) {
         if let identifier = note.identifier {
@@ -67,7 +67,7 @@ import Dependencies
             fatalError("Tried to push a note with no identifier; that's not going to work.")
         }
     }
-    
+
     /// Pushes a detail view for the note with the given ID, creating one if needed.
     func pushNote(id: RawEventID) {
         do {
@@ -77,13 +77,13 @@ import Dependencies
             Log.optional(error)
             crashReporting.report(error)
         }
-    }    
-    
+    }
+
     /// Pushes a detail view for the event with the given replaceable ID and author, creating one if needed.
     func pushNote(replaceableID: RawReplaceableID, authorID: RawAuthorID, kind: Int64) {
         do {
             let note = try Event.findOrCreateStubBy(
-                replaceableID: replaceableID, 
+                replaceableID: replaceableID,
                 authorID: authorID,
                 kind: kind,
                 context: persistenceController.viewContext
@@ -94,12 +94,12 @@ import Dependencies
             crashReporting.report(error)
         }
     }
-    
+
     /// Pushes a profile view for the given author.
     func push(_ author: Author) {
         push(.author(author.hexadecimalPublicKey))
     }
-    
+
     /// Pushes a profile view for the author with the given ID, creating one if needed.
     func pushAuthor(id: RawAuthorID) {
         do {
@@ -110,7 +110,7 @@ import Dependencies
             crashReporting.report(error)
         }
     }
-    
+
     /// Pushes a web view for the given url.
     func push(_ url: URL) {
         push(.url(url))
@@ -184,14 +184,16 @@ extension Router {
                     guard parts.count >= 3,
                         let kindString = parts.last,
                         let kind = Int64(kindString),
-                        let authorID = parts.dropLast().last else {
+                        let authorID = parts.dropLast().last
+                    else {
                         Log.debug("Something went wrong parsing the replaceableID and author from the naddr link")
                         return
                     }
                     let replaceableID = parts.dropLast(2).joined(separator: separator)
                     pushNote(replaceableID: replaceableID, authorID: authorID, kind: kind)
                 } else if let scheme = url.scheme,
-                    DeepLinkService.supportedURLSchemes.contains(scheme) {
+                    DeepLinkService.supportedURLSchemes.contains(scheme)
+                {
                     DeepLinkService.handle(url, router: self)
                 } else if url.scheme == "http" || url.scheme == "https" {
                     push(url)

--- a/Nos/Service/Analytics.swift
+++ b/Nos/Service/Analytics.swift
@@ -1,7 +1,7 @@
-import Foundation
-import PostHog
 import Dependencies
+import Foundation
 import Logger
+import PostHog
 import Starscream
 
 /// An object to manage analytics data, currently wired up to send data to PostHog and registered as a global
@@ -35,85 +35,85 @@ class Analytics {
     }
 
     // MARK: - Screens
-    
+
     func startedOnboarding() {
         track("Started Onboarding")
     }
-    
+
     func completedOnboarding() {
         track("Completed Onboarding")
     }
-    
+
     func showedHome() {
         track("Home Tab Tapped")
     }
-    
+
     func showedDiscover() {
         track("Discover Tab Tapped")
     }
-    
+
     func showedNoteComposer() {
         track("New Note Tapped")
     }
-    
+
     func showedNotifications() {
         track("Notifications Tab Tapped")
     }
-    
+
     func showedProfile() {
         track("Profile View Opened")
     }
-    
+
     func showedThread() {
         track("Thread View Opened")
     }
-    
+
     func showedSideMenu() {
         track("Contact Support Tapped")
     }
-    
+
     func showedRelays() {
         track("Relay View Opened")
     }
-    
+
     func showedSettings() {
         track("Settings View Opened")
     }
-    
+
     func showedSupport() {
         track("Contact Support Tapped")
     }
 
     // MARK: - Actions
-    
+
     func generatedKey() {
         track("Generated Private Key")
     }
-    
+
     func importedKey() {
         track("Imported Private Key")
     }
-    
+
     func added(_ relay: Relay) {
         track("Added Relay", properties: ["relay_address": relay.address ?? ""])
     }
-    
+
     func removed(_ relay: Relay) {
         track("Removed Relay", properties: ["relay_address": relay.address ?? ""])
     }
-    
+
     func followed(_ author: Author) {
         track("Followed", properties: ["followed": author.publicKey?.npub ?? ""])
     }
-    
+
     func unfollowed(_ author: Author) {
         track("Unfollowed", properties: ["unfollowed": author.publicKey?.npub ?? ""])
     }
-    
+
     func reported(_ reportedObject: ReportTarget) {
         track("Reported", properties: ["type": reportedObject.analyticsString])
     }
-    
+
     func identify(with keyPair: KeyPair, nip05: String? = nil) {
         let npub = keyPair.npub
         Log.info("Analytics: Identified \(npub)")
@@ -123,29 +123,29 @@ class Analytics {
         }
         postHog?.identify(keyPair.npub, userProperties: userProperties)
     }
-    
+
     func databaseStatistics(_ statistics: [(String, Int)]) {
         let properties = Dictionary(uniqueKeysWithValues: statistics)
         track("Database Statistics", properties: properties)
     }
-    
+
     func databaseCleanupStarted() {
         track("Database Cleanup Started")
     }
-    
+
     func databaseCleanupTaskExpired() {
         track("Database Cleanup Task Expired")
     }
-    
+
     func databaseCleanupCompleted(duration: TimeInterval) {
         track("Database Cleanup Completed", properties: ["duration": duration])
     }
-    
+
     func logout() {
         track("Logged out")
         postHog?.reset()
     }
-    
+
     private func track(_ eventName: String, properties: [String: Any] = [:]) {
         if properties.isEmpty {
             Log.info("Analytics: \(eventName)")
@@ -176,45 +176,45 @@ class Analytics {
     }
 
     // MARK: - Relays
-    
+
     func rateLimited(by socket: WebSocket, requestCount: Int) {
         track(
-            "Rate Limited", 
+            "Rate Limited",
             properties: [
                 "relay": socket.request.url?.absoluteString ?? "null",
                 "count": requestCount,
             ]
         )
     }
-    
+
     func badRequest(from socket: WebSocket, message: String) {
         track(
-            "Bad Request to Relay", 
+            "Bad Request to Relay",
             properties: [
                 "relay": socket.request.url?.absoluteString ?? "null",
-                "details": message
+                "details": message,
             ]
         )
     }
-    
+
     // MARK: - Notifications
-    
+
     func receivedNotification() {
         track("Push Notification Received")
     }
-    
+
     func displayedNotification() {
         track("Push Notification Displayed")
     }
-    
+
     func tappedNotification() {
         track("Push Notification Tapped")
     }
-    
+
     func pushNotificationRegistrationFailed(reason: String) {
         track("Push Notification Registration Failed", properties: ["reason": reason])
     }
-    
+
     // MARK: NIP-05 Usernames
 
     func showedNIP05Wizard() {
@@ -234,61 +234,61 @@ class Analytics {
     }
 
     // MARK: UNS
-    
+
     func showedUNSWizard() {
         track("UNS Showed Wizard")
     }
-    
+
     func canceledUNSWizard() {
         track("UNS Canceled Wizard")
     }
-    
+
     func completedUNSWizard() {
         track("UNS Completed Wizard")
     }
-    
+
     func enteredUNSPhone() {
         track("UNS Entered Phone")
     }
-    
+
     func enteredUNSCode() {
         track("UNS Entered Code")
     }
-    
+
     func registeredUNSName() {
         track("UNS Registered Name")
     }
-    
+
     func linkedUNSName() {
         track("UNS Linked Name")
     }
-    
+
     func choseInvalidUNSName() {
         track("UNS Invalid Name")
     }
-    
+
     func encounteredUNSError(_ error: Error?) {
         track("UNS Error", properties: ["errorDescription": error?.localizedDescription ?? "null"])
     }
-    
+
     // MARK: Message Actions
-    
+
     func copiedNoteIdentifier() {
         track("Copied Note Identifier")
     }
-    
+
     func sharedNoteLink() {
         track("Shared Note Link")
     }
-    
+
     func copiedNoteText() {
         track("Copied Note Text")
     }
-    
+
     func viewedNoteSource() {
         track("Viewed Note Source")
     }
-    
+
     func deletedNote() {
         track("Deleted Note")
     }
@@ -301,19 +301,19 @@ class Analytics {
     func selectedUploadFromCamera() {
         track("Selected Upload From Camera")
     }
-    
+
     func selectedUploadFromPhotoLibrary() {
         track("Selected Upload From Photo Library")
     }
-    
+
     func selectedImage() {
         track("Selected Image")
     }
-    
+
     func cancelledImageSelection() {
         track("Cancelled Image Selection")
     }
-    
+
     func cancelledUploadSourceSelection() {
         track("Cancelled Upload Source Selection")
     }

--- a/Nos/Service/AsyncTimer.swift
+++ b/Nos/Service/AsyncTimer.swift
@@ -2,13 +2,13 @@ import Foundation
 
 /// A timer that executes a task on a schedule. Similar to NSTimer but works with Swift Structured Concurrency.
 class AsyncTimer {
-    
+
     private var task: Task<Void, Never>
-    
+
     init(
-        timeInterval: TimeInterval, 
-        priority: TaskPriority = .utility, 
-        firesImmediately: Bool = true, 
+        timeInterval: TimeInterval,
+        priority: TaskPriority = .utility,
+        firesImmediately: Bool = true,
         onFire: @escaping () async -> Void
     ) {
         self.task = Task(priority: priority) {
@@ -22,7 +22,7 @@ class AsyncTimer {
             }
         }
     }
-    
+
     func cancel() {
         task.cancel()
     }

--- a/Nos/Service/Bech32.swift
+++ b/Nos/Service/Bech32.swift
@@ -7,7 +7,7 @@ import Foundation
 /// https://medium.com/@meshcollider/some-of-the-math-behind-bech32-addresses-cf03c7496285 could help understanding
 /// how Bech32 works
 enum Bech32 {
-    private static let gen: [UInt32] = [0x3b6a57b2, 0x26508e6d, 0x1ea119fa, 0x3d4233dd, 0x2a1462b3]
+    private static let gen: [UInt32] = [0x3b6a_57b2, 0x2650_8e6d, 0x1ea1_19fa, 0x3d42_33dd, 0x2a14_62b3]
     /// Bech32 checksum delimiter
     private static let checksumMarker: String = "1"
     /// Bech32 character set for encoding
@@ -17,13 +17,13 @@ enum Bech32 {
         -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
         -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
         -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-        15, -1, 10, 17, 21, 20, 26, 30,  7,  5, -1, -1, -1, -1, -1, -1,
-        -1, 29, -1, 24, 13, 25,  9,  8, 23, -1, 18, 22, 31, 27, 19, -1,
-        1,  0,  3, 16, 11, 28, 12, 14,  6,  4,  2, -1, -1, -1, -1, -1,
-        -1, 29, -1, 24, 13, 25,  9,  8, 23, -1, 18, 22, 31, 27, 19, -1,
-        1,  0,  3, 16, 11, 28, 12, 14,  6,  4,  2, -1, -1, -1, -1, -1
+        15, -1, 10, 17, 21, 20, 26, 30, 7, 5, -1, -1, -1, -1, -1, -1,
+        -1, 29, -1, 24, 13, 25, 9, 8, 23, -1, 18, 22, 31, 27, 19, -1,
+        1, 0, 3, 16, 11, 28, 12, 14, 6, 4, 2, -1, -1, -1, -1, -1,
+        -1, 29, -1, 24, 13, 25, 9, 8, 23, -1, 18, 22, 31, 27, 19, -1,
+        1, 0, 3, 16, 11, 28, 12, 14, 6, 4, 2, -1, -1, -1, -1, -1,
     ]
-    
+
     /// Find the polynomial with value coefficients mod the generator as 30-bit.
     private static func polymod(_ values: Data) -> UInt32 {
         var chk: UInt32 = 1
@@ -36,11 +36,11 @@ enum Bech32 {
         }
         return chk
     }
-    
+
     /// Expand a HRP for use in checksum computation.
     private static func expandHrp(_ hrp: String) -> Data {
         guard let hrpBytes = hrp.data(using: .utf8) else { return Data() }
-        var result = Data(repeating: 0x00, count: hrpBytes.count*2+1)
+        var result = Data(repeating: 0x00, count: hrpBytes.count * 2 + 1)
         for (i, c) in hrpBytes.enumerated() {
             result[i] = c >> 5
             result[i + hrpBytes.count + 1] = c & 0x1f
@@ -48,14 +48,14 @@ enum Bech32 {
         result[hrp.count] = 0
         return result
     }
-    
+
     /// Verify checksum
     private static func verifyChecksum(hrp: String, checksum: Data) -> Bool {
         var data = expandHrp(hrp)
         data.append(checksum)
         return polymod(data) == 1
     }
-    
+
     /// Create checksum
     private static func createChecksum(hrp: String, values: Data) -> Data {
         var enc = expandHrp(hrp)
@@ -68,7 +68,7 @@ enum Bech32 {
         }
         return ret
     }
-    
+
     /// Encode Bech32 string
     static func encode(_ hrp: String, baseFiveData values: Data) -> String {
         let checksum = createChecksum(hrp: hrp, values: values)
@@ -80,20 +80,20 @@ enum Bech32 {
         for i in combined {
             ret.append(encCharset[Int(i)])
         }
-        return String(decoding: ret, as: UTF8.self) 
+        return String(decoding: ret, as: UTF8.self)
     }
-    
+
     static func encode(_ hrp: String, baseEightData: Data) -> String {
         encode(hrp, baseFiveData: baseEightData.base5)
     }
-    
+
     static func encode(_ hrp: String, hex: String) -> String? {
         guard let decoded = hex.hexDecoded else {
             return nil
         }
         return encode(hrp, baseFiveData: decoded.base5)
     }
-    
+
     /// Decode Bech32 string
     static func decode(_ str: String) throws -> (hrp: String, checksum: Data) {
         guard let strBytes = str.data(using: .utf8) else {
@@ -142,7 +142,7 @@ enum Bech32 {
         guard verifyChecksum(hrp: hrp, checksum: values) else {
             throw DecodingError.checksumMismatch
         }
-        return (hrp, Data(values[..<(vSize-6)]))
+        return (hrp, Data(values[..<(vSize - 6)]))
     }
 }
 
@@ -155,10 +155,10 @@ extension Bech32 {
         case incorrectHrpSize
         case incorrectChecksumSize
         case stringLengthExceeded
-        
+
         case invalidCharacter
         case checksumMismatch
-        
+
         var errorDescription: String? {
             switch self {
             case .checksumMismatch:

--- a/Nos/Service/CrashReporting.swift
+++ b/Nos/Service/CrashReporting.swift
@@ -4,33 +4,33 @@ import Sentry
 
 /// An abstraction of an external crash reporting service, like Sentry.io
 class CrashReporting {
-    
+
     private let sentry: SentrySDK.Type
-    
+
     init(mock: Bool = false) {
         sentry = SentrySDK.self
         let dsn = Bundle.main.infoDictionary?["SENTRY_DSN"] as? String ?? ""
 
         #if DEBUG
-        let debug = true
+            let debug = true
         #else
-        let debug = false
+            let debug = false
         #endif
-        
+
         guard !mock && !debug && !dsn.isEmpty else {
             return
         }
-        
+
         sentry.start { options in
             options.dsn = dsn
             #if STAGING
-            options.environment = "staging"
+                options.environment = "staging"
             #elseif DEV
-            options.environment = "debug"
+                options.environment = "debug"
             #endif
             options.enableTracing = true
-            options.tracesSampleRate = 0.3 // tracing must be enabled for profiling
-            options.profilesSampleRate = 0.3 // see also `profilesSampler` if you need custom sampling logic
+            options.tracesSampleRate = 0.3  // tracing must be enabled for profiling
+            options.profilesSampleRate = 0.3  // see also `profilesSampler` if you need custom sampling logic
             // Enable all experimental features
             options.attachViewHierarchy = true
             options.enablePreWarmedAppStartTracing = true
@@ -39,7 +39,7 @@ class CrashReporting {
             options.swiftAsyncStacktraces = true
         }
     }
-    
+
     func identify(with keyPair: KeyPair) {
         let user = User(userId: keyPair.npub)
         sentry.setUser(user)
@@ -49,12 +49,12 @@ class CrashReporting {
         Log.error("Reporting error to Crash Reporting service: \(error.localizedDescription)")
         sentry.capture(error: error)
     }
-    
+
     func report(_ errorMessage: String) {
         Log.error("Reporting error to Crash Reporting service: \(errorMessage)")
         sentry.capture(message: errorMessage)
     }
-    
+
     func logout() {
         SentrySDK.setUser(nil)
     }

--- a/Nos/Service/CurrentUser+PublishEvents.swift
+++ b/Nos/Service/CurrentUser+PublishEvents.swift
@@ -2,7 +2,7 @@ import Foundation
 import Logger
 
 extension CurrentUser {
-    
+
     /// Builds a dictionary to be used as content when publishing a kind 0
     /// event.
     private func buildMetadataJSONObject(author: Author) -> [String: String] {
@@ -58,7 +58,7 @@ extension CurrentUser {
         }
 
         self.author = author
-        
+
         let jsonObject = buildMetadataJSONObject(author: author)
         let data = try JSONSerialization.data(withJSONObject: jsonObject)
         let content = String(decoding: data, as: UTF8.self)
@@ -81,15 +81,15 @@ extension CurrentUser {
             throw CurrentUserError.errorWhilePublishingToRelays
         }
     }
-    
+
     @MainActor func publishMuteList(keys: [String]) async {
         guard let pubKey = publicKeyHex else {
             Log.debug("Error: no pubKey")
             return
         }
-        
+
         let jsonEvent = JSONEvent(pubKey: pubKey, kind: .mute, tags: keys.pTags, content: "")
-        
+
         if let pair = keyPair {
             do {
                 try await relayService.publishToAll(event: jsonEvent, signingKey: pair, context: viewContext)
@@ -98,16 +98,16 @@ extension CurrentUser {
             }
         }
     }
-    
+
     @MainActor func publishDelete(for identifiers: [String], reason: String = "") async {
         guard let pubKey = publicKeyHex else {
             Log.debug("Error: no pubKey")
             return
         }
-        
+
         let tags = identifiers.eTags
         let jsonEvent = JSONEvent(pubKey: pubKey, kind: .delete, tags: tags, content: reason)
-        
+
         if let pair = keyPair {
             do {
                 try await relayService.publishToAll(event: jsonEvent, signingKey: pair, context: viewContext)
@@ -116,29 +116,29 @@ extension CurrentUser {
             }
         }
     }
-    
+
     @MainActor func publishContactList(tags: [[String]]) async {
         guard let keyPair else {
             Log.error("Error: Failed to publish contact list because there was no key pair")
             return
         }
-        
+
         let pubKey = keyPair.publicKey.hex
-        
+
         guard let relays = author?.relays.compactMap({ $0.address }) else {
             Log.debug("Error: No relay service")
             return
         }
-        
+
         let jsonEvent = JSONEvent.contactList(pubKey: pubKey, tags: tags, relayAddresses: relays)
-        
+
         do {
             try await relayService.publishToAll(event: jsonEvent, signingKey: keyPair, context: viewContext)
         } catch {
             Log.debug("failed to update Follows \(error.localizedDescription)")
         }
     }
-    
+
     /// Follow by public hex key
     @MainActor func follow(author toFollow: Author) async throws {
         guard let followKey = toFollow.hexadecimalPublicKey else {
@@ -150,7 +150,7 @@ extension CurrentUser {
 
         var followKeys = await Array(socialGraph.followedKeys)
         followKeys.append(followKey)
-        
+
         // Update author to add the new follow
         if let followedAuthor = try? Author.find(by: followKey, context: viewContext), let currentUser = author {
             let follow = try Follow.findOrCreate(
@@ -162,11 +162,11 @@ extension CurrentUser {
             // Add to the current user's follows
             currentUser.follows.insert(follow)
         }
-        
+
         try viewContext.save()
         await publishContactList(tags: followKeys.pTags)
     }
-    
+
     /// Unfollow by public hex key
     @MainActor func unfollow(author toUnfollow: Author) async throws {
         guard let unfollowedKey = toUnfollow.hexadecimalPublicKey else {
@@ -175,10 +175,10 @@ extension CurrentUser {
         }
 
         Log.debug("Unfollowing \(unfollowedKey)")
-        
+
         let stillFollowingKeys = await Array(socialGraph.followedKeys)
             .filter { $0 != unfollowedKey }
-        
+
         // Update author to only follow those still following
         if let unfollowedAuthor = try? Author.find(by: unfollowedKey, context: viewContext), let currentUser = author {
             // Remove from the current user's follows
@@ -193,13 +193,13 @@ extension CurrentUser {
         try viewContext.save()
         await publishContactList(tags: stillFollowingKeys.pTags)
     }
-    
+
     @MainActor func publishAccountDeletedMetadata() async throws {
         guard let author else {
             Log.error("Error: Failed to publish account deleted metadata because there was no Author")
             return
         }
-        
+
         author.about = nil
         author.displayName = "Account deleted"
         author.name = "Account deleted"
@@ -208,37 +208,38 @@ extension CurrentUser {
         author.profilePhotoURL = nil
         author.uns = nil
         author.rawMetadata = nil
-        
+
         try viewContext.save()
         try await publishMetadata()
     }
-    
+
     @MainActor func publishEmptyFollowList() async throws {
         guard let author else {
             Log.error("Error: Failed to publish empty follow list because there was no Author")
             return
         }
-        
+
         author.relays = Set()
-        
+
         try viewContext.save()
         await publishContactList(tags: [])
     }
-    
+
     @MainActor func publishRequestToVanish(reason: String? = nil) async throws {
         guard let keyPair else {
             Log.debug("Error: no key pair")
             return
         }
-        
+
         let pubKey = keyPair.publicKey.hex
         let jsonEvent = JSONEvent.requestToVanish(pubKey: pubKey, reason: reason)
-        
+
         do {
             try await relayService.publishToAll(event: jsonEvent, signingKey: keyPair, context: viewContext)
-            
+
             if let authorRelays = author?.relays.compactMap({ $0.addressURL }),
-                !authorRelays.contains(Relay.nosAddress) {
+                !authorRelays.contains(Relay.nosAddress)
+            {
                 // Make sure the NIP-62 event is always published to relay.nos.social - even if it isn't in
                 // the user's relay list. This will ensure that our servers see the request and can delete their
                 // data across all our web services: the relay, our push notification database, the follow

--- a/Nos/Service/DatabaseCleaner.swift
+++ b/Nos/Service/DatabaseCleaner.swift
@@ -1,59 +1,59 @@
-import Foundation
-import Logger
 import CoreData
 import Dependencies
+import Foundation
+import Logger
 
 enum DatabaseCleaner {
-    
+
     /// Deletes unneeded entities from Core Data.
     ///
     /// This should only be called once right at app launch.
-    /// 
+    ///
     /// The general strategy here is to:
-    /// - keep some max number of events, delete the others 
-    /// - delete authors outside the user's network 
+    /// - keep some max number of events, delete the others
+    /// - delete authors outside the user's network
     /// - delete any other models that are orphaned by the previous deletions
     /// - fix EventReferences whose referencedEvent was deleted by createing a stubbed Event
     static func cleanupEntities(
-        for authorKey: RawAuthorID, 
+        for authorKey: RawAuthorID,
         in context: NSManagedObjectContext,
         keeping eventsToKeep: Int = 1000
     ) async throws {
         // this function was written in a hurry and probably should be refactored and tested thorougly.
         @Dependency(\.analytics) var analytics
-        
+
         let startTime = Date.now
         analytics.databaseCleanupStarted()
         Log.info("Starting Core Data cleanup...")
-        
+
         Log.info("Database statistics: \(try await PersistenceController.databaseStatistics(from: context))")
-        
+
         try await context.perform {
-            
+
             guard let currentUser = try? Author.find(by: authorKey, context: context) else {
                 return
             }
-            
+
             // This is a delicate dance to get rid of events without breaking the consistency of the object graph.
             // The app expects that certain post-processing has been done during parsing i.e. every "e" tag should
             // have an EventReference and the EventReference should have at least a stubbed Event. So we can't just
             // delete events before a certain date or we would leave dangling references around.
             //
-            // The generic strategy is to pick a date and delete stuff received before then. However there are complex 
+            // The generic strategy is to pick a date and delete stuff received before then. However there are complex
             // exceptions to i.e. keep events the current user has published. Most of these are defined in
             // `Event.protectedFromCleanupPredicate(for: user)` which is used in several fetch requests.
             let deleteBefore = try computeDeleteBeforeDate(keeping: eventsToKeep, context: context)
-            
+
             // Get rid of all event references where 1) neither event is protected and 2) both events are old
             try batchDelete(
                 objectsMatching: [EventReference.cleanupRequest(before: deleteBefore, user: currentUser)],
                 in: context
             )
-            
+
             // stub all events that aren't in a protected class before deleteBefore but are still referenced by events
             // we are keeping
             try stubReferencedOldEvents(before: deleteBefore, user: currentUser, in: context)
-            
+
             try batchDelete(
                 objectsMatching: [
                     // delete all events before deleteBefore that aren't protected or referenced
@@ -69,25 +69,25 @@ enum DatabaseCleaner {
                 ],
                 in: context
             )
-            
+
             try context.saveIfNeeded()
         }
-        
+
         let newStatistics = try await PersistenceController.databaseStatistics(from: context)
         Log.info("Database statistics: \(newStatistics)")
         analytics.databaseStatistics(newStatistics)
-        
-        let elapsedTime = Date.now.timeIntervalSince1970 - startTime.timeIntervalSince1970 
+
+        let elapsedTime = Date.now.timeIntervalSince1970 - startTime.timeIntervalSince1970
         Log.info("Finished Core Data cleanup in \(elapsedTime) seconds.")
         analytics.databaseCleanupCompleted(duration: elapsedTime)
     }
-    
+
     /// This converts old hydrated events back to stubs. We do this because EventReferences can form long chains
     /// of events that we can't delete. By stubbing an event we can delete its eventReferences and also the
     /// referencedEvents.
     private static func stubReferencedOldEvents(
-        before deleteBefore: Date, 
-        user: Author, 
+        before deleteBefore: Date,
+        user: Author,
         in context: NSManagedObjectContext
     ) throws {
         let request = NSFetchRequest<Event>(entityName: "Event")
@@ -98,21 +98,21 @@ enum DatabaseCleaner {
             notPredicateWithSubpredicate: Event.protectedFromCleanupPredicate(for: user)
         )
         request.predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [
-            oldEventPredicate, 
-            referencedEventsPredicate, 
-            nonProtectedEventsPredicate
+            oldEventPredicate,
+            referencedEventsPredicate,
+            nonProtectedEventsPredicate,
         ])
-        
+
         let events = try context.fetch(request)
         Log.info("Stubbing \(events.count) old Events that are still referenced by newer events")
         for event in events {
             event.resetToStub()
         }
     }
-    
+
     /// Performs a batch delete request using the given `fetchRequests` with nice logging.
     private static func batchDelete(
-        objectsMatching fetchRequests: [NSPersistentStoreRequest], 
+        objectsMatching fetchRequests: [NSPersistentStoreRequest],
         in context: NSManagedObjectContext
     ) throws {
         for request in fetchRequests {
@@ -120,7 +120,7 @@ enum DatabaseCleaner {
                 Log.error("Bad fetch request: \(request)")
                 continue
             }
-            
+
             let batchDeleteRequest = NSBatchDeleteRequest(fetchRequest: fetchRequest)
             batchDeleteRequest.resultType = .resultTypeCount
             let deleteResult = try context.execute(batchDeleteRequest) as? NSBatchDeleteResult
@@ -129,14 +129,14 @@ enum DatabaseCleaner {
             }
         }
     }
-    
+
     /// Takes the number of events we want to keep in our database and computes a date after which we can safely delete
     /// events. We use a date because you can't tell Core Data to just delete events after a certain index. Also the
     /// date is used for other fetch requests, i.e. to avoid deleting older events that are referenced by newer events.
     ///
-    /// This must be called inside a `NSManagedObjectContext.perform` block. 
+    /// This must be called inside a `NSManagedObjectContext.perform` block.
     private static func computeDeleteBeforeDate(
-        keeping eventsToKeep: Int, 
+        keeping eventsToKeep: Int,
         context: NSManagedObjectContext
     ) throws -> Date {
         // Delete all but the most recent n events
@@ -150,10 +150,11 @@ enum DatabaseCleaner {
         fetchFirstEventToDelete.fetchOffset = eventsToKeep - 1
         fetchFirstEventToDelete.predicate = NSPredicate(format: "receivedAt != nil")
         if let firstEventToDelete = try context.fetch(fetchFirstEventToDelete).first,
-            let receivedAt = firstEventToDelete.receivedAt {
+            let receivedAt = firstEventToDelete.receivedAt
+        {
             deleteBefore = receivedAt
         }
-        
+
         return deleteBefore
     }
 }

--- a/Nos/Service/DeepLinkService.swift
+++ b/Nos/Service/DeepLinkService.swift
@@ -1,9 +1,9 @@
+import Dependencies
 import Foundation
 import Logger
-import Dependencies
 
 enum DeepLinkService {
-    
+
     /// Returns the URL schemes that Nos supports. Dev, Staging, and Production builds each have their own scheme,
     /// and all of them also support the `nostr:` scheme.
     static var supportedURLSchemes: [String] = {
@@ -13,28 +13,29 @@ enum DeepLinkService {
                 return urlSchemes
             }
         }
-        
+
         return []
     }()
-    
+
     @MainActor static func handle(_ url: URL, router: Router) {
         @Dependency(\.persistenceController) var persistenceController
         Log.info("handling link \(url.absoluteString)")
-        
+
         let components = URLComponents(url: url, resolvingAgainstBaseURL: true)
-        
+
         guard let components,
             let scheme = components.scheme,
-            supportedURLSchemes.contains(scheme) else {
+            supportedURLSchemes.contains(scheme)
+        else {
             return
         }
-        
+
         if components.host == "note", components.path == "/new" {
             let noteContents = components
                 .queryItems?
                 .first(where: { $0.name == "contents" })?
                 .value
-            
+
             router.showNoteComposer(contents: noteContents)
         } else {
             // The destination (npub, note, nprofile, nevent, or naddr) may be in the host or the path.

--- a/Nos/Service/DependencyInjection.swift
+++ b/Nos/Service/DependencyInjection.swift
@@ -9,7 +9,7 @@ extension DependencyValues {
         get { self[AnalyticsKey.self] }
         set { self[AnalyticsKey.self] = newValue }
     }
-    
+
     var currentUser: CurrentUser {
         get { self[CurrentUserKey.self] }
         set { self[CurrentUserKey.self] = newValue }
@@ -24,32 +24,32 @@ extension DependencyValues {
         get { self[RouterKey.self] }
         set { self[RouterKey.self] = newValue }
     }
-    
+
     var relayService: RelayService {
         get { self[RelayServiceKey.self] }
         set { self[RelayServiceKey.self] = newValue }
     }
-    
+
     var pushNotificationService: PushNotificationService {
         get { self[PushNotificationServiceKey.self] }
         set { self[PushNotificationServiceKey.self] = newValue }
     }
-    
+
     var persistenceController: PersistenceController {
         get { self[PersistenceControllerKey.self] }
         set { self[PersistenceControllerKey.self] = newValue }
     }
-    
+
     var userDefaults: UserDefaults {
         get { self[UserDefaultsKey.self] }
         set { self[UserDefaultsKey.self] = newValue }
     }
-    
+
     var crashReporting: CrashReporting {
         get { self[CrashReportingKey.self] }
         set { self[CrashReportingKey.self] = newValue }
     }
-    
+
     var unsAPI: UNSAPI {
         get { self[UNSAPIKey.self] }
         set { self[UNSAPIKey.self] = newValue }
@@ -79,7 +79,7 @@ extension DependencyValues {
         get { self[FeatureFlagsKey.self] }
         set { self[FeatureFlagsKey.self] = newValue }
     }
-        
+
     var keychain: Keychain {
         get { self[KeychainKey.self] }
         set { self[KeychainKey.self] = newValue }
@@ -101,23 +101,23 @@ extension DependencyValues {
     }
 }
 
-fileprivate enum AnalyticsKey: DependencyKey {
+private enum AnalyticsKey: DependencyKey {
     static let liveValue = Analytics()
     static let testValue = Analytics(mock: true)
     static let previewValue = Analytics(mock: true)
 }
 
-fileprivate enum CurrentUserKey: DependencyKey {
+private enum CurrentUserKey: DependencyKey {
     @MainActor static let liveValue = CurrentUser()
     @MainActor static let testValue = CurrentUser()
     @MainActor static let previewValue = CurrentUser()
 }
 
-fileprivate enum FileStorageAPIClientKey: DependencyKey {
+private enum FileStorageAPIClientKey: DependencyKey {
     static var liveValue: any FileStorageAPIClient = NostrBuildAPIClient()
 }
 
-fileprivate enum RouterKey: DependencyKey {
+private enum RouterKey: DependencyKey {
     @MainActor static let liveValue = Router()
     @MainActor static let testValue = Router()
     @MainActor static let previewValue = Router()
@@ -129,81 +129,81 @@ private enum RelayServiceKey: DependencyKey {
     static let previewValue: RelayService = MockRelayService()
 }
 
-fileprivate enum PushNotificationServiceKey: DependencyKey {
+private enum PushNotificationServiceKey: DependencyKey {
     @MainActor static let liveValue = PushNotificationService()
     @MainActor static let testValue: PushNotificationService = MockPushNotificationService()
     @MainActor static let previewValue: PushNotificationService = MockPushNotificationService()
 }
 
-fileprivate enum PersistenceControllerKey: DependencyKey {
+private enum PersistenceControllerKey: DependencyKey {
     static let liveValue = PersistenceController()
     static var testValue = PersistenceController(inMemory: true)
     static let previewValue = PersistenceController(inMemory: true)
 }
 
-fileprivate enum UserDefaultsKey: DependencyKey {
+private enum UserDefaultsKey: DependencyKey {
     static let liveValue = UserDefaults.standard
     static let testValue = UserDefaults()
     static let previewValue = UserDefaults()
 }
 
-fileprivate enum CrashReportingKey: DependencyKey {
+private enum CrashReportingKey: DependencyKey {
     static let liveValue = CrashReporting()
     static let testValue = CrashReporting(mock: true)
     static let previewValue = CrashReporting(mock: true)
 }
 
-fileprivate enum UNSAPIKey: DependencyKey {
+private enum UNSAPIKey: DependencyKey {
     static let liveValue = UNSAPI()!
 }
 
-fileprivate enum NamesAPIKey: DependencyKey {
+private enum NamesAPIKey: DependencyKey {
     static let liveValue = NamesAPI()!
     static let previewValue = NamesAPI(host: "localhost")!
 }
 
-fileprivate enum URLParserKey: DependencyKey {
+private enum URLParserKey: DependencyKey {
     static let liveValue = URLParser()
     static let testValue = URLParser()
     static let previewValue = URLParser()
 }
 
-fileprivate enum URLSessionProtocolKey: DependencyKey {
+private enum URLSessionProtocolKey: DependencyKey {
     static let liveValue: any URLSessionProtocol = URLSession.shared
     static let testValue: any URLSessionProtocol = MockURLSession()
     static let previewValue: any URLSessionProtocol = MockURLSession()
 }
 
-fileprivate enum NoteParserKey: DependencyKey {
+private enum NoteParserKey: DependencyKey {
     static let liveValue = NoteParser()
     static let testValue = NoteParser()
     static let previewValue = NoteParser()
 }
 
-fileprivate enum FeatureFlagsKey: DependencyKey {
+private enum FeatureFlagsKey: DependencyKey {
     static let liveValue: any FeatureFlags = DefaultFeatureFlags.liveValue
     static let testValue: any FeatureFlags = MockFeatureFlags()
     static let previewValue: any FeatureFlags = MockFeatureFlags()
 }
 
-fileprivate enum KeychainKey: DependencyKey {
+private enum KeychainKey: DependencyKey {
     @MainActor static let liveValue: Keychain = SystemKeychain()
     @MainActor static let testValue: Keychain = InMemoryKeychain()
     @MainActor static let previewValue: Keychain = InMemoryKeychain()
 }
 
-fileprivate enum MediaServiceKey: DependencyKey {
+private enum MediaServiceKey: DependencyKey {
     static let liveValue: any MediaService = DefaultMediaService()
     static let testValue: any MediaService = MockMediaService()
-    static let previewValue: any MediaService = DefaultMediaService() // enables manual testing with previews
+    static let previewValue: any MediaService = DefaultMediaService()  // enables manual testing with previews
 }
 
-fileprivate enum OpenGraphServiceKey: DependencyKey {
+private enum OpenGraphServiceKey: DependencyKey {
     static let liveValue: any OpenGraphService = DefaultOpenGraphService()
     static let testValue: any OpenGraphService = MockOpenGraphService()
-    static let previewValue: any OpenGraphService = DefaultOpenGraphService() // enables manual testing with previews
+    static let previewValue: any OpenGraphService = DefaultOpenGraphService()  // enables manual testing with previews
 }
 
-fileprivate enum PreviewEventRepositoryKey: DependencyKey {
+private enum PreviewEventRepositoryKey: DependencyKey {
     static let liveValue: any PreviewEventRepository = DefaultPreviewEventRepository()
 }

--- a/Nos/Service/FeatureFlags.swift
+++ b/Nos/Service/FeatureFlags.swift
@@ -1,5 +1,5 @@
-import Foundation
 import Dependencies
+import Foundation
 import SwiftUI
 
 /// Feature flags for enabling experimental or beta features.
@@ -16,8 +16,8 @@ protocol FeatureFlags {
 
     // MARK: - Additional requirements for debug mode
     #if DEBUG || STAGING
-    /// Sets the value of the specified feature flag.
-    func setFeature(_ feature: FeatureFlag, enabled: Bool)
+        /// Sets the value of the specified feature flag.
+        func setFeature(_ feature: FeatureFlag, enabled: Bool)
     #endif
 }
 
@@ -30,7 +30,7 @@ protocol FeatureFlags {
 
     /// Feature flags and their values.
     private var featureFlags: [FeatureFlag: Bool] = [
-        .newModerationFlow: false,
+        .newModerationFlow: false
     ]
 
     /// Returns true if the feature is enabled.
@@ -39,8 +39,8 @@ protocol FeatureFlags {
     }
 
     #if DEBUG || STAGING
-    func setFeature(_ feature: FeatureFlag, enabled: Bool) {
-        featureFlags[feature] = enabled
-    }
+        func setFeature(_ feature: FeatureFlag, enabled: Bool) {
+            featureFlags[feature] = enabled
+        }
     #endif
 }

--- a/Nos/Service/FileStorage/FileStorageAPIClient.swift
+++ b/Nos/Service/FileStorage/FileStorageAPIClient.swift
@@ -60,7 +60,7 @@ class NostrBuildAPIClient: FileStorageAPIClient {
     }
 
     // MARK: - Internal
-    
+
     /// The URL of the API to upload data to.
     private func apiURL() async throws -> URL {
         if serverInfo?.apiUrl == nil {
@@ -68,13 +68,14 @@ class NostrBuildAPIClient: FileStorageAPIClient {
         }
 
         guard let apiURLString = serverInfo?.apiUrl,
-            let apiURL = URL(string: apiURLString) else {
+            let apiURL = URL(string: apiURLString)
+        else {
             throw FileStorageAPIClientError.invalidURLRequest
         }
-        
+
         return apiURL
     }
-    
+
     /// The URL of the uploaded asset parsed from the API's response.
     private func assetURL(from responseData: Data, response: HTTPURLResponse?) throws -> URL {
         let decodedResponse = try decoder.decode(FileStorageUploadResponseJSON.self, from: responseData)
@@ -114,7 +115,7 @@ class NostrBuildAPIClient: FileStorageAPIClient {
             throw FileStorageAPIClientError.decodingError
         }
     }
-    
+
     /// Gets the file size limit from the error message.
     /// - Parameter message: The error message from nostr.build.
     /// - Returns: The file size limit from the error message.
@@ -124,7 +125,7 @@ class NostrBuildAPIClient: FileStorageAPIClient {
         guard let match = message.firstMatch(of: pattern) else {
             return nil
         }
-        
+
         return String(match.1)
     }
 
@@ -138,7 +139,7 @@ class NostrBuildAPIClient: FileStorageAPIClient {
             apiURL: apiURL
         )
     }
-    
+
     /// Creates a URLRequest and Data to be uploaded to the file storage API.
     private func uploadRequest(
         data: Data,
@@ -153,13 +154,13 @@ class NostrBuildAPIClient: FileStorageAPIClient {
         request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
 
         var header = ""
-        
+
         if isProfilePhoto {
             header.append("\r\n--\(boundary)\r\n")
             header.append("Content-Disposition: form-data; name=\"media_type\"\r\n")
             header.append("\"avatar\"\r\n\r\n")
         }
-        
+
         header.append("\r\n--\(boundary)\r\n")
         header.append("Content-Disposition: form-data; name=\"file\"; filename=\"\(filename)\"\r\n")
         header.append("Content-Type: image/jpg\r\n\r\n")
@@ -168,7 +169,8 @@ class NostrBuildAPIClient: FileStorageAPIClient {
         footer.append("\r\n--\(boundary)--\r\n")
 
         guard let headerData = header.data(using: .utf8),
-            let footerData = footer.data(using: .utf8) else {
+            let footerData = footer.data(using: .utf8)
+        else {
             throw FileStorageAPIClientError.encodingError
         }
 

--- a/Nos/Service/GiftWrapper.swift
+++ b/Nos/Service/GiftWrapper.swift
@@ -27,7 +27,7 @@ enum GiftWrapper: NIP44v2Encrypting {
             senderKeyPair: senderKeyPair,
             receiverPubkey: receiverPubkey
         )
-        
+
         let sealCreatedAt = randomTimeUpTo2DaysInThePast()
         var seal = JSONEvent(
             pubKey: senderKeyPair.publicKeyHex,
@@ -47,7 +47,7 @@ enum GiftWrapper: NIP44v2Encrypting {
             senderKeyPair: randomKeyPair,
             receiverPubkey: receiverPubkey
         )
-        
+
         let wrapCreatedAt = randomTimeUpTo2DaysInThePast()
         var giftWrap = JSONEvent(
             pubKey: randomKeyPair.publicKeyHex,
@@ -56,9 +56,9 @@ enum GiftWrapper: NIP44v2Encrypting {
             tags: [["p", receiverPubkey]],
             content: encryptedSeal
         )
-        
+
         try giftWrap.sign(withKey: randomKeyPair)
-        
+
         // Unsigned, publication will do that
         return giftWrap
     }
@@ -78,11 +78,11 @@ enum GiftWrapper: NIP44v2Encrypting {
         guard let sealEvent = JSONEvent.from(json: seal) else {
             throw GiftWrapperError.serializationError
         }
-        
+
         guard try sealEvent.verifySignature() else {
             throw GiftWrapperError.invalidSealSignature
         }
-        
+
         let encryptedRumor = sealEvent.content
 
         let rumor = try decryptCyphertext(
@@ -90,20 +90,20 @@ enum GiftWrapper: NIP44v2Encrypting {
             receiverKeyPair: receiverKeyPair,
             senderPubkey: sealEvent.pubKey
         )
-        
+
         guard let rumorEvent = JSONEvent.from(json: rumor) else {
             throw GiftWrapperError.serializationError
         }
-        
+
         if rumorEvent.pubKey != sealEvent.pubKey {
             throw GiftWrapperError.invalidPublicKey
         }
 
         return rumorEvent
     }
-    
+
     // MARK: - Helpers
-    
+
     private static func encryptJSONEvent(
         _ jsonEvent: JSONEvent,
         senderKeyPair: KeyPair,
@@ -112,14 +112,14 @@ enum GiftWrapper: NIP44v2Encrypting {
         guard let jsonEventJson = try jsonEvent.toJSON() else {
             throw GiftWrapperError.serializationError
         }
-        
+
         return try encryptPlainText(
             jsonEventJson,
             senderKeyPair: senderKeyPair,
             receiverPubkey: receiverPubkey
         )
     }
-    
+
     private static func encryptPlainText(
         _ plainText: String,
         senderKeyPair: KeyPair,
@@ -127,14 +127,14 @@ enum GiftWrapper: NIP44v2Encrypting {
     ) throws -> String {
         let privateKeyA = try toNostrSDKPrivateKey(keyPair: senderKeyPair)
         let publicKeyB = try toNostrSDKPublicKey(rawAuthorId: receiverPubkey)
-        
+
         return try NIP44v2Encrypter().encrypt(
             plaintext: plainText,
             privateKeyA: privateKeyA,
             publicKeyB: publicKeyB
         )
     }
-    
+
     private static func decryptCyphertext(
         _ cyphertext: String,
         receiverKeyPair: KeyPair,
@@ -142,14 +142,14 @@ enum GiftWrapper: NIP44v2Encrypting {
     ) throws -> String {
         let privateKeyA = try toNostrSDKPrivateKey(keyPair: receiverKeyPair)
         let publicKeyB = try toNostrSDKPublicKey(rawAuthorId: senderPubkey)
-        
+
         return try NIP44v2Encrypter().decrypt(
             payload: cyphertext,
             privateKeyA: privateKeyA,
             publicKeyB: publicKeyB
         )
     }
-    
+
     private static func validateRumor(_ rumor: JSONEvent) throws -> JSONEvent {
         guard rumor.signature.isEmptyOrNil else {
             throw GiftWrapperError.signedRumor
@@ -183,7 +183,7 @@ enum GiftWrapper: NIP44v2Encrypting {
 
         return publicKey
     }
-    
+
     static func randomTimeUpTo2DaysInThePast() -> Date {
         Date().addingTimeInterval(-TimeInterval.random(in: 0...twoDays))
     }

--- a/Nos/Service/Keychain.swift
+++ b/Nos/Service/Keychain.swift
@@ -2,80 +2,80 @@ import Security
 import UIKit
 
 @MainActor protocol Keychain {
-    
+
     var keychainPrivateKey: String { get }
-    
-    func save(key: String, data: Data) -> OSStatus 
-    func load(key: String) -> Data? 
-    func delete(key: String) -> OSStatus 
+
+    func save(key: String, data: Data) -> OSStatus
+    func load(key: String) -> Data?
+    func delete(key: String) -> OSStatus
 }
 
 /// Don't use this outside CurrentUser
 class SystemKeychain: Keychain {
-    
+
     let keychainPrivateKey = "privateKey"
-        
+
     @discardableResult
     func save(key: String, data: Data) -> OSStatus {
         let query =
-		[
-            kSecClass as String: kSecClassGenericPassword as String,
-            kSecAttrAccount as String: key,
-            kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlock,
-            kSecValueData as String: data
-		] as [String: Any]
-        
+            [
+                kSecClass as String: kSecClassGenericPassword as String,
+                kSecAttrAccount as String: key,
+                kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlock,
+                kSecValueData as String: data,
+            ] as [String: Any]
+
         SecItemDelete(query as CFDictionary)
-        
+
         return SecItemAdd(query as CFDictionary, nil)
     }
-    
-	func load(key: String) -> Data? {
+
+    func load(key: String) -> Data? {
         let query =
-		[
-            kSecClass as String: kSecClassGenericPassword,
-            kSecAttrAccount as String: key,
-            kSecReturnData as String: kCFBooleanTrue!,
-            kSecMatchLimit as String: kSecMatchLimitOne
-		] as [String: Any]
-        
+            [
+                kSecClass as String: kSecClassGenericPassword,
+                kSecAttrAccount as String: key,
+                kSecReturnData as String: kCFBooleanTrue!,
+                kSecMatchLimit as String: kSecMatchLimitOne,
+            ] as [String: Any]
+
         var dataTypeRef: AnyObject?
-        
+
         let status: OSStatus = SecItemCopyMatching(query as CFDictionary, &dataTypeRef)
-        
+
         if status == noErr {
             return dataTypeRef as? Data
         } else {
             return nil
         }
     }
-    
+
     func delete(key: String) -> OSStatus {
         let query =
-        [
-            kSecClass as String: kSecClassGenericPassword as String,
-            kSecAttrAccount as String: key,
-        ] as [String: Any]
-        
+            [
+                kSecClass as String: kSecClassGenericPassword as String,
+                kSecAttrAccount as String: key,
+            ] as [String: Any]
+
         return SecItemDelete(query as CFDictionary)
     }
 }
 
 class InMemoryKeychain: Keychain {
-    
+
     let keychainPrivateKey = "privateKey"
-    
+
     private var keychain = [String: Data]()
-    
+
     func save(key: String, data: Data) -> OSStatus {
         keychain[key] = data
         return 0
     }
-    
+
     func load(key: String) -> Data? {
         keychain[key]
     }
-    
+
     func delete(key: String) -> OSStatus {
         keychain.removeValue(forKey: key)
         return 0

--- a/Nos/Service/Media/MediaService.swift
+++ b/Nos/Service/Media/MediaService.swift
@@ -63,9 +63,10 @@ struct DefaultMediaService: MediaService {
 
         switch type {
         case .video:
-            if let width = metadata.video?.width, 
+            if let width = metadata.video?.width,
                 let height = metadata.video?.height,
-                height > width {
+                height > width
+            {
                 return .portrait
             } else {
                 return .landscape

--- a/Nos/Service/Media/OpenGraphService.swift
+++ b/Nos/Service/Media/OpenGraphService.swift
@@ -20,7 +20,7 @@ struct DefaultOpenGraphService: OpenGraphService {
     }
 
     func fetchMetadata(for url: URL) async throws -> OpenGraphMetadata? {
-        var request = URLRequest(url: url) // example.com/video.mp4 // example.com/video
+        var request = URLRequest(url: url)  // example.com/video.mp4 // example.com/video
         // some websites, like YouTube, only provide metadata for specific User-Agent values
         request.setValue("facebookexternalhit/1.1 Facebot Twitterbot/1.0", forHTTPHeaderField: "User-Agent")
         let (data, response) = try await session.data(for: request)

--- a/Nos/Service/MockRelayService.swift
+++ b/Nos/Service/MockRelayService.swift
@@ -1,4 +1,4 @@
-import Foundation 
+import Foundation
 
 /// A version of the relay service that won't talk to real relays.
 class MockRelayService: RelayService {

--- a/Nos/Service/MockRelaySubscriptionManager.swift
+++ b/Nos/Service/MockRelaySubscriptionManager.swift
@@ -2,7 +2,7 @@ import Foundation
 import Starscream
 
 class MockRelaySubscriptionManager: RelaySubscriptionManager {
-    
+
     var all = [RelaySubscription]()
 
     var sockets = [WebSocket]()
@@ -24,14 +24,14 @@ class MockRelaySubscriptionManager: RelaySubscriptionManager {
 
     func close(socket: WebSocket) async {
     }
-    
+
     func trackAuthenticationRequest(from socket: WebSocket, responseID: RawNostrID) async {
     }
-    
+
     func checkAuthentication(
-        success: Bool, 
-        from socket: WebSocket, 
-        eventID: RawNostrID, 
+        success: Bool,
+        from socket: WebSocket,
+        eventID: RawNostrID,
         message: String?
     ) async -> Bool {
         false
@@ -55,10 +55,10 @@ class MockRelaySubscriptionManager: RelaySubscriptionManager {
         queueSubscriptionFilter = filter
         return RelaySubscription(filter: filter, relayAddress: relayAddress)
     }
-    
+
     func receivedClose(for subscriptionID: RelaySubscription.ID, from socket: WebSocket) async {
     }
-    
+
     func socket(for address: String) async -> WebSocket? {
         nil
     }

--- a/Nos/Service/NamesAPI.swift
+++ b/Nos/Service/NamesAPI.swift
@@ -7,7 +7,7 @@ class NamesAPI {
 
     /// A shared URLCache instance to store responses from NIP-05 providers
     private let urlCache = URLCache(
-        memoryCapacity: 4 * 1024 * 1024, // 4 MB
+        memoryCapacity: 4 * 1024 * 1024,  // 4 MB
         diskCapacity: 20 * 1024 * 1024,  // 20 MB
         directory: .cachesDirectory.appending(component: "NamesAPI")
     )
@@ -233,7 +233,7 @@ class NamesAPI {
         let content = ""
         let tags = [
             ["u", url.absoluteString],
-            ["method", method.rawValue]
+            ["method", method.rawValue],
         ]
         var jsonEvent = JSONEvent(
             pubKey: keyPair.publicKeyHex,
@@ -270,8 +270,8 @@ class NamesAPI {
                 "name": username,
                 "data": [
                     "pubkey": keyPair.publicKeyHex,
-                    "relays": relays.map { $0.absoluteString }
-                ]
+                    "relays": relays.map { $0.absoluteString },
+                ],
             ]
         )
     }

--- a/Nos/Service/NostrIdentifier/NostrIdentifierPrefix.swift
+++ b/Nos/Service/NostrIdentifier/NostrIdentifierPrefix.swift
@@ -8,16 +8,16 @@ enum NostrIdentifierPrefix {
 
     /// The Bech32 prefix for a public key.
     static let publicKey = "npub"
-    
+
     /// The Bech32 prefix for note ID.
     static let note = "note"
 
     /// The Bech32 prefix for a nostr profile.
     static let profile = "nprofile"
-    
+
     /// The Bech32 prefix for a nostr event.
     static let event = "nevent"
-    
+
     /// The Bech32 prefix for a nostr replaceable event coordinate, or address.
     static let address = "naddr"
 }

--- a/Nos/Service/NostrIdentifier/TLVElement.swift
+++ b/Nos/Service/NostrIdentifier/TLVElement.swift
@@ -27,7 +27,7 @@ extension TLVElement {
         while offset + 1 < converted.count {
             let rawType = converted[offset]
             let length = Int(converted[offset + 1])
-            let value = converted.subdata(in: offset + 2 ..< offset + 2 + length)
+            let value = converted.subdata(in: offset + 2..<offset + 2 + length)
 
             if let type = TLVType(rawValue: rawType) {
                 let element = TLVElement(type: type, value: value)

--- a/Nos/Service/PushNotificationService.swift
+++ b/Nos/Service/PushNotificationService.swift
@@ -1,25 +1,27 @@
+import Combine
+import CoreData
+import Dependencies
 import Foundation
 import Logger
-import Dependencies
 import UIKit
-import CoreData
-import Combine
 
 /// A class that abstracts our interactions with push notification infrastructure and iOS permissions. It can handle
 /// UNUserNotificationCenterDelegate callbacks for receiving and displaying notifications, and it watches the db for
 /// all new events and creates `NosNotification`s and displays them when appropriate.
-@MainActor class PushNotificationService: 
-    NSObject, ObservableObject, NSFetchedResultsControllerDelegate, UNUserNotificationCenterDelegate {
-    
+@MainActor
+class PushNotificationService:
+    NSObject, ObservableObject, NSFetchedResultsControllerDelegate, UNUserNotificationCenterDelegate
+{
+
     // MARK: - Public Properties
-    
+
     /// The number of unread notifications that should be displayed as a badge
     @Published var badgeCount = 0
 
     private let showPushNotificationsAfterKey = "PushNotificationService.notificationCutoff"
 
     /// Used to limit which notifications are displayed to the user as push notifications.
-    /// 
+    ///
     /// When the user first opens the app it is initialized to Date.now.
     /// This is to prevent us showing tons of push notifications on first login.
     /// Then after that it is set to the date of the last notification that we showed.
@@ -37,9 +39,9 @@ import Combine
             userDefaults.set(newValue.timeIntervalSince1970, forKey: showPushNotificationsAfterKey)
         }
     }
-    
+
     // MARK: - Private Properties
-    
+
     @Dependency(\.relayService) private var relayService
     @Dependency(\.persistenceController) private var persistenceController
     @Dependency(\.router) private var router
@@ -47,52 +49,53 @@ import Combine
     @Dependency(\.crashReporting) private var crashReporting
     @Dependency(\.userDefaults) private var userDefaults
     @Dependency(\.currentUser) private var currentUser
-    
+
     private var notificationWatcher: NSFetchedResultsController<Event>?
     private var relaySubscription: SubscriptionCancellable?
-    private var currentAuthor: Author? 
+    private var currentAuthor: Author?
     private lazy var modelContext: NSManagedObjectContext = {
         persistenceController.newBackgroundContext()
     }()
-    
+
     private lazy var registrar = PushNotificationRegistrar()
-    
+
     // MARK: - Setup
-    
+
     func listen(for user: CurrentUser) async {
         relaySubscription = nil
-        
+
         guard let author = user.author,
-            let authorKey = author.hexadecimalPublicKey else {
+            let authorKey = author.hexadecimalPublicKey
+        else {
             notificationWatcher = NSFetchedResultsController(
-                fetchRequest: Event.emptyRequest(), 
+                fetchRequest: Event.emptyRequest(),
                 managedObjectContext: modelContext,
                 sectionNameKeyPath: nil,
                 cacheName: nil
             )
             return
         }
-        
+
         currentAuthor = author
         notificationWatcher = NSFetchedResultsController(
-            fetchRequest: Event.all(notifying: author, since: showPushNotificationsAfter), 
+            fetchRequest: Event.all(notifying: author, since: showPushNotificationsAfter),
             managedObjectContext: modelContext,
             sectionNameKeyPath: nil,
             cacheName: nil
         )
         notificationWatcher?.delegate = self
         await modelContext.perform { [weak self] in
-            do { 
+            do {
                 try self?.notificationWatcher?.performFetch()
             } catch {
                 Log.error("Error watching notifications:")
                 self?.crashReporting.report(error)
             }
         }
-        
+
         let userMentionsFilter = Filter(
-            kinds: [.text], 
-            pTags: [authorKey], 
+            kinds: [.text],
+            pTags: [authorKey],
             limit: 50,
             keepSubscriptionOpen: true
         )
@@ -101,18 +104,18 @@ import Combine
         )
 
         await updateBadgeCount()
-        
+
         do {
             try await registrar.register(user, context: modelContext)
         } catch {
             Log.optional(error, "failed to register for push notifications")
         }
     }
-    
+
     func registerForNotifications(_ user: CurrentUser, with deviceToken: Data) async throws {
         try await registrar.register(user, with: deviceToken, context: modelContext)
     }
-    
+
     // MARK: - Helpers
 
     func requestNotificationPermissionsFromUser() {
@@ -126,7 +129,7 @@ import Combine
             }
         }
     }
-    
+
     /// Recomputes the number of unread notifications for the `currentAuthor`, publishes the new value to
     /// `badgeCount`, and updates the application badge icon.
     func updateBadgeCount() async {
@@ -136,20 +139,20 @@ import Combine
                 (try? NosNotification.unreadCount(in: self.modelContext)) ?? 0
             }
         }
-        
+
         self.badgeCount = badgeCount
         try? await UNUserNotificationCenter.current().setBadgeCount(badgeCount)
     }
-    
+
     // MARK: - Internal
-    
-    /// Tells the system to display a notification for the given event if it's appropriate. This will create a 
+
+    /// Tells the system to display a notification for the given event if it's appropriate. This will create a
     /// NosNotification record in the database.
     @MainActor private func showNotificationIfNecessary(for eventID: RawEventID) async {
         guard let authorKey = currentAuthor?.hexadecimalPublicKey else {
             return
         }
-        
+
         let viewModel: NotificationViewModel? = await modelContext.perform { () -> NotificationViewModel? in
             guard let event = Event.find(by: eventID, context: self.modelContext),
                 let eventCreated = event.createdAt,
@@ -158,30 +161,32 @@ import Combine
                     date: eventCreated,
                     authorKey: authorKey,
                     in: self.modelContext
-                ) else {
+                )
+            else {
                 // We already have a notification for this event.
                 return nil
             }
-            
+
             defer { try? self.modelContext.save() }
-            
+
             // Don't alert for old notifications or muted authors
-            guard let eventCreated = event.createdAt, 
+            guard let eventCreated = event.createdAt,
                 eventCreated > self.showPushNotificationsAfter,
-                event.author?.muted == false else { 
+                event.author?.muted == false
+            else {
                 coreDataNotification.isRead = true
                 return nil
             }
-            
-            return NotificationViewModel(coreDataModel: coreDataNotification, context: self.modelContext) 
+
+            return NotificationViewModel(coreDataModel: coreDataNotification, context: self.modelContext)
         }
-        
+
         if let viewModel {
-            // Leave an hour of margin on the showPushNotificationsAfter date to allow for events arriving slightly 
+            // Leave an hour of margin on the showPushNotificationsAfter date to allow for events arriving slightly
             // out of order.
             showPushNotificationsAfter = viewModel.date.addingTimeInterval(-60 * 60)
             await viewModel.loadContent(in: self.persistenceController.backgroundViewContext)
-            
+
             do {
                 try await UNUserNotificationCenter.current().add(viewModel.notificationCenterRequest)
                 await updateBadgeCount()
@@ -190,17 +195,18 @@ import Combine
             }
         }
     }
-    
+
     // MARK: - UNUserNotificationCenterDelegate
-    
+
     func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse) async {
         if response.actionIdentifier == UNNotificationDefaultActionIdentifier {
             analytics.tappedNotification()
-            
+
             let userInfo = response.notification.request.content.userInfo
             if let eventID = userInfo["eventID"] as? String,
-                !eventID.isEmpty {
-                
+                !eventID.isEmpty
+            {
+
                 Task { @MainActor in
                     guard let event = Event.find(by: eventID, context: self.persistenceController.viewContext) else {
                         return
@@ -211,7 +217,8 @@ import Combine
             } else if let data = userInfo["data"] as? [AnyHashable: Any] {
                 if let followPubkeys = data["follows"] as? [String],
                     let firstPubkey = followPubkeys.first,
-                    let publicKey = PublicKey.build(npubOrHex: firstPubkey) {
+                    let publicKey = PublicKey.build(npubOrHex: firstPubkey)
+                {
                     Task { @MainActor in
                         self.router.selectedTab = .notifications
                         self.router.pushAuthor(id: publicKey.hex)
@@ -220,39 +227,40 @@ import Combine
             }
         }
     }
-    
+
     func userNotificationCenter(
-        _ center: UNUserNotificationCenter, 
+        _ center: UNUserNotificationCenter,
         willPresent notification: UNNotification
     ) async -> UNNotificationPresentationOptions {
         analytics.displayedNotification()
         return [.list, .banner, .badge, .sound]
     }
-    
+
     // MARK: - NSFetchedResultsControllerDelegate
-    
+
     nonisolated func controller(
-        _ controller: NSFetchedResultsController<NSFetchRequestResult>, 
-        didChange anObject: Any, 
-        at indexPath: IndexPath?, 
-        for type: NSFetchedResultsChangeType, 
+        _ controller: NSFetchedResultsController<NSFetchRequestResult>,
+        didChange anObject: Any,
+        at indexPath: IndexPath?,
+        for type: NSFetchedResultsChangeType,
         newIndexPath: IndexPath?
     ) {
         guard type == .insert else {
             return
         }
-        
+
         guard let event = anObject as? Event,
-            let eventID = event.identifier else {
+            let eventID = event.identifier
+        else {
             return
         }
-        
+
         Task { await showNotificationIfNecessary(for: eventID) }
     }
 }
 
 class MockPushNotificationService: PushNotificationService {
-    override func listen(for user: CurrentUser) async { }
-    override func registerForNotifications(_ user: CurrentUser, with deviceToken: Data) async throws { }
-    override func requestNotificationPermissionsFromUser() { }
+    override func listen(for user: CurrentUser) async {}
+    override func registerForNotifications(_ user: CurrentUser, with deviceToken: Data) async throws {}
+    override func requestNotificationPermissionsFromUser() {}
 }

--- a/Nos/Service/Relay/Filter.swift
+++ b/Nos/Service/Relay/Filter.swift
@@ -1,9 +1,9 @@
 import Foundation
 
-/// Describes a set of Nostr Events, usually so we can ask relay servers for them. 
+/// Describes a set of Nostr Events, usually so we can ask relay servers for them.
 /// See [NIP-01](https://github.com/nostr-protocol/nips/blob/master/01.md#communication-between-clients-and-relays).
 struct Filter: Hashable, Identifiable {
-    
+
     /// List of author identifiers the Filter should be constrained to.
     var authorKeys: [RawAuthorID]
 
@@ -86,10 +86,10 @@ struct Filter: Hashable, Identifiable {
         self.until = until
         self.keepSubscriptionOpen = keepSubscriptionOpen
     }
-    
+
     var dictionary: [String: Any] {
         var filterDict = [String: Any]()
-        
+
         if let limit {
             filterDict["limit"] = limit
         }
@@ -97,7 +97,7 @@ struct Filter: Hashable, Identifiable {
         if !authorKeys.isEmpty {
             filterDict["authors"] = authorKeys
         }
-        
+
         if !eventIDs.isEmpty {
             filterDict["ids"] = eventIDs
         }
@@ -113,19 +113,19 @@ struct Filter: Hashable, Identifiable {
         if !eTags.isEmpty {
             filterDict["#e"] = eTags
         }
-        
+
         if !pTags.isEmpty {
             filterDict["#p"] = pTags
         }
-        
+
         if let search {
             filterDict["search"] = search
         }
-        
+
         if let since {
             filterDict["since"] = Int(since.timeIntervalSince1970)
         }
-        
+
         if let until {
             filterDict["until"] = Int(until.timeIntervalSince1970)
         }
@@ -150,7 +150,7 @@ struct Filter: Hashable, Identifiable {
         hasher.combine(until)
         hasher.combine(keepSubscriptionOpen)
     }
-    
+
     var id: String {
         hashValue.description
     }

--- a/Nos/Service/Relay/PagedRelaySubscription.swift
+++ b/Nos/Service/Relay/PagedRelaySubscription.swift
@@ -1,10 +1,10 @@
+import Combine
 import Foundation
 import Logger
-import Combine
 
 /// This class manages a Filter and fetches events in reverse-chronological order as `loadMore()` is called. This
 /// can be used to paginate a list of events. The underlying relay subscriptions will be deallocated when this object
-/// goes out of scope.  
+/// goes out of scope.
 ///
 /// Paging in Nostr is very different from traditional HTTP paging, because we can't just ask for "the next 20 events
 /// after index 100". Instead we have to use dates and ask for "the next 20 events older than X". Moreover because we
@@ -15,29 +15,29 @@ import Combine
 class PagedRelaySubscription {
     let startDate: Date
     let filter: Filter
-    
+
     private var relayService: RelayService
     private var subscriptionManager: RelaySubscriptionManager
-    
+
     /// A set of subscriptions fetching older events.
     private var pagedSubscriptionIDs = Set<RelaySubscription.ID>()
-    
+
     /// A set of subscriptions always listening for new events published after the `startDate`.
     private var newEventsSubscriptionIDs = Set<RelaySubscription.ID>()
-    
+
     /// The relays we are fetching events from
     private let relayAddresses: Set<URL>
-    
+
     /// The oldest event each relay has returned. Used to load the next page.
     private var oldestEventByRelay = [URL: Date]()
-    
+
     private var cancellables = [AnyCancellable]()
-    
+
     init(
-        startDate: Date, 
-        filter: Filter, 
+        startDate: Date,
+        filter: Filter,
         relayService: RelayService,
-        subscriptionManager: RelaySubscriptionManager, 
+        subscriptionManager: RelaySubscriptionManager,
         relayAddresses: Set<URL>
     ) {
         self.startDate = startDate
@@ -46,7 +46,7 @@ class PagedRelaySubscription {
         self.subscriptionManager = subscriptionManager
         self.relayAddresses = relayAddresses
         Task {
-            // We keep two sets of subscriptions. One is always listening for new events and the other fetches 
+            // We keep two sets of subscriptions. One is always listening for new events and the other fetches
             // progressively older events as we page down.
             var newEventsFilter = filter
             newEventsFilter.since = startDate
@@ -60,17 +60,17 @@ class PagedRelaySubscription {
             loadMore()
         }
     }
-    
+
     deinit {
         for subscriptionID in newEventsSubscriptionIDs {
             relayService.decrementSubscriptionCount(for: subscriptionID)
         }
-        
+
         for subscriptionID in pagedSubscriptionIDs {
             relayService.decrementSubscriptionCount(for: subscriptionID)
         }
     }
-    
+
     /// Instructs the pager to load the next page of events from each relay. The given date should be roughly the date
     /// of the content the user is looking at and is used to put a given realy into "catch up" mode where we fetch
     /// more events to catch up what the user is looking at.
@@ -82,17 +82,17 @@ class PagedRelaySubscription {
             }
             pagedSubscriptionIDs.removeAll()
             cancellables.removeAll()
-            
+
             // Open new subscriptions
             for relayAddress in relayAddresses {
-                
+
                 // To fetch the next "page" we need to know what the last event we got was, then we ask for the next
                 // `limit` events older than that.
                 let nextPageStartDate = oldestEventByRelay[relayAddress] ?? startDate
                 var nextPageFilter = self.filter
                 nextPageFilter.until = nextPageStartDate
                 nextPageFilter.keepSubscriptionOpen = false
-                
+
                 // If the most recent event we got is older than what the user is looking at, open an extra subscription
                 // with no limit so we can "catch up".
                 if let displayedDate, nextPageStartDate >= displayedDate {
@@ -101,19 +101,19 @@ class PagedRelaySubscription {
                     catchUpFilter.until = nextPageStartDate
                     catchUpFilter.limit = nil
                     let catchUpSubscription = await subscriptionManager.queueSubscription(
-                        with: nextPageFilter, 
+                        with: nextPageFilter,
                         to: relayAddress
                     )
                     pagedSubscriptionIDs.insert(catchUpSubscription.id)
-                    
+
                     nextPageFilter.until = displayedDate
                 }
-                
+
                 let nextPageSubscription = await subscriptionManager.queueSubscription(
-                    with: nextPageFilter, 
+                    with: nextPageFilter,
                     to: relayAddress
                 )
-                
+
                 /// Keep track of the oldest event seen for this relay so we can use it when it's time to load the next
                 /// page.
                 nextPageSubscription.events
@@ -123,22 +123,22 @@ class PagedRelaySubscription {
                         }
                     }
                     .store(in: &cancellables)
-                
+
                 pagedSubscriptionIDs.insert(nextPageSubscription.id)
-                
+
                 await subscriptionManager.processSubscriptionQueue()
             }
         }
     }
-    
-    /// Used to record the oldest event we've seen from a relay. We need this because `track(event:from:)` is 
+
+    /// Used to record the oldest event we've seen from a relay. We need this because `track(event:from:)` is
     /// nonisolated so it can be called from a Combine chain.
     func updateOldestEvent(for relay: URL, to date: Date) {
         oldestEventByRelay[relay] = date
     }
-    
+
     /// Records the `created_at` date from given event if it's the oldest one we've seen so far. This information
-    /// is needed to load the next page when it's time. 
+    /// is needed to load the next page when it's time.
     nonisolated func track(event: JSONEvent, from relay: URL) async {
         if let oldestSeen = await oldestEventByRelay[relay] {
             if event.createdDate < oldestSeen {

--- a/Nos/Service/ReportPublisher.swift
+++ b/Nos/Service/ReportPublisher.swift
@@ -1,7 +1,7 @@
-import Foundation
-import Dependencies
-import Logger
 import CoreData
+import Dependencies
+import Foundation
+import Logger
 
 enum Tagr {
     // swiftlint:disable:next force_unwrapping
@@ -17,16 +17,16 @@ class ReportPublisher {
     @Dependency(\.relayService) private var relayService
     @Dependency(\.currentUser) private var currentUser
     @Dependency(\.analytics) private var analytics
-    
+
     /// Publishes a report for the given target and category.
     func publishPublicReport(for target: ReportTarget, category: ReportCategory, context: NSManagedObjectContext) {
         guard let keyPair = currentUser.keyPair else {
             Log.error("Cannot publish report - No signed in user")
             return
         }
-        
+
         let publicReport = createPublicReport(for: target, category: category, pubKey: keyPair.publicKeyHex)
-        
+
         Task {
             do {
                 try await relayService.publishToAll(event: publicReport, signingKey: keyPair, context: context)
@@ -36,18 +36,18 @@ class ReportPublisher {
             }
         }
     }
-    
+
     func publishPrivateReport(for target: ReportTarget, category: ReportCategory, context: NSManagedObjectContext) {
         guard let keyPair = currentUser.keyPair else {
             Log.error("Cannot publish report - No signed in user")
             return
         }
-        
+
         guard let reportRequestDM = createReportRequestDM(target: target, category: category, keyPair: keyPair) else {
             Log.error("Failed to create gift wrapped report request")
             return
         }
-        
+
         Task {
             do {
                 switch target {
@@ -60,7 +60,7 @@ class ReportPublisher {
                     }
                     Log.info("Sending report request to Nos for npub \(npub)")
                 }
-                
+
                 try await relayService.publish(
                     event: reportRequestDM,
                     to: Relay.nosAddress,
@@ -72,9 +72,9 @@ class ReportPublisher {
             }
         }
     }
-    
+
     // MARK: Helpers
-    
+
     func createPublicReport(
         for target: ReportTarget,
         category: ReportCategory,
@@ -86,13 +86,13 @@ class ReportPublisher {
             tags: [],
             content: String(localized: .localizable.reportEventContent(category.displayName))
         )
-        
+
         let nip56Reason = category.nip56Code.rawValue
         event.tags += target.tags(for: nip56Reason)
-        
+
         return event
     }
-    
+
     func createReportRequestDM(
         target: ReportTarget,
         category: ReportCategory,
@@ -104,7 +104,7 @@ class ReportPublisher {
                 reporterPubkey: keyPair.publicKeyHex,
                 reporterText: category.displayName
             ).toJSON()
-            
+
             let reportRequestGiftWrap = try DirectMessageWrapper.wrap(
                 message: reportRequestJSON,
                 senderKeyPair: keyPair,
@@ -122,28 +122,28 @@ struct ReportRequest {
     let reportedTarget: ReportTarget
     let reporterPubkey: RawAuthorID
     let reporterText: String
-    
+
     func toJSON() throws -> String {
         var dictionary: [String: Any] = [
             "reporterPubkey": reporterPubkey,
-            "reporterText": reporterText
+            "reporterText": reporterText,
         ]
-        
+
         switch reportedTarget {
         case .note(let note):
             guard let jsonEvent = note.codable else {
                 throw ReportError.encodingFailed("Could not encode note to JSON")
             }
-            
-            dictionary[ "reportedEvent"] = jsonEvent.dictionary
+
+            dictionary["reportedEvent"] = jsonEvent.dictionary
         case .author(let author):
             guard let pubKey = author.hexadecimalPublicKey else {
                 throw ReportError.missingPublicKey("Author's public key is missing")
             }
-            
+
             dictionary["reportedPubkey"] = pubKey
         }
-        
+
         let data = try JSONSerialization.data(withJSONObject: dictionary)
         return String(decoding: data, as: UTF8.self)
     }

--- a/Nos/Service/UNSAPI.swift
+++ b/Nos/Service/UNSAPI.swift
@@ -1,7 +1,7 @@
-import secp256k1
+import Dependencies
 import Foundation
 import Logger
-import Dependencies
+import secp256k1
 
 typealias JSONObject = [String: Any]
 typealias UNSNameID = String
@@ -32,17 +32,17 @@ class UNSAPI {
     private var clientSecret: String
     private var orgCode: String
     private var apiKey: String
-    
+
     // State
     private(set) var accessToken: String?
     private var refreshToken: String?
     private var personaID: String?
     private var verificationID: String?
-    
+
     private let refreshTokenKey = "com.nos.uns.refreshToken"
-    
+
     @Dependency(\.userDefaults) private var userDefaults
-    
+
     init?() {
         guard let authConnectionURLString = Self.getEnvironmentVariable(named: "UNS_AUTH_CONNECTION_URL"),
             let authConnectionURL = URL(string: "https://\(authConnectionURLString)"),
@@ -51,10 +51,11 @@ class UNSAPI {
             let clientID = Self.getEnvironmentVariable(named: "UNS_CLIENT_ID"),
             let clientSecret = Self.getEnvironmentVariable(named: "UNS_CLIENT_SECRET"),
             let apiKey = Self.getEnvironmentVariable(named: "UNS_API_KEY"),
-            let orgCode = Self.getEnvironmentVariable(named: "UNS_ORG_CODE") else {
+            let orgCode = Self.getEnvironmentVariable(named: "UNS_ORG_CODE")
+        else {
             return nil
         }
-        
+
         self.authConnectionURL = authConnectionURL
         self.connectionURL = connectionURL
         self.clientID = clientID
@@ -63,7 +64,7 @@ class UNSAPI {
         self.apiKey = apiKey
         loadRefreshToken()
     }
-    
+
     func requestVerificationCode(phoneNumber: String) async throws {
         var request = URLRequest(url: authConnectionURL.appending(path: "v1/phone_verification/request_otp"))
         request.setValue(apiKey, forHTTPHeaderField: "x-api-key")
@@ -79,14 +80,15 @@ class UNSAPI {
         request.httpMethod = "POST"
         Log.info(request.description)
         let response = try await URLSession.shared.data(for: request)
-        
+
         guard let httpResponse = response.1 as? HTTPURLResponse,
-            httpResponse.statusCode == 204 else {
+            httpResponse.statusCode == 204
+        else {
             logError(response: response)
             throw UNSError.generic
         }
     }
-    
+
     func verifyPhone(phoneNumber: String, code: String) async throws {
         var request = URLRequest(url: authConnectionURL.appending(path: "v1/phone_verification/validate_otp"))
         request.setValue(apiKey, forHTTPHeaderField: "x-api-key")
@@ -103,34 +105,35 @@ class UNSAPI {
         request.httpMethod = "POST"
         let response = try await URLSession.shared.data(for: request)
         let data = response.0
-        
+
         guard let responseDict = try JSONSerialization.jsonObject(with: data) as? JSONObject,
             let dataDict = responseDict["data"] as? JSONObject,
             let accessTokenDict = dataDict["access_token"] as? JSONObject,
             let personaDict = dataDict["persona"] as? JSONObject,
             let personaID = personaDict["persona_id"] as? String,
             let accessToken = accessTokenDict["access_token"] as? String,
-            let refreshToken = accessTokenDict["refresh_token"] as? String else {
+            let refreshToken = accessTokenDict["refresh_token"] as? String
+        else {
             logError(response: response)
             throw UNSError.badResponse
         }
-        
+
         self.personaID = personaID
         self.accessToken = accessToken
         self.refreshToken = refreshToken
         saveRefreshToken()
     }
-    
+
     func refreshAccessToken() async throws {
         guard let refreshToken else {
             throw UNSError.notAuthenticated
         }
-        
+
         var request = URLRequest(url: authConnectionURL.appending(path: "v1/oauth"))
         request.setValue(apiKey, forHTTPHeaderField: "x-api-key")
         request.setValue(orgCode, forHTTPHeaderField: "x-org-code")
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        
+
         let body = [
             "client_id": clientID,
             "client_secret": clientSecret,
@@ -142,21 +145,22 @@ class UNSAPI {
         request.httpMethod = "POST"
         let response = try await URLSession.shared.data(for: request)
         let data = response.0
-        
+
         guard let responseDict = try JSONSerialization.jsonObject(with: data) as? JSONObject,
             let dataDict = responseDict["data"] as? JSONObject,
             let accessToken = dataDict["access_token"] as? String,
-            let refreshToken = dataDict["refresh_token"] as? String else {
+            let refreshToken = dataDict["refresh_token"] as? String
+        else {
             logError(response: response)
             self.refreshToken = nil
             throw UNSError.badResponse
         }
-        
+
         self.accessToken = accessToken
         self.refreshToken = refreshToken
         saveRefreshToken()
     }
-    
+
     func getNames() async throws -> [UNSNameRecord] {
         let accessToken = try await checkAccessToken()
         guard let personaID else {
@@ -169,7 +173,7 @@ class UNSAPI {
         request.httpMethod = "GET"
         let response = try await URLSession.shared.data(for: request)
         let data = response.0
-        
+
         guard let responseDict = try JSONSerialization.jsonObject(with: data) as? JSONObject else {
             throw UNSError.badResponse
         }
@@ -180,14 +184,15 @@ class UNSAPI {
         var names = [UNSNameRecord]()
         for nameDict in dataDict {
             if let name = nameDict["name"] as? String,
-                let nameID = nameDict["name_id"] as? String {
+                let nameID = nameDict["name_id"] as? String
+            {
                 names.append(UNSNameRecord(name: name, id: nameID))
             }
         }
-        
+
         return names
     }
-    
+
     func createName(_ name: String) async throws -> UNSNameID {
         let accessToken = try await checkAccessToken()
         var request = URLRequest(url: connectionURL.appending(path: "v1/names"))
@@ -204,15 +209,17 @@ class UNSAPI {
         request.httpMethod = "POST"
         let response = try await URLSession.shared.data(for: request)
         if let httpResponse = response.1 as? HTTPURLResponse,
-            httpResponse.statusCode == 201 {
-            
+            httpResponse.statusCode == 201
+        {
+
             guard let responseDict = try? jsonDictionary(from: response.0),
                 let dataDict = responseDict["data"] as? JSONObject,
                 let nameDict = dataDict["name"] as? JSONObject,
-                let nameID = nameDict["name_id"] as? String else {
+                let nameID = nameDict["name_id"] as? String
+            else {
                 throw UNSError.badResponse
             }
-            
+
             return nameID
         } else if isNeedPaymentError(response.0) {
             throw UNSError.requiresPayment(URL(string: "https://www.universalname.space/name/\(name)")!)
@@ -223,7 +230,7 @@ class UNSAPI {
             throw UNSError.badResponse
         }
     }
-    
+
     func requestNostrVerification(npub: String, nameID: String) async throws -> String? {
         let accessToken = try await checkAccessToken()
         var request = URLRequest(url: connectionURL.appending(path: "/v1/resolver/social_connections"))
@@ -231,36 +238,38 @@ class UNSAPI {
         request.setValue(orgCode, forHTTPHeaderField: "x-org-code")
         request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        let body = [
-            "name_id": nameID,
-            "connection_type": "NOSTR_SIGNATURE",
-            "scope": "PUBLIC",
-            "arguments": [
-                "nostr_pub_key": npub
-            ]
-        ] as JSONObject
+        let body =
+            [
+                "name_id": nameID,
+                "connection_type": "NOSTR_SIGNATURE",
+                "scope": "PUBLIC",
+                "arguments": [
+                    "nostr_pub_key": npub
+                ],
+            ] as JSONObject
         let jsonBody = try JSONSerialization.data(withJSONObject: body)
         request.httpBody = jsonBody
         request.httpMethod = "POST"
-        
+
         let response = try await URLSession.shared.data(for: request)
         let responseData = response.0
         let responseString = String(decoding: responseData, as: UTF8.self)
         if responseString.ranges(of: "DUPLICATED_SOCIAL_CONNECTION").isEmpty == false {
             return nil
         }
-            
+
         let responseJSON = try jsonDictionary(from: response.0)
         guard let dataDict = responseJSON["data"] as? JSONObject,
             let verificationID = dataDict["verification_id"] as? String,
-            let message = dataDict["message"] as? String else {
+            let message = dataDict["message"] as? String
+        else {
             logError(response: response)
             throw UNSError.badResponse
         }
         self.verificationID = verificationID
         return message
     }
-    
+
     func submitNostrVerification(message: String, keyPair: KeyPair) async throws -> String {
         let accessToken = try await checkAccessToken()
         var request = URLRequest(url: connectionURL.appending(path: "/v1/resolver/social_connections/nostr/signature"))
@@ -271,11 +280,12 @@ class UNSAPI {
         guard var bytesToSign = try message.data(using: .utf8)?.sha256.bytes else {
             throw UNSError.generic
         }
-        let body = [
-            "verification_id": verificationID ?? "null",
-            "public_key": keyPair.npub,
-            "signature": try keyPair.sign(bytes: &bytesToSign)
-        ] as JSONObject
+        let body =
+            [
+                "verification_id": verificationID ?? "null",
+                "public_key": keyPair.npub,
+                "signature": try keyPair.sign(bytes: &bytesToSign),
+            ] as JSONObject
         let jsonBody = try JSONSerialization.data(withJSONObject: body)
         request.httpBody = jsonBody
         request.httpMethod = "POST"
@@ -284,13 +294,14 @@ class UNSAPI {
         let responseJSON = try jsonDictionary(from: response.0)
         guard let dataDict = responseJSON["data"] as? JSONObject,
             let verificationDict = dataDict["verification"] as? JSONObject,
-            let externalID = verificationDict["external_id"] as? String else {
+            let externalID = verificationDict["external_id"] as? String
+        else {
             logError(response: response)
             throw UNSError.badResponse
         }
         return externalID
     }
-    
+
     func getNIP05(for nameID: UNSNameID) async throws -> String {
         let accessToken = try await checkAccessToken()
         var url = connectionURL.appending(path: "/v1/resolver/admin")
@@ -308,21 +319,22 @@ class UNSAPI {
         request.httpMethod = "GET"
         let response = try await URLSession.shared.data(for: request)
         let responseJSON = try jsonDictionary(from: response.0)
-        
+
         guard let dataDict = responseJSON["data"] as? [JSONObject],
             let nostrConnection = dataDict.first,
-            let nip05 = nostrConnection["value"] as? String else {
+            let nip05 = nostrConnection["value"] as? String
+        else {
             logError(response: response)
             throw UNSError.badResponse
         }
         return nip05
-    }    
-   
+    }
+
     func nameRecord(for name: UNSName) async throws -> UNSNameRecord? {
         let accessToken = try await checkAccessToken()
         var url = connectionURL.appending(path: "/v1/names")
         url = url.appending(queryItems: [
-            URLQueryItem(name: "name", value: name.lowercased()),
+            URLQueryItem(name: "name", value: name.lowercased())
         ])
         var request = URLRequest(url: url)
         request.setValue(apiKey, forHTTPHeaderField: "x-api-key")
@@ -330,17 +342,18 @@ class UNSAPI {
         request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.httpMethod = "GET"
-        
+
         let response = try await URLSession.shared.data(for: request)
         let responseJSON = try jsonDictionary(from: response.0)
-        
+
         guard let dataDict = responseJSON["data"] as? JSONObject,
-            let available = dataDict["available"] as? Int else {
+            let available = dataDict["available"] as? Int
+        else {
             logError(response: response)
             throw UNSError.badResponse
         }
-        
-        if available == 0 { 
+
+        if available == 0 {
             guard let nameID = dataDict["name_id"] as? String else {
                 throw UNSError.badResponse
             }
@@ -349,7 +362,7 @@ class UNSAPI {
             return nil
         }
     }
-    
+
     func names(matching query: String) async throws -> [RawAuthorID] {
         if let nameRecord = try await nameRecord(for: query) {
             let nostrPubKeys = try await nostrKeys(for: nameRecord)
@@ -358,7 +371,7 @@ class UNSAPI {
             return []
         }
     }
-    
+
     private func nostrKeys(for nameRecord: UNSNameRecord) async throws -> [RawAuthorID] {
         let accessToken = try await checkAccessToken()
         var url = connectionURL.appending(path: "/v1/resolver")
@@ -374,85 +387,88 @@ class UNSAPI {
         request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.httpMethod = "GET"
-        
+
         let response = try await URLSession.shared.data(for: request)
         let responseJSON = try jsonDictionary(from: response.0)
         print(responseJSON)
-        
+
         guard let dataArray = responseJSON["data"] as? [JSONObject] else {
             throw UNSError.badResponse
         }
-        
+
         var nostrPubKeys = [RawAuthorID]()
         for connection in dataArray {
             if let npub = connection["display_value"] as? String,
-                let pubKey = PublicKey(npub: npub) {
+                let pubKey = PublicKey(npub: npub)
+            {
                 nostrPubKeys.append(pubKey.hex)
             }
         }
-        
+
         return nostrPubKeys
     }
-    
+
     func logout() {
         refreshToken = nil
         accessToken = nil
         personaID = nil
         saveRefreshToken()
     }
-    
+
     // MARK: - Helpers
-    
+
     func isNeedPaymentError(_ data: Data) -> Bool {
         guard let responseDict = try? jsonDictionary(from: data) else {
             return false
         }
         if let errorDict = responseDict["error"] as? JSONObject,
             let codeDict = errorDict["code"] as? JSONObject,
-            let numCode = codeDict["num_code"] as? Int {
-            return numCode == 60_404 
+            let numCode = codeDict["num_code"] as? Int
+        {
+            return numCode == 60_404
         }
-        
+
         return false
     }
-    
+
     func isNameTakenError(_ data: Data) -> Bool {
         guard let responseDict = try? jsonDictionary(from: data) else {
             return false
         }
         if let errorDict = responseDict["error"] as? JSONObject,
             let codeDict = errorDict["code"] as? JSONObject,
-            let numCode = codeDict["num_code"] as? Int {
+            let numCode = codeDict["num_code"] as? Int
+        {
             return numCode == 60_105 || numCode == 60_103
         }
-        
+
         return false
     }
-    
+
     func jsonDictionary(from data: Data) throws -> JSONObject {
         guard let responseDict = try JSONSerialization.jsonObject(with: data) as? JSONObject else {
             throw UNSError.badResponse
         }
-        
+
         return responseDict
     }
-    
+
     func logError(from functionName: String = #function, response: (Data, URLResponse)) {
         Log.error("\(functionName) failed with \(String(decoding: response.0, as: UTF8.self))")
     }
-    
+
     class func getEnvironmentVariable(named name: String) -> String? {
         Bundle.main.infoDictionary?[name] as? String
     }
-    
+
     func saveRefreshToken() {
         userDefaults.set(self.refreshToken, forKey: refreshTokenKey)
     }
-    
+
     func loadRefreshToken() {
         self.refreshToken = userDefaults.string(forKey: refreshTokenKey)
     }
-   
+
     func checkAccessToken() async throws -> String {
         if accessToken == nil {
             try await refreshAccessToken()

--- a/Nos/Service/Zipper.swift
+++ b/Nos/Service/Zipper.swift
@@ -24,7 +24,7 @@ enum Zipper {
         }
         return try await zipFiles([sqliteURL])
     }
-    
+
     /// Zips the files at the given URLs.
     /// - Parameter fileURLs: the URLs of the files to zip.
     /// - Returns: The file URL of the zip.
@@ -38,15 +38,15 @@ enum Zipper {
                 let destFileURL = url.appendingPathComponent(appFileURL.lastPathComponent)
                 try FileManager.default.copyItem(at: appFileURL, to: destFileURL)
             }
-            
+
             try fileURLs.forEach { try copy($0) }
 
             let coord = NSFileCoordinator()
             var readError: NSError?
             return try await withCheckedThrowingContinuation { continuation in
                 coord.coordinate(
-                    readingItemAt: url, 
-                    options: .forUploading, 
+                    readingItemAt: url,
+                    options: .forUploading,
                     error: &readError
                 ) { (zippedURL: URL) in
                     do {

--- a/Nos/Views/AppView.swift
+++ b/Nos/Views/AppView.swift
@@ -1,10 +1,10 @@
-import SwiftUI
 import Dependencies
+import SwiftUI
 
 struct AppView: View {
 
     @State var showNewPost = false
-    @State var newPostContents: String? 
+    @State var newPostContents: String?
 
     @Environment(AppController.self) var appController
     @EnvironmentObject private var router: Router
@@ -13,7 +13,7 @@ struct AppView: View {
     @Dependency(\.crashReporting) private var crashReporting
     @Dependency(\.userDefaults) private var userDefaults
     @Environment(CurrentUser.self) var currentUser
-    
+
     @State private var lastSelectedTab = AppDestination.home
     @State private var showNIP05Wizard = false
 
@@ -52,7 +52,7 @@ struct AppView: View {
                                 }
                             }
                     }
-                    
+
                     DiscoverTab()
                         .tabItem {
                             VStack {
@@ -69,7 +69,7 @@ struct AppView: View {
                         .toolbarBackground(.visible, for: .tabBar)
                         .toolbarBackground(Color.cardBgBottom, for: .tabBar)
                         .tag(AppDestination.discover)
-                    
+
                     VStack {}
                         .tabItem {
                             VStack {
@@ -77,8 +77,8 @@ struct AppView: View {
                                 Text(.localizable.post)
                             }
                         }
-                    .tag(AppDestination.noteComposer(nil))
-                    
+                        .tag(AppDestination.noteComposer(nil))
+
                     NotificationsView(user: currentUser.author)
                         .tabItem {
                             VStack {
@@ -96,7 +96,7 @@ struct AppView: View {
                         .toolbarBackground(Color.cardBgBottom, for: .tabBar)
                         .tag(AppDestination.notifications)
                         .badge(pushNotificationService.badgeCount)
-                    
+
                     if let author = currentUser.author {
                         ProfileTab(author: author, path: $router.profilePath)
                             .tabItem {
@@ -133,12 +133,14 @@ struct AppView: View {
                         }
                     }
                 }
-                .sheet(isPresented: $showNewPost, content: {
-                    NoteComposer(initialContents: newPostContents, isPresented: $showNewPost)
-                        .environment(currentUser)
-                        .interactiveDismissDisabled()
-                })
-                
+                .sheet(
+                    isPresented: $showNewPost,
+                    content: {
+                        NoteComposer(initialContents: newPostContents, isPresented: $showNewPost)
+                            .environment(currentUser)
+                            .interactiveDismissDisabled()
+                    })
+
                 SideMenu(
                     menuWidth: 300,
                     menuOpened: router.sideMenuOpened,
@@ -191,13 +193,13 @@ struct AppView: View {
 }
 
 struct AppView_Previews: PreviewProvider {
-    
+
     static var previewData = PreviewData()
     static var persistenceController = PersistenceController.preview
     static var previewContext = persistenceController.viewContext
     static var relayService = previewData.relayService
     static var router = Router()
-    static var currentUser = previewData.currentUser 
+    static var currentUser = previewData.currentUser
     static var pushNotificationService = DependencyValues().pushNotificationService
 
     static var loggedInAppController: AppController = {
@@ -205,13 +207,13 @@ struct AppView_Previews: PreviewProvider {
         appController.completeOnboarding()
         return appController
     }()
-    
+
     static var routerWithSideMenuOpened: Router = {
         let router = Router()
         router.toggleSideMenu()
         return router
     }()
-    
+
     static var previews: some View {
         AppView()
             .environment(\.managedObjectContext, previewContext)

--- a/Nos/Views/Components/ActionBanner.swift
+++ b/Nos/Views/Components/ActionBanner.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 /// A large colorful banner with a message and action button.
 struct ActionBanner: View {
-    
+
     var messageText: LocalizedStringResource
     var messageImage: Image?
     var buttonText: LocalizedStringResource
@@ -17,13 +17,13 @@ struct ActionBanner: View {
             endPoint: .trailing
         )
     }
-    
+
     var body: some View {
         ZStack {
             Color.actionBannerBg
                 .cornerRadius(21)
                 .offset(y: 2)
-            
+
             VStack {
                 HStack {
                     Text(messageText)
@@ -85,11 +85,11 @@ struct ActionBanner: View {
                             endPoint: .bottom
                         )
                         .blendMode(.softLight)
-                        
+
                         backgroundGradient.blendMode(.normal)
                     }
                 }
-                    .offset(y: -2)
+                .offset(y: -2)
             )
             .cornerRadius(20)
         }

--- a/Nos/Views/Components/ActivityView.swift
+++ b/Nos/Views/Components/ActivityView.swift
@@ -1,5 +1,5 @@
-import UIKit
 import SwiftUI
+import UIKit
 
 struct ActivityViewController: UIViewControllerRepresentable {
 
@@ -15,7 +15,7 @@ struct ActivityViewController: UIViewControllerRepresentable {
             activityItems: activityItems,
             applicationActivities: applicationActivities
         )
-        controller.completionWithItemsHandler = { _, _, _, _  in
+        controller.completionWithItemsHandler = { _, _, _, _ in
             completion?()
         }
         return controller
@@ -24,5 +24,5 @@ struct ActivityViewController: UIViewControllerRepresentable {
     func updateUIViewController(
         _ uiViewController: UIActivityViewController,
         context: UIViewControllerRepresentableContext<ActivityViewController>
-    ) { }
+    ) {}
 }

--- a/Nos/Views/Components/Author/AuthorCard.swift
+++ b/Nos/Views/Components/Author/AuthorCard.swift
@@ -9,7 +9,7 @@ struct AuthorCard: View {
     let showsFollowButton: Bool
 
     var tapAction: (() -> Void)?
-    
+
     /// Initializes an `AuthorCard` with the given parameters.
     /// - Parameters:
     ///   - author: The author to show in the card.
@@ -98,7 +98,7 @@ struct AuthorCard: View {
 
 #Preview {
     var previewData = PreviewData()
-    
+
     return VStack {
         AuthorCard(author: previewData.alice)
         AuthorCard(author: previewData.unsAuthor, showsFollowButton: false)

--- a/Nos/Views/Components/Author/AuthorLabel.swift
+++ b/Nos/Views/Components/Author/AuthorLabel.swift
@@ -1,10 +1,10 @@
 import SwiftUI
 
 struct AuthorLabel: View {
-    
+
     @ObservedObject var author: Author
     var note: Event?
-    
+
     private var attributedAuthor: AttributedString {
         var authorName = AttributedString(author.safeName)
         authorName.foregroundColor = .primaryTxt
@@ -13,7 +13,7 @@ struct AuthorLabel: View {
             let postedOrRepliedString = String(localized: note.isReply ? .reply.replied : .reply.posted)
             var postedOrReplied = AttributedString(" " + postedOrRepliedString)
             postedOrReplied.foregroundColor = .secondaryTxt
-            
+
             authorName.append(postedOrReplied)
         }
         return authorName

--- a/Nos/Views/Components/Author/AuthorListView.swift
+++ b/Nos/Views/Components/Author/AuthorListView.swift
@@ -2,9 +2,9 @@ import Foundation
 import SwiftUI
 
 struct AuthorListView: View {
-    
+
     @Binding var isPresented: Bool
-    
+
     @Environment(\.managedObjectContext) private var viewContext
 
     @State private var authors: [Author]?
@@ -12,7 +12,7 @@ struct AuthorListView: View {
     @State private var filteredAuthors: [Author]?
 
     @StateObject private var searchTextObserver = SearchTextFieldObserver()
-    
+
     @FocusState private var isSearching: Bool
 
     var didSelectGesture: ((Author) -> Void)?
@@ -51,12 +51,14 @@ struct AuthorListView: View {
         }
         .toolbar {
             ToolbarItem(placement: .cancellationAction) {
-                Button(action: {
-                    isPresented = false
-                }, label: {
-                    Text(.localizable.cancel)
-                        .foregroundColor(.primaryTxt)
-                })
+                Button(
+                    action: {
+                        isPresented = false
+                    },
+                    label: {
+                        Text(.localizable.cancel)
+                            .foregroundColor(.primaryTxt)
+                    })
             }
         }
     }

--- a/Nos/Views/Components/Author/AuthorObservationView.swift
+++ b/Nos/Views/Components/Author/AuthorObservationView.swift
@@ -1,15 +1,15 @@
 import SwiftUI
 
-/// A view that observes changes to an `Author` with the given `RawAuthorID` and continually passes the newest version 
+/// A view that observes changes to an `Author` with the given `RawAuthorID` and continually passes the newest version
 /// to a child view. Useful for hosting views that just take an `Author` but want to observe changes to the author.
 struct AuthorObservationView<Content: View>: View {
-    
+
     /// A view building function that will be given the latest version of the `Author`.
     let contentBuilder: (Author) -> Content
-    
+
     /// A fetch request that will trigger a view update when the `Author` changes.
     @FetchRequest private var authors: FetchedResults<Author>
-    
+
     init(authorID: RawAuthorID?, contentBuilder: @escaping (Author) -> Content) {
         if let authorID {
             _authors = FetchRequest(fetchRequest: Author.request(by: authorID))
@@ -18,7 +18,7 @@ struct AuthorObservationView<Content: View>: View {
         }
         self.contentBuilder = contentBuilder
     }
-    
+
     var body: some View {
         if let author = authors.first {
             contentBuilder(author)

--- a/Nos/Views/Components/Author/CompactAuthorCard.swift
+++ b/Nos/Views/Components/Author/CompactAuthorCard.swift
@@ -8,7 +8,7 @@ struct CompactAuthorCard: View {
 
     @EnvironmentObject private var router: Router
     @EnvironmentObject private var relayService: RelayService
-    
+
     @State private var relaySubscriptions = SubscriptionCancellables()
 
     var body: some View {
@@ -41,12 +41,12 @@ struct CompactAuthorCard: View {
         .listRowInsets(EdgeInsets())
         .cornerRadius(15)
         .onAppear {
-            Task(priority: .userInitiated) { 
+            Task(priority: .userInitiated) {
                 let subscription = await relayService.requestMetadata(
-                    for: author.hexadecimalPublicKey, 
+                    for: author.hexadecimalPublicKey,
                     since: author.lastUpdatedMetadata
-                ) 
-                relaySubscriptions.append(subscription) 
+                )
+                relaySubscriptions.append(subscription)
             }
         }
         .onDisappear {

--- a/Nos/Views/Components/Author/NIP05View.swift
+++ b/Nos/Views/Components/Author/NIP05View.swift
@@ -68,8 +68,8 @@ struct NIP05View: View {
                 .foregroundStyle(Color.primaryTxt)
         } else {
             Text(parts.username)
-                .foregroundStyle(Color.primaryTxt) +
-            Text("@" + parts.domain)
+                .foregroundStyle(Color.primaryTxt)
+                + Text("@" + parts.domain)
                 .foregroundStyle(Color.secondaryTxt)
         }
     }

--- a/Nos/Views/Components/AvatarView.swift
+++ b/Nos/Views/Components/AvatarView.swift
@@ -1,11 +1,11 @@
-import SwiftUI
 import SDWebImageSwiftUI
+import SwiftUI
 
 struct AvatarView: View {
-    
+
     var imageUrl: URL?
     var size: CGFloat
-    
+
     var body: some View {
         WebImage(
             url: imageUrl,
@@ -29,9 +29,9 @@ struct AvatarView: View {
 }
 
 struct AvatarView_Previews: PreviewProvider {
-    
+
     static let avatarURL = URL(string: "https://tinyurl.com/47amhyzz") ?? URL.homeDirectory
-    
+
     static var previews: some View {
         VStack {
             AvatarView(imageUrl: avatarURL, size: 24)

--- a/Nos/Views/Components/BioView.swift
+++ b/Nos/Views/Components/BioView.swift
@@ -8,7 +8,7 @@ struct BioView: View {
     @Environment(\.managedObjectContext) private var viewContext
 
     @Dependency(\.noteParser) private var noteParser
-    
+
     @State
     private var shouldShowReadMore = false
 

--- a/Nos/Views/Components/Button/ActionButton.swift
+++ b/Nos/Views/Components/Button/ActionButton.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 /// A big bright button that is used as the primary call-to-action on a screen.
 struct ActionButton: View {
-    
+
     enum ImageAlignment {
         case left
         case right
@@ -18,7 +18,7 @@ struct ActionButton: View {
     var backgroundGradient = LinearGradient(
         colors: [
             Color.actionPrimaryGradientTop,
-            Color.actionPrimaryGradientBottom
+            Color.actionPrimaryGradientBottom,
         ],
         startPoint: .bottomLeading,
         endPoint: .topTrailing
@@ -30,48 +30,53 @@ struct ActionButton: View {
     var shouldFillHorizontalSpace = false
     var action: (() async -> Void)?
     @State var disabled = false
-    
+
     var body: some View {
-        Button(action: {
-            disabled = true
-            Task {
-                await action?()
-                disabled = false
+        Button(
+            action: {
+                disabled = true
+                Task {
+                    await action?()
+                    disabled = false
+                }
+            },
+            label: {
+                HStack(spacing: 4) {
+                    if shouldFillHorizontalSpace {
+                        // Center the image+text if the button has to fill the
+                        // available space.
+                        Spacer(minLength: 0)
+                    }
+                    if imageAlignment == .left {
+                        image
+                    }
+                    Text(title)
+                        .font(font)
+                        .transition(.opacity)
+                        .font(.headline)
+                        .foregroundColor(textColor)
+                    if imageAlignment == .right {
+                        image
+                    }
+                    if shouldFillHorizontalSpace {
+                        // Center the image+text if the button has to fill the
+                        // available space.
+                        Spacer(minLength: 0)
+                    }
+                }
             }
-        }, label: {
-            HStack(spacing: 4) {
-                if shouldFillHorizontalSpace {
-                    // Center the image+text if the button has to fill the
-                    // available space.
-                    Spacer(minLength: 0)
-                }
-                if imageAlignment == .left {
-                    image
-                }
-                Text(title)
-                    .font(font)
-                    .transition(.opacity)
-                    .font(.headline)
-                    .foregroundColor(textColor)
-                if imageAlignment == .right {
-                    image
-                }
-                if shouldFillHorizontalSpace {
-                    // Center the image+text if the button has to fill the
-                    // available space.
-                    Spacer(minLength: 0)
-                }
-            }
-        })
+        )
         .lineLimit(nil)
         .foregroundColor(.black)
-        .buttonStyle(ActionButtonStyle(
-            depthEffectColor: depthEffectColor,
-            backgroundGradient: backgroundGradient,
-            padding: padding,
-            textShadow: textShadow,
-            shouldFillHorizontalSpace: shouldFillHorizontalSpace
-        ))
+        .buttonStyle(
+            ActionButtonStyle(
+                depthEffectColor: depthEffectColor,
+                backgroundGradient: backgroundGradient,
+                padding: padding,
+                textShadow: textShadow,
+                shouldFillHorizontalSpace: shouldFillHorizontalSpace
+            )
+        )
         .disabled(disabled)
     }
 }
@@ -87,7 +92,7 @@ struct SecondaryActionButton: View {
     /// button.
     var shouldFillHorizontalSpace = false
     var action: (() async -> Void)?
-    
+
     var body: some View {
         ActionButton(
             title: title,
@@ -103,9 +108,9 @@ struct SecondaryActionButton: View {
 }
 
 struct ActionButtonStyle: ButtonStyle {
-    
+
     @SwiftUI.Environment(\.isEnabled) private var isEnabled
-    
+
     let cornerRadius: CGFloat = 17
     let depthEffectColor: Color
     let backgroundGradient: LinearGradient
@@ -141,13 +146,13 @@ struct ActionButtonStyle: ButtonStyle {
                         LinearGradient(
                             colors: [
                                 Color.actionButtonBackgroundGradientTop,
-                                Color.actionButtonBackgroundGradientBottom
+                                Color.actionButtonBackgroundGradientBottom,
                             ],
                             startPoint: .top,
                             endPoint: .bottom
                         )
                         .blendMode(.softLight)
-                        
+
                         backgroundGradient.blendMode(.normal)
                     }
                 )
@@ -165,17 +170,17 @@ struct ActionButton_Previews: PreviewProvider {
 
             ActionButton(title: .localizable.done, action: {})
                 .disabled(true)
-            
+
             ActionButton(
                 title: .localizable.edit,
                 font: .clarity(.medium),
-                image: Image.editProfile, 
+                image: Image.editProfile,
                 textColor: Color.actionBannerButtonTxt,
                 depthEffectColor: Color.actionBannerButtonEffect,
                 backgroundGradient: LinearGradient(
                     colors: [
                         Color.actionBannerButtonGradientLeading,
-                        Color.actionBannerButtonGradientTrailing
+                        Color.actionBannerButtonGradientTrailing,
                     ],
                     startPoint: .leading,
                     endPoint: .trailing
@@ -183,7 +188,7 @@ struct ActionButton_Previews: PreviewProvider {
                 textShadow: false,
                 action: {}
             )
-            
+
             SecondaryActionButton(title: .localizable.edit, action: {})
 
             // Something that should wrap at larger text sizes

--- a/Nos/Views/Components/Button/BigActionButton.swift
+++ b/Nos/Views/Components/Button/BigActionButton.swift
@@ -2,25 +2,28 @@ import SwiftUI
 
 /// A big bright button that is used as the primary call-to-action on a screen.
 struct BigActionButton: View {
-    
+
     var title: LocalizedStringResource
     var backgroundGradient: LinearGradient = .bigAction
     var action: () async -> Void
     @State var disabled = false
-    
+
     var body: some View {
-        Button(action: {
-            disabled = true
-            Task {
-                await action()
-                disabled = false
+        Button(
+            action: {
+                disabled = true
+                Task {
+                    await action()
+                    disabled = false
+                }
+            },
+            label: {
+                Text(title)
+                    .font(.clarity(.bold))
+                    .transition(.opacity)
+                    .font(.headline)
             }
-        }, label: {
-            Text(title)
-                .font(.clarity(.bold))
-                .transition(.opacity)
-                .font(.headline)
-        })
+        )
         .lineLimit(nil)
         .foregroundColor(.black)
         .buttonStyle(BigActionButtonStyle(backgroundGradient: backgroundGradient))
@@ -33,7 +36,7 @@ extension LinearGradient {
         LinearGradient(
             colors: [
                 Color.bigActionButtonGradientTop,
-                Color.bigActionButtonGradientBottom
+                Color.bigActionButtonGradientBottom,
             ],
             startPoint: .top,
             endPoint: .bottom
@@ -42,12 +45,12 @@ extension LinearGradient {
 }
 
 struct BigActionButtonStyle: ButtonStyle {
-    
+
     @SwiftUI.Environment(\.isEnabled) private var isEnabled
-    
+
     var backgroundGradient: LinearGradient = .bigAction
     let cornerRadius: CGFloat = 50
-    
+
     func makeBody(configuration: Configuration) -> some View {
         ZStack {
             // Button shadow/background
@@ -59,10 +62,10 @@ struct BigActionButtonStyle: ButtonStyle {
             .shadow(
                 color: Color.lightShadow,
                 radius: 2,
-                x: 0, 
+                x: 0,
                 y: configuration.isPressed ? 0 : 1
             )
-            
+
             // Button face
             ZStack {
                 // Gradient background color
@@ -76,10 +79,10 @@ struct BigActionButtonStyle: ButtonStyle {
                         endPoint: UnitPoint(x: 0.5, y: 0.99)
                     )
                     .blendMode(.softLight)
-                    
+
                     backgroundGradient.blendMode(.normal)
                 }
-                
+
                 // Text container
                 configuration.label
                     .foregroundColor(.white)
@@ -105,7 +108,7 @@ struct BigGradientButton_Previews: PreviewProvider {
         VStack(spacing: 20) {
             BigActionButton(title: .localizable.tryIt, action: {})
                 .frame(width: 268)
-            
+
             BigActionButton(title: .localizable.tryIt, action: {})
                 .disabled(true)
                 .frame(width: 268)

--- a/Nos/Views/Components/Button/CardButtonStyle.swift
+++ b/Nos/Views/Components/Button/CardButtonStyle.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct CardButtonStyle: ButtonStyle {
-    
+
     var style: CardStyle
 
     func makeBody(configuration: Configuration) -> some View {
@@ -9,8 +9,8 @@ struct CardButtonStyle: ButtonStyle {
     }
 }
 
-fileprivate extension CardStyle {
-    var cornerRadius: CGFloat {
+extension CardStyle {
+    fileprivate var cornerRadius: CGFloat {
         switch self {
         case .golden:
             return 16
@@ -42,7 +42,7 @@ extension View {
     VStack {
         Spacer()
         Button {
-        } label: { 
+        } label: {
             VStack {
                 Text("hello world")
                     .padding()

--- a/Nos/Views/Components/Button/CircularFollowButton.swift
+++ b/Nos/Views/Components/Button/CircularFollowButton.swift
@@ -54,7 +54,7 @@ struct CircularFollowButton: View {
                     )
                 if following {
                     Image.followingIcon
-                        .padding(.top, 3) // the icon file isn't square so we need to shift it down
+                        .padding(.top, 3)  // the icon file isn't square so we need to shift it down
                 } else {
                     Image.followIcon
                 }

--- a/Nos/Views/Components/Button/FollowButton.swift
+++ b/Nos/Views/Components/Button/FollowButton.swift
@@ -1,6 +1,6 @@
-import SwiftUI
-import Dependencies
 import CoreData
+import Dependencies
+import SwiftUI
 
 struct FollowButton: View {
     @ObservedObject var currentUserAuthor: Author
@@ -15,7 +15,7 @@ struct FollowButton: View {
     @Environment(CurrentUser.self) private var currentUser
     @Dependency(\.analytics) private var analytics
     @Dependency(\.crashReporting) private var crashReporting
-    
+
     /// Returns an icon associated to the follow or unfollow state.
     private func image(for following: Bool) -> Image? {
         guard shouldDisplayIcon else {
@@ -23,7 +23,7 @@ struct FollowButton: View {
         }
         return following ? Image.slimFollowingIcon : Image.slimFollowIcon
     }
-    
+
     var body: some View {
         let following = currentUser.isFollowing(author: author)
         ActionButton(
@@ -48,28 +48,28 @@ struct FollowButton: View {
 }
 
 struct FollowButton_Previews: PreviewProvider {
-    
+
     static var previewData = PreviewData()
     static var persistenceController = PersistenceController.preview
-    
+
     static var previewContext = {
         let context = persistenceController.viewContext
         return context
     }()
-    
+
     static var user: Author {
         let author = Author(context: previewContext)
         author.hexadecimalPublicKey = KeyFixture.pubKeyHex
         return author
     }
-    
+
     static var alice: Author = {
         let author = Author(context: previewContext)
         author.hexadecimalPublicKey = KeyFixture.alice.publicKeyHex
         author.name = "Alice"
         return author
     }()
-    
+
     static func createTestData(in context: NSManagedObjectContext) {
         let follow = Follow(context: previewContext)
         follow.source = user
@@ -77,7 +77,7 @@ struct FollowButton_Previews: PreviewProvider {
         user.follows = Set([follow])
         try? previewContext.save()
     }
-    
+
     static var previews: some View {
         VStack(spacing: 10) {
             FollowButton(currentUserAuthor: user, author: alice)

--- a/Nos/Views/Components/Button/LikeButton.swift
+++ b/Nos/Views/Components/Button/LikeButton.swift
@@ -3,7 +3,7 @@ import Logger
 import SwiftUI
 
 struct LikeButton: View {
-    
+
     var note: Event
 
     /// Indicates whether the number of likes is displayed.
@@ -35,7 +35,7 @@ struct LikeButton: View {
             _likes = FetchRequest(fetchRequest: Event.emptyRequest())
         }
     }
-    
+
     var likeCount: Int {
         likes
             .compactMap { $0.eventReferences.lastObject as? EventReference }
@@ -43,7 +43,7 @@ struct LikeButton: View {
             .filter { $0 == note.identifier }
             .count
     }
-      
+
     var currentUserLikesNote: Bool {
         likes
             .filter {
@@ -52,7 +52,7 @@ struct LikeButton: View {
             .compactMap { $0.eventReferences.lastObject as? EventReference }
             .contains(where: { $0.eventId == note.identifier })
     }
-    
+
     var buttonLabel: some View {
         HStack {
             if currentUserLikesNote || isLiked {
@@ -69,7 +69,7 @@ struct LikeButton: View {
         .padding(.horizontal, 10)
         .padding(.vertical, 12)
     }
-    
+
     var body: some View {
         Button {
             Task {
@@ -77,7 +77,7 @@ struct LikeButton: View {
             }
         } label: {
             buttonLabel
-        }                             
+        }
         .disabled(isPublishing)
     }
 

--- a/Nos/Views/Components/Button/NoteButton.swift
+++ b/Nos/Views/Components/Button/NoteButton.swift
@@ -1,7 +1,7 @@
-import Foundation
-import SwiftUI
 import CoreData
 import Dependencies
+import Foundation
+import SwiftUI
 
 /// This view displays the a button with the information we have for a note suitable for being used in a list
 /// or grid.
@@ -26,14 +26,14 @@ struct NoteButton: View {
 
     var displayRootMessage: Bool
     var isTapEnabled: Bool
-    
+
     private let replyAction: ((Event) -> Void)?
     private let tapAction: ((Event) -> Void)?
     @State private var relaySubscriptions = SubscriptionCancellables()
 
     @EnvironmentObject private var relayService: RelayService
     @EnvironmentObject private var router: Router
-    
+
     /// Initializes a NoteButton object.
     ///
     /// - Parameter note: Note event to display.
@@ -55,10 +55,10 @@ struct NoteButton: View {
     /// - Parameter tapAction: Handler that get called when the user taps on the button. If
     /// `nil`, it navigates to RepliesView. Defaults to `nil`.
     init(
-        note: Event, 
-        style: CardStyle = CardStyle.compact, 
-        shouldTruncate: Bool = true, 
-        hideOutOfNetwork: Bool = true, 
+        note: Event,
+        style: CardStyle = CardStyle.compact,
+        shouldTruncate: Bool = true,
+        hideOutOfNetwork: Bool = true,
         repliesDisplayType: RepliesDisplayType = .displayNothing,
         showsLikeCount: Bool = true,
         showsRepostCount: Bool = true,
@@ -85,7 +85,8 @@ struct NoteButton: View {
     /// The note displayed in the note card. Could be different from `note` i.e. in the case of a repost.
     var displayedNote: Event {
         if note.kind == EventKind.repost.rawValue,
-            let repostedNote = note.repostedNote() {
+            let repostedNote = note.repostedNote()
+        {
             return repostedNote
         } else {
             return note
@@ -95,25 +96,27 @@ struct NoteButton: View {
     var body: some View {
         VStack {
             if note.kind == EventKind.repost.rawValue, let author = note.author {
-                Button(action: { 
-                    router.push(author)
-                }, label: { 
-                    HStack(alignment: .center) {
-                        AuthorLabel(author: author)
-                        Image.repostSymbol
-                        if let elapsedTime = note.createdAt?.distanceString() {
-                            Text(elapsedTime)
-                                .lineLimit(1)
-                                .font(.clarity(.medium))
-                                .foregroundColor(.secondaryTxt)
+                Button(
+                    action: {
+                        router.push(author)
+                    },
+                    label: {
+                        HStack(alignment: .center) {
+                            AuthorLabel(author: author)
+                            Image.repostSymbol
+                            if let elapsedTime = note.createdAt?.distanceString() {
+                                Text(elapsedTime)
+                                    .lineLimit(1)
+                                    .font(.clarity(.medium))
+                                    .foregroundColor(.secondaryTxt)
+                            }
+                            Spacer()
                         }
-                        Spacer()
-                    }
-                    .padding(.horizontal)
-                    .readabilityPadding()
-                })
+                        .padding(.horizontal)
+                        .readabilityPadding()
+                    })
             }
-            
+
             let buttonLabel = NoteCard(
                 note: displayedNote,
                 style: style,
@@ -151,17 +154,19 @@ struct NoteButton: View {
 
             switch style {
             case .compact:
-                let compactButtonOrLabel = buttonOrLabel
+                let compactButtonOrLabel =
+                    buttonOrLabel
                     .fixedSize(horizontal: false, vertical: true)
                     .padding(.horizontal)
                     .readabilityPadding()
-                
-                if displayRootMessage, 
+
+                if displayRootMessage,
                     note.kind != EventKind.repost.rawValue,
-                    let root = note.rootNote() ?? note.referencedNote() {
-                    
+                    let root = note.rootNote() ?? note.referencedNote()
+                {
+
                     ThreadRootView(
-                        root: root, 
+                        root: root,
                         isRootNoteInteractive: !note.isPreview,
                         tapAction: { root in router.push(root) },
                         reply: { compactButtonOrLabel }
@@ -205,7 +210,7 @@ struct NoteButton: View {
 }
 
 struct NoteButton_Previews: PreviewProvider {
-    
+
     static var previewData = PreviewData()
     static var previews: some View {
         ScrollView {

--- a/Nos/Views/Components/Button/NoteOptionsButton.swift
+++ b/Nos/Views/Components/Button/NoteOptionsButton.swift
@@ -1,13 +1,13 @@
+import Dependencies
 import Foundation
 import SwiftUI
-import Dependencies
 
 struct NoteOptionsButton: View {
     @Environment(CurrentUser.self) private var currentUser
-    
+
     @Dependency(\.analytics) private var analytics
     @Dependency(\.persistenceController) private var persistenceController
-    
+
     @ObservedObject var note: Event
 
     @State private var showingOptions = false
@@ -77,9 +77,12 @@ struct NoteOptionsButton: View {
             )
             .sheet(isPresented: $showingSource) {
                 NavigationView {
-                    RawEventView(viewModel: RawEventController(note: note, dismissHandler: {
-                        showingSource = false
-                    }))
+                    RawEventView(
+                        viewModel: RawEventController(
+                            note: note,
+                            dismissHandler: {
+                                showingSource = false
+                            }))
                 }
             }
             .sheet(isPresented: $showingShare) {
@@ -90,22 +93,22 @@ struct NoteOptionsButton: View {
             }
         }
     }
-    
+
     func copyMessageIdentifier() {
         UIPasteboard.general.string = note.bech32NoteID
     }
-    
+
     func copyMessage() {
         Task {
             // TODO: put links back in
             let attrString = await Event.attributedContent(
-                noteID: note.identifier, 
+                noteID: note.identifier,
                 context: persistenceController.viewContext
-            ) 
+            )
             UIPasteboard.general.string = String(attrString.characters)
         }
     }
-    
+
     func deletePost() async {
         if let identifier = note.identifier {
             await currentUser.publishDelete(for: [identifier])
@@ -118,13 +121,13 @@ struct NoteOptionsButton_Previews: PreviewProvider {
     static var persistenceController = PersistenceController.preview
     static var previewContext = persistenceController.viewContext
     static var currentUser = previewData.currentUser
-    
+
     static var shortNote: Event {
         let note = Event(context: previewContext)
         note.content = "Hello, world!"
         return note
     }
-    
+
     static let note: Event = {
         var note = shortNote
         return note

--- a/Nos/Views/Components/Button/RelayPickerToolbarButton.swift
+++ b/Nos/Views/Components/Button/RelayPickerToolbarButton.swift
@@ -1,14 +1,14 @@
 import SwiftUI
 
 struct RelayPickerToolbarButton: ToolbarContent {
-    
+
     @Binding var selectedRelay: Relay?
     @Binding var isPresenting: Bool
     var defaultSelection: LocalizedStringResource
     var action: () -> Void
-    
+
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
-    
+
     var title: String {
         if let selectedRelay {
             return selectedRelay.host ?? String(localized: .localizable.error)
@@ -16,7 +16,7 @@ struct RelayPickerToolbarButton: ToolbarContent {
             return String(localized: defaultSelection)
         }
     }
-    
+
     var imageName: String {
         if isPresenting {
             return "chevron.up"
@@ -24,7 +24,7 @@ struct RelayPickerToolbarButton: ToolbarContent {
             return "chevron.down"
         }
     }
-    
+
     var disclosureIndicator: some View {
         Image(systemName: imageName)
             .font(.system(size: 10))
@@ -36,11 +36,11 @@ struct RelayPickerToolbarButton: ToolbarContent {
                     .frame(width: 25, height: 25)
             )
     }
-    
+
     var maxWidth: CGFloat {
         horizontalSizeClass == .regular ? 400 : 190
     }
-    
+
     var body: some ToolbarContent {
         ToolbarItem(placement: .principal) {
             HStack {
@@ -65,7 +65,7 @@ struct RelayPickerToolbarButton: ToolbarContent {
 }
 
 struct RelayPickerToolbarButton_Previews: PreviewProvider {
-    
+
     static var previews: some View {
         StatefulPreviewContainer(false) { isPresented in
             StatefulPreviewContainer(nil as Relay?) { selectedRelay in
@@ -75,17 +75,17 @@ struct RelayPickerToolbarButton_Previews: PreviewProvider {
                     }
                     .background(Color.appBg)
                     .toolbar {
-                        
+
                         ToolbarItem(placement: .navigationBarLeading) {
-                            Button {}
-                            label: {
+                            Button {
+                            } label: {
                                 Text(.localizable.cancel)
                                     .foregroundColor(.secondaryTxt)
                             }
                         }
                         RelayPickerToolbarButton(
-                            selectedRelay: selectedRelay, 
-                            isPresenting: isPresented, 
+                            selectedRelay: selectedRelay,
+                            isPresenting: isPresented,
                             defaultSelection: .localizable.allMyRelays
                         ) {}
                         ToolbarItem(placement: .navigationBarTrailing) {

--- a/Nos/Views/Components/Button/ReplyButton.swift
+++ b/Nos/Views/Components/Button/ReplyButton.swift
@@ -5,19 +5,21 @@ struct ReplyButton: View {
     var replyAction: ((Event) -> Void)?
 
     @EnvironmentObject private var router: Router
-    
+
     var body: some View {
-        Button(action: {
-            if let replyAction {
-                replyAction(note)
-            } else {
-                router.push(.replyTo(note.identifier))
-            }
-        }, label: {
-            Image.buttonReply
-                .padding(.leading, 10)
-                .padding(.trailing, 23)
-                .padding(.vertical, 12)
-        })
+        Button(
+            action: {
+                if let replyAction {
+                    replyAction(note)
+                } else {
+                    router.push(.replyTo(note.identifier))
+                }
+            },
+            label: {
+                Image.buttonReply
+                    .padding(.leading, 10)
+                    .padding(.trailing, 23)
+                    .padding(.vertical, 12)
+            })
     }
 }

--- a/Nos/Views/Components/Button/SideMenuButton.swift
+++ b/Nos/Views/Components/Button/SideMenuButton.swift
@@ -1,9 +1,9 @@
 import SwiftUI
 
 struct SideMenuButton: View {
-    
+
     @EnvironmentObject private var router: Router
-    
+
     var body: some View {
         Button {
             router.toggleSideMenu()

--- a/Nos/Views/Components/Event/EventObservationView.swift
+++ b/Nos/Views/Components/Event/EventObservationView.swift
@@ -3,13 +3,13 @@ import SwiftUI
 /// A view that observes changes to an `Event` with the given `RawEventID` and continually passes the newest version to
 /// a child view. Useful for hosting views that just take an `Event` but want to observe changes to the event.
 struct EventObservationView<Content: View>: View {
-    
+
     /// A view building function that will be given the latest version of the `Event`.
     let contentBuilder: (Event) -> Content
-    
+
     /// A fetch request that will trigger a view update when the `Event` changes.
     @FetchRequest private var events: FetchedResults<Event>
-    
+
     init(eventID: RawEventID?, contentBuilder: @escaping (Event) -> Content) {
         if let eventID {
             _events = FetchRequest(fetchRequest: Event.event(by: eventID))

--- a/Nos/Views/Components/Event/RawEventView.swift
+++ b/Nos/Views/Components/Event/RawEventView.swift
@@ -47,7 +47,7 @@ struct RawEventView<ViewModel>: View where ViewModel: RawEventViewModel {
         attributed.mergeAttributes(container)
         return attributed
     }
-    
+
     var body: some View {
         ScrollView {
             if let source = viewModel.rawMessage {
@@ -82,7 +82,7 @@ struct RawEventView<ViewModel>: View where ViewModel: RawEventViewModel {
     }
 }
 
-fileprivate class PreviewViewModel: RawEventViewModel {
+private class PreviewViewModel: RawEventViewModel {
 
     @Published var rawMessage: String?
 
@@ -102,28 +102,28 @@ fileprivate class PreviewViewModel: RawEventViewModel {
 struct RawMessageView_Previews: PreviewProvider {
     // swiftlint:disable line_length
     static let source = """
-    {
-        "key": "%6Ic4dzY/mBxVXdSNwSIyQ1TqBp+FKsY+tLnumBPdxaA=.sha256",
-        "value": {
-            "previous": "%d8Iyl2ZVHwdyiAAeIvbDCVXVeLXPYajI7IRHgC0/rf4=.sha256",
-            "author": "@8Y7zrkRdt1HxkueXjdwIU4fbYkjapDztCHgjNjiCn/M=.ed25519",
-            "sequence": 31,
-            "timestamp": 1549386935492,
-            "hash": "sha256",
-            "content": {
-                "type": "vote",
-                "channel": "ssb-server",
-                "vote": {
-                    "link": "%OoBqCtaYm6ayBQqCVlHi66vsWfvaK5+t98aqsXlRyZU=.sha256",
-                    "value": 1,
-                    "expression": "Like"
-                }
+        {
+            "key": "%6Ic4dzY/mBxVXdSNwSIyQ1TqBp+FKsY+tLnumBPdxaA=.sha256",
+            "value": {
+                "previous": "%d8Iyl2ZVHwdyiAAeIvbDCVXVeLXPYajI7IRHgC0/rf4=.sha256",
+                "author": "@8Y7zrkRdt1HxkueXjdwIU4fbYkjapDztCHgjNjiCn/M=.ed25519",
+                "sequence": 31,
+                "timestamp": 1549386935492,
+                "hash": "sha256",
+                "content": {
+                    "type": "vote",
+                    "channel": "ssb-server",
+                    "vote": {
+                        "link": "%OoBqCtaYm6ayBQqCVlHi66vsWfvaK5+t98aqsXlRyZU=.sha256",
+                        "value": 1,
+                        "expression": "Like"
+                    }
+                },
+                "signature": "8caUJ2gqJ4DOnfD2gDFpyWbseUeNMhzX/tr8j2IR7xSG3GcyDG8GCAyrv7YkOTu2PnEM6fdLb1jNrit+YVYlDg==.sig.ed25519"
             },
-            "signature": "8caUJ2gqJ4DOnfD2gDFpyWbseUeNMhzX/tr8j2IR7xSG3GcyDG8GCAyrv7YkOTu2PnEM6fdLb1jNrit+YVYlDg==.sig.ed25519"
-        },
-        "timestamp": 1546962907954.0059
-    }
-    """
+            "timestamp": 1546962907954.0059
+        }
+        """
     // swiftlint:enable line_length
 
     static var previews: some View {

--- a/Nos/Views/Components/FlagOptionPicker.swift
+++ b/Nos/Views/Components/FlagOptionPicker.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+
 /// Displays a list of selectable flag options
 struct FlagOptionPicker: View {
     /// The previous selection made by the user, used for displaying information related to changes in selection.
@@ -48,7 +49,7 @@ struct FlagOptionPicker: View {
             ForEach(options) { flag in
                 FlagPickerRow(
                     flag: flag,
-                    selection: $currentSelection, 
+                    selection: $currentSelection,
                     previousSelection: $previousSelection
                 )
                 BeveledSeparator()
@@ -79,11 +80,14 @@ private struct FlagPickerRow: View {
     }
 
     var body: some View {
-        Button(action: {
-            selection = flag
-        }, label: {
-            buttonLabel
-        })
+        Button(
+            action: {
+                selection = flag
+            },
+            label: {
+                buttonLabel
+            }
+        )
         .padding(14)
     }
 
@@ -122,7 +126,7 @@ private struct FlagPickerRow: View {
                         .font(.footnote)
                         .lineSpacing(8)
                         .multilineTextAlignment(.leading)
-                        .fixedSize(horizontal: false, vertical: true) // this enables the text view expand as needed
+                        .fixedSize(horizontal: false, vertical: true)  // this enables the text view expand as needed
                 }
             }
             Spacer()
@@ -143,13 +147,15 @@ private struct FlagPickerRow: View {
                     .foregroundColor(.primaryTxt)
                     .font(.subheadline)
                     .multilineTextAlignment(.leading)
-                    .padding(EdgeInsets(
-                        top: 13,
-                        leading: 12,
-                        bottom: 18,
-                        trailing: 13
-                    ))
-                .lineSpacing(8)
+                    .padding(
+                        EdgeInsets(
+                            top: 13,
+                            leading: 12,
+                            bottom: 18,
+                            trailing: 13
+                        )
+                    )
+                    .lineSpacing(8)
 
                 Spacer()
             }
@@ -179,7 +185,7 @@ private struct HeaderView: View {
 
         var body: some View {
             FlagOptionPicker(
-                previousSelection: $selectedFlag, 
+                previousSelection: $selectedFlag,
                 currentSelection: $selectedFlag,
                 options: flagCategories,
                 title: "Create a tag for this content that other people in your network can see.",

--- a/Nos/Views/Components/Form/NosForm.swift
+++ b/Nos/Views/Components/Form/NosForm.swift
@@ -2,13 +2,13 @@ import SwiftUI
 import SwiftUINavigation
 
 struct NosForm<Content: View>: View {
-    
+
     let content: Content
-    
+
     init(@ViewBuilder builder: () -> Content) {
         self.content = builder()
     }
-    
+
     var body: some View {
         VStack {
             ScrollView {
@@ -28,7 +28,7 @@ struct NosForm_Previews: PreviewProvider {
                 WithState(initialValue: "Alice") { text in
                     NosTextField(label: .localizable.url, text: text)
                 }
-            }   
-        }    
+            }
+        }
     }
 }

--- a/Nos/Views/Components/Form/NosFormField.swift
+++ b/Nos/Views/Components/Form/NosFormField.swift
@@ -14,7 +14,7 @@ struct NosFormField<Control: View>: View {
         self.label = label
         self.control = builder()
     }
-    
+
     var body: some View {
         VStack {
             HStack {
@@ -23,7 +23,7 @@ struct NosFormField<Control: View>: View {
                     .font(.clarity(.medium, textStyle: .subheadline))
                 Spacer()
             }
-            
+
             control
                 .accessibilityLabel(String(localized: label))
                 .focused($focus)

--- a/Nos/Views/Components/Form/NosFormSection.swift
+++ b/Nos/Views/Components/Form/NosFormSection.swift
@@ -2,15 +2,15 @@ import SwiftUI
 import SwiftUINavigation
 
 struct NosFormSection<Content: View>: View {
-    
+
     var label: LocalizedStringResource?
     let content: Content
-    
+
     init(label: LocalizedStringResource? = nil, @ViewBuilder builder: () -> Content) {
         self.label = label
         self.content = builder()
     }
-    
+
     var body: some View {
         VStack {
             if let label {
@@ -19,11 +19,11 @@ struct NosFormSection<Content: View>: View {
                         .font(.clarity(.semibold, textStyle: .headline))
                         .foregroundColor(.primaryTxt)
                         .padding(.top, 16)
-                    
+
                     Spacer()
                 }
             }
-            
+
             ZStack {
                 // 3d card effect
                 ZStack {
@@ -32,12 +32,12 @@ struct NosFormSection<Content: View>: View {
                 .cornerRadius(21)
                 .offset(y: 4.5)
                 .shadow(
-                    color: Color.lightShadow, 
-                    radius: 2, 
-                    x: 0, 
+                    color: Color.lightShadow,
+                    radius: 2,
+                    x: 0,
                     y: 0
                 )
-                
+
                 VStack {
                     content
                 }
@@ -56,7 +56,7 @@ struct NosFormSection_Previews: PreviewProvider {
                 WithState(initialValue: "Alice") { text in
                     NosTextField(label: .localizable.url, text: text)
                 }
-            }    
+            }
         }
     }
 }

--- a/Nos/Views/Components/Form/NosTextEditor.swift
+++ b/Nos/Views/Components/Form/NosTextEditor.swift
@@ -2,12 +2,12 @@ import SwiftUI
 import SwiftUINavigation
 
 struct NosTextEditor: View {
-    
+
     var label: LocalizedStringResource
     @Binding var text: String
-    
+
     var body: some View {
-        NosFormField(label: label) { 
+        NosFormField(label: label) {
             TextEditor(text: $text)
                 .textInputAutocapitalization(.none)
                 .foregroundColor(.primaryTxt)
@@ -24,7 +24,7 @@ struct NosTextEditor_Previews: PreviewProvider {
                     NosTextEditor(label: .localizable.bio, text: text)
                         .scrollContentBackground(.hidden)
                         .frame(maxHeight: 200)
-                }    
+                }
             }
         }
     }

--- a/Nos/Views/Components/Form/NosTextField.swift
+++ b/Nos/Views/Components/Form/NosTextField.swift
@@ -2,10 +2,10 @@ import SwiftUI
 import SwiftUINavigation
 
 struct NosTextField: View {
-    
+
     var label: LocalizedStringResource
     @Binding var text: String
-    
+
     var body: some View {
         NosFormField(label: label) {
             TextField("", text: $text)
@@ -22,8 +22,8 @@ struct NosTextField_Previews: PreviewProvider {
             NosFormSection(label: .localizable.profilePicture) {
                 WithState(initialValue: "Alice") { text in
                     NosTextField(label: .localizable.url, text: text)
-                }    
-            }   
+                }
+            }
         }
     }
 }

--- a/Nos/Views/Components/FullscreenProgressView.swift
+++ b/Nos/Views/Components/FullscreenProgressView.swift
@@ -2,12 +2,12 @@ import SwiftUI
 import SwiftUINavigation
 
 struct FullscreenProgressView: View {
-    
-    @Binding var isPresented: Bool 
+
+    @Binding var isPresented: Bool
 
     var text: String?
     var hideAfter: DispatchTime?
-    
+
     var body: some View {
         VStack {
             Spacer()

--- a/Nos/Views/Components/GoldenPostView.swift
+++ b/Nos/Views/Components/GoldenPostView.swift
@@ -1,5 +1,5 @@
-import SwiftUI
 import Dependencies
+import SwiftUI
 
 let goldenRatio: CGFloat = 0.618
 
@@ -100,7 +100,7 @@ struct GoldenPostView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             imageView
-            
+
             VStack {
                 HStack {
                     if isTextOnly {
@@ -121,18 +121,18 @@ struct GoldenPostView: View {
 }
 
 struct GoldenPostView_Previews: PreviewProvider {
-    
+
     static var persistenceController = PersistenceController.preview
     static var previewContext = persistenceController.viewContext
-    
+
     static var shortNote: Event {
         let note = Event(context: previewContext)
         note.content = "Hello, world!"
         return note
     }
-    
+
     static var previewAuthor = Author(context: previewContext)
-    
+
     static var longNote: Event {
         let note = Event(context: previewContext)
         note.content = .loremIpsum(5)
@@ -143,29 +143,31 @@ struct GoldenPostView_Previews: PreviewProvider {
         note.author?.profilePhotoURL = URL(string: "https://avatars.githubusercontent.com/u/1165004?s=40&v=4")
         return note
     }
-    
+
     static var imageNote: Event {
         let note = Event(context: previewContext)
         note.content = "Hello, world!https://cdn.ymaws.com/nacfm.com/resource/resmgr/images/blog_photos/footprints.jpg"
         return note
     }
-    
+
     static var verticalImageNote: Event {
         let note = Event(context: previewContext)
         // swiftlint:disable line_length
-        note.content = "Hello, world!https://nostr.build/i/nostr.build_1b958a2af7a2c3fcb2758dd5743912e697ba34d3a6199bfb1300fa6be1dc62ee.jpeg"
+        note.content =
+            "Hello, world!https://nostr.build/i/nostr.build_1b958a2af7a2c3fcb2758dd5743912e697ba34d3a6199bfb1300fa6be1dc62ee.jpeg"
         // swiftlint:enable line_length
         return note
     }
-    
+
     static var veryWideImageNote: Event {
         let note = Event(context: previewContext)
         // swiftlint:disable line_length
-        note.content = "Hello, world! https://nostr.build/i/nostr.build_db8287dde9aedbc65df59972386fde14edf9e1afc210e80c764706e61cd1cdfa.png"
+        note.content =
+            "Hello, world! https://nostr.build/i/nostr.build_db8287dde9aedbc65df59972386fde14edf9e1afc210e80c764706e61cd1cdfa.png"
         // swiftlint:enable line_length
         return note
     }
-    
+
     static var previews: some View {
         Group {
             LazyVGrid(columns: [GridItem(.flexible(), spacing: 10), GridItem(.flexible())], spacing: 10) {

--- a/Nos/Views/Components/GridPattern.swift
+++ b/Nos/Views/Components/GridPattern.swift
@@ -6,18 +6,18 @@ struct GridPattern: View {
         GeometryReader { geometry in
             let rowHeight = 50
             let columnWidth = 50
-            
+
             let rows = Int(geometry.size.height / CGFloat(rowHeight))
             let columns = Int(geometry.size.width / CGFloat(columnWidth))
-            
+
             let rowIndices = Array(0..<rows)
             let columnIndices = Array(0..<columns)
-            
+
             ZStack {
                 ForEach(rowIndices, id: \.self) { row in
                     ForEach(columnIndices, id: \.self) { column in
                         Rectangle()
-                            .fill((row + column).isMultiple(of: 2) ? Color.gray : Color.white) 
+                            .fill((row + column).isMultiple(of: 2) ? Color.gray : Color.white)
                             .frame(width: CGFloat(columnWidth), height: CGFloat(rowHeight))
                             .offset(x: CGFloat(column) * CGFloat(columnWidth), y: CGFloat(row) * CGFloat(rowHeight))
                     }

--- a/Nos/Views/Components/HighlightedText.swift
+++ b/Nos/Views/Components/HighlightedText.swift
@@ -1,25 +1,25 @@
-import SwiftUI
 import Logger
+import SwiftUI
 
 /// A block of markdown text that optionally highlights one word with a gradient and tappable link.
 struct HighlightedText: View {
-    
+
     /// The full text that should be displayed.
     let text: String
-    
+
     /// The word that should be highlighted, if any. Must be a substring of `text`.
     let highlightedWord: String?
-    
+
     /// The gradient that will be used to highlight the word.
     let highlightGradient: LinearGradient
-    
+
     let foregroundColor: Color
-    
+
     let font: Font
-    
+
     /// A link that the highlighted word will open if tapped. Optional.
     let link: URL?
-    
+
     /// A model for the segments of the string. `HightlightedText` is built by appending several `Text` views together,
     /// and each `Segment` will eventually be rendered as `Text`
     private enum Segment {
@@ -27,10 +27,10 @@ struct HighlightedText: View {
         case highlighted(String)
         case space
     }
-    
+
     /// An array of segments of text, along with a bool specifying if they should be highlighted.
     private var segments: [Segment]
-    
+
     /// Creates a `HighlightedText`.
     /// - Parameters:
     ///   - text: The full text that should be displayed.
@@ -54,7 +54,7 @@ struct HighlightedText: View {
             link: link
         )
     }
-    
+
     /// Creates a `HighlightedText`.
     /// - Parameters:
     ///   - text: The full text that should be displayed.
@@ -75,31 +75,32 @@ struct HighlightedText: View {
         self.foregroundColor = textColor
         self.font = font
         self.link = link
-        
+
         // If we have a highlighted word we break it up into segments.
         if let highlightedWord = highlightedWord,
-            let rangeOfHighlightedWord = text.ranges(of: highlightedWord).first {
+            let rangeOfHighlightedWord = text.ranges(of: highlightedWord).first
+        {
             segments = []
             let beforeHighlightedWord = String(text[..<rangeOfHighlightedWord.lowerBound])
             if !beforeHighlightedWord.isEmpty {
                 segments.append(.body(beforeHighlightedWord))
-                
+
                 // Add spaces back because markdown parsing strips them
                 if beforeHighlightedWord.suffix(1) == " " {
                     segments.append(.space)
                 }
             }
-            
+
             segments.append(.highlighted(highlightedWord))
-            
+
             let afterHighlightedWord = String(text[rangeOfHighlightedWord.upperBound...])
             if !afterHighlightedWord.isEmpty {
-                
+
                 // Add spaces back because markdown parsing strips them
                 if afterHighlightedWord.prefix(1) == " " {
                     segments.append(.space)
                 }
-                
+
                 segments.append(.body(String(afterHighlightedWord)))
             }
         } else {
@@ -107,7 +108,7 @@ struct HighlightedText: View {
             segments = [.body(text)]
         }
     }
-    
+
     /// A layer that has the body text colored in, but the highlighted word is clear.
     private var bodyText: Text {
         buildTextFromSegments(
@@ -120,7 +121,7 @@ struct HighlightedText: View {
             }
         )
     }
-    
+
     /// A layer that has the body text clear, and the highlighted word colored with `highlightGradient`.
     private var highlightedText: some View {
         buildTextFromSegments(
@@ -134,7 +135,7 @@ struct HighlightedText: View {
         )
         .foregroundLinearGradient(highlightGradient)
     }
-    
+
     /// A layer that has all text clear, but has a tap target where the highlighted word is, which is used to open
     /// the `link`. This is necessary because the gradient overlay interferes with SwiftUI's tap gesture recognizer,
     /// so we can't just add the link in the `highlightedText` layer.
@@ -157,7 +158,7 @@ struct HighlightedText: View {
         )
         .tint(.clear)
     }
-    
+
     /// This function iterates through a list of segments and builds a single `Text` view from them.
     /// - Parameters:
     ///   - segments: the list of segments that will be iterated through.
@@ -184,7 +185,7 @@ struct HighlightedText: View {
         }
         return textView
     }
-    
+
     /// Convenience function to make a `Text` from raw markdown and fail gracefully.
     private func textView(markdown: String) -> Text {
         var attributedString: AttributedString
@@ -196,7 +197,7 @@ struct HighlightedText: View {
         }
         return Text(attributedString).font(font)
     }
-    
+
     var body: some View {
         // Note: gradient here is too wide. Need to restrict it to just the word "Discover"
         ZStack {

--- a/Nos/Views/Components/KnownFollowersView.swift
+++ b/Nos/Views/Components/KnownFollowersView.swift
@@ -2,14 +2,14 @@ import Foundation
 import SwiftUI
 
 /// Shows a list of followers of the given author that the logged in user might know. This helps the user avoid
-/// impersonation attacks by making sure they choose the right person to follow, mention, message, etc. 
+/// impersonation attacks by making sure they choose the right person to follow, mention, message, etc.
 struct KnownFollowersView: View {
-    
+
     @ObservedObject var author: Author
-    
+
     /// The authors that the `source` author follows who also follow the `author`
     @FetchRequest private var knownFollowers: FetchedResults<Author>
-    
+
     /// The authors that will be featured with profile pictures and names
     var displayedAuthors: ArraySlice<Author> {
         knownFollowers
@@ -17,18 +17,18 @@ struct KnownFollowersView: View {
             .filter { $0.profilePhotoURL != nil }
             .prefix(3)
     }
-    
+
     /// The avatars of the authors that will be featured with profile pictures and names
     var avatarURLs: [URL?] {
         displayedAuthors.compactMap { $0.profilePhotoURL }
     }
-    
+
     /// The text that will be displayed alongside the avatars listing some of the displayedAuthor's names
     var followText: Text {
         let stringResource: LocalizedStringResource
         let authors = self.displayedAuthors
         switch authors.count {
-        case 0: 
+        case 0:
             return Text("")
         case 1:
             guard let name = authors[safe: 0]?.safeName else {
@@ -37,13 +37,15 @@ struct KnownFollowersView: View {
             stringResource = LocalizedStringResource.localizable.followedByOne(name)
         case 2:
             guard let firstName = authors[safe: 0]?.safeName,
-                let secondName = authors[safe: 1]?.safeName else {
+                let secondName = authors[safe: 1]?.safeName
+            else {
                 return Text("")
             }
             stringResource = LocalizedStringResource.localizable.followedByTwo(firstName, secondName)
         default:
             guard let firstName = authors[safe: 0]?.safeName,
-                let secondName = authors[safe: 1]?.safeName else {
+                let secondName = authors[safe: 1]?.safeName
+            else {
                 return Text("")
             }
             stringResource = LocalizedStringResource.localizable.followedByTwoAndMore(
@@ -62,16 +64,16 @@ struct KnownFollowersView: View {
             )
         return Text(attributedString)
     }
-    
+
     init(source: Author?, destination: Author) {
         self.author = destination
         if let source {
             self._knownFollowers = FetchRequest(fetchRequest: source.knownFollowers(of: destination))
         } else {
             self._knownFollowers = FetchRequest(fetchRequest: Author.emptyRequest())
-        } 
+        }
     }
-    
+
     var body: some View {
         if knownFollowers.isEmpty == false {
             HStack {
@@ -95,7 +97,7 @@ struct KnownFollowersView: View {
 
 #Preview {
     var previewData = PreviewData()
-    
+
     return VStack {
         KnownFollowersView(source: previewData.currentUser.author, destination: previewData.alice)
         // should display nothing

--- a/Nos/Views/Components/Media/AspectRatioContainer.swift
+++ b/Nos/Views/Components/Media/AspectRatioContainer.swift
@@ -5,7 +5,7 @@ import SwiftUI
 struct AspectRatioContainer<Content: View>: View {
     /// The orientation, which determines the aspect ratio of this container.
     let orientation: MediaOrientation
-    
+
     /// The content to be displayed in the container.
     let content: () -> Content
 

--- a/Nos/Views/Components/Media/GalleryView.swift
+++ b/Nos/Views/Components/Media/GalleryView.swift
@@ -12,13 +12,13 @@ struct GalleryView: View {
 
     /// The currently-selected tab in the tab view.
     @State private var selectedTab = 0
-    
+
     /// The orientation for this gallery view.
     @State private var orientation: MediaOrientation?
-    
+
     /// The media service that loads content from URLs and determines the orientation for this gallery.
     @Dependency(\.mediaService) private var mediaService
-    
+
     /// The orientation determined by the `metadata`, if any.
     private var metadataOrientation: MediaOrientation? {
         metadata?[urls.first?.absoluteString]?.orientation
@@ -35,7 +35,7 @@ struct GalleryView: View {
             loadingView()
         }
     }
-    
+
     /// Produces a tab view with custom paging indicators in the given orientation.
     /// - Parameter orientation: The orientation to use for the gallery.
     /// - Returns: A gallery view in the given orientation.
@@ -71,7 +71,7 @@ struct GalleryView: View {
         }
         .padding(.bottom, 10)
     }
-    
+
     /// Produces a ``LinkView`` with the given URL in the given orientation.
     /// - Parameters:
     ///   - url: The URL to display in the ``LinkView``.
@@ -82,7 +82,7 @@ struct GalleryView: View {
             LinkView(url: url)
         }
     }
-    
+
     /// A loading view that determines the orientation for the gallery. When possible, the aspect ratio of the
     /// loading view matches the aspect ratio of the gallery. Otherwise, `landscape`.
     /// - Returns: A loading view in the aspect ratio that matches the gallery media when possible.
@@ -110,19 +110,19 @@ struct GalleryView: View {
 // Thanks for the [example](https://betterprogramming.pub/custom-paging-ui-in-swiftui-13f1347cf529) Alexandru Turcanu!
 
 /// Custom paging indicators for a `GalleryView`.
-fileprivate struct GalleryIndexView: View {
+private struct GalleryIndexView: View {
     /// The number of pages in the tab view.
     let numberOfPages: Int
 
     /// The currently-selected tab in the tab view.
     let currentIndex: Int
-    
+
     /// The size of the circle representing the currently-selected tab.
     private let circleSize: CGFloat = 8.0
 
     /// The space between circles.
     private let circleSpacing: CGFloat = 6.0
-    
+
     /// The fill style of the circle indicating which tab is selected.
     private let primaryFill = LinearGradient.horizontalAccent
 

--- a/Nos/Views/Components/Media/ImageButton.swift
+++ b/Nos/Views/Components/Media/ImageButton.swift
@@ -16,7 +16,7 @@ struct ImageButton: View {
 
     /// Whether the image is animating or not.
     @State private var isAnimating = false
-    
+
     /// Whether to show an error view or not.
     @State private var showError = false
 
@@ -83,7 +83,8 @@ struct ImageButton: View {
 #Preview("Animated WebP") {
     ImageButton(
         url: URL(
-            string: "https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExYWtidXM3bTc5bWRzMW15c2xma3ZodXhuOGYzcThzZzB1enh0Z2hhZCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/iemgeDQlYlgNZrZUoQ/giphy.webp" // swiftlint:disable:this line_length
+            string:
+                "https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExYWtidXM3bTc5bWRzMW15c2xma3ZodXhuOGYzcThzZzB1enh0Z2hhZCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/iemgeDQlYlgNZrZUoQ/giphy.webp"  // swiftlint:disable:this line_length
         )!
     )
 }

--- a/Nos/Views/Components/Media/LPLinkViewRepresentable.swift
+++ b/Nos/Views/Components/Media/LPLinkViewRepresentable.swift
@@ -1,12 +1,12 @@
-import SwiftUI
 import LinkPresentation
+import SwiftUI
 
 /// A view that displays an Open Graph Protocol preview of the given URL.
 struct LPLinkViewRepresentable: UIViewRepresentable {
-    
+
     /// The URL of the content to display.
     let url: URL
-    
+
     func makeUIView(context: Context) -> LPLinkView {
         let linkView = LPLinkView(url: url)
         linkView.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
@@ -14,7 +14,7 @@ struct LPLinkViewRepresentable: UIViewRepresentable {
         linkView.sizeToFit()
         return linkView
     }
-    
+
     func updateUIView(_ uiView: LPLinkView, context: Context) {
         let provider = LPMetadataProvider()
         provider.startFetchingMetadata(for: url) { metadata, error in

--- a/Nos/Views/Components/Media/SquareImage.swift
+++ b/Nos/Views/Components/Media/SquareImage.swift
@@ -1,11 +1,11 @@
-import SwiftUI
 import SDWebImageSwiftUI
+import SwiftUI
 
 struct SquareImage: View {
     var url: URL
-    
+
     var onTap: (() -> Void)?
-    
+
     var body: some View {
         Color.clear
             .aspectRatio(1, contentMode: .fit)

--- a/Nos/Views/Components/Media/ZoomableContainer.swift
+++ b/Nos/Views/Components/Media/ZoomableContainer.swift
@@ -27,7 +27,7 @@ struct ZoomableContainer<ContainerContent: View>: View {
     }
 }
 
-fileprivate struct ZoomableScrollView<ScrollViewContent: View>: UIViewRepresentable {
+private struct ZoomableScrollView<ScrollViewContent: View>: UIViewRepresentable {
     private var content: ScrollViewContent
     private let maxAllowedScale: CGFloat
 
@@ -49,7 +49,7 @@ fileprivate struct ZoomableScrollView<ScrollViewContent: View>: UIViewRepresenta
     func makeUIView(context: Context) -> UIScrollView {
         // Setup the UIScrollView
         let scrollView = UIScrollView()
-        scrollView.delegate = context.coordinator // for viewForZooming(in:)
+        scrollView.delegate = context.coordinator  // for viewForZooming(in:)
         scrollView.maximumZoomScale = maxAllowedScale
         scrollView.minimumZoomScale = 1
         scrollView.bouncesZoom = true
@@ -76,9 +76,9 @@ fileprivate struct ZoomableScrollView<ScrollViewContent: View>: UIViewRepresenta
         // Update the hosting controller's SwiftUI content
         context.coordinator.hostingController.rootView = content
 
-        if uiView.zoomScale > uiView.minimumZoomScale { // Scale out
+        if uiView.zoomScale > uiView.minimumZoomScale {  // Scale out
             uiView.setZoomScale(currentScale, animated: true)
-        } else if tapLocation != .zero { // Scale in to a specific point
+        } else if tapLocation != .zero {  // Scale in to a specific point
             uiView.zoom(to: zoomRect(for: uiView, scale: uiView.maximumZoomScale, center: tapLocation), animated: true)
             // Reset the location to prevent scaling to it in case of a negative scale (manual pinch)
             // Use the main thread to prevent unexpected behavior

--- a/Nos/Views/Components/NosNavigationBar.swift
+++ b/Nos/Views/Components/NosNavigationBar.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct NosNavigationBarModifier: ViewModifier {
-    
+
     var title: AttributedString
 
     func body(content: Content) -> some View {

--- a/Nos/Views/Components/NosNavigationStack.swift
+++ b/Nos/Views/Components/NosNavigationStack.swift
@@ -3,49 +3,53 @@ import SwiftUI
 /// A `NavigationStack` that knows how to present views common to all the tabs like `Events` and `Authors`.
 /// Take care not to nest these.
 struct NosNavigationStack<Content: View>: View {
-    
+
     @Binding var path: NavigationPath
-    
+
     var content: () -> Content
-    
+
     var body: some View {
         NavigationStack(path: $path) {
             content()
-                .navigationDestination(for: NosNavigationDestination.self, destination: { destination in
-                    switch destination {
-                    case .note(let noteIdentifiable):
-                        if case let .identifier(eventID) = noteIdentifiable {
+                .navigationDestination(
+                    for: NosNavigationDestination.self,
+                    destination: { destination in
+                        switch destination {
+                        case .note(let noteIdentifiable):
+                            if case let .identifier(eventID) = noteIdentifiable {
+                                EventObservationView(eventID: eventID) { event in
+                                    NoteView(note: event)
+                                }
+                            } else if case let .replaceableIdentifier(replaceableEventID, author, kind) =
+                                noteIdentifiable
+                            {
+                                EventObservationView(
+                                    replaceableEventID: replaceableEventID,
+                                    author: author,
+                                    kind: kind
+                                ) { event in
+                                    NoteView(note: event)
+                                }
+                            }
+                        case .author(let authorID):
+                            AuthorObservationView(authorID: authorID) { author in
+                                ProfileView(author: author)
+                            }
+                        case .url(let url):
+                            URLView(url: url)
+                        case .replyTo(let eventID):
                             EventObservationView(eventID: eventID) { event in
-                                NoteView(note: event)
-                            }
-                        } else if case let .replaceableIdentifier(replaceableEventID, author, kind) = noteIdentifiable {
-                            EventObservationView(
-                                replaceableEventID: replaceableEventID,
-                                author: author,
-                                kind: kind
-                            ) { event in
-                                NoteView(note: event)
+                                NoteView(note: event, showKeyboard: true)
                             }
                         }
-                    case .author(let authorID):
-                        AuthorObservationView(authorID: authorID) { author in
-                            ProfileView(author: author)
-                        }
-                    case .url(let url):
-                        URLView(url: url) 
-                    case .replyTo(let eventID):
-                        EventObservationView(eventID: eventID) { event in
-                            NoteView(note: event, showKeyboard: true)
-                        }
-                    }
-                })
-        }            
+                    })
+        }
     }
 }
 
 #Preview {
     @State var path = NavigationPath()
-    
+
     return NosNavigationStack(path: $path) {
         Text("hello world")
     }

--- a/Nos/Views/Components/NosRadioButton.swift
+++ b/Nos/Views/Components/NosRadioButton.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+
 /// A  custom radio button.
 struct NosRadioButton: View {
     var isSelected: Bool
@@ -25,7 +26,7 @@ private struct RadioButtonBackground: View {
                     )
                 )
                 .frame(width: 25, height: 25)
-            // Inner shadow effect
+                // Inner shadow effect
                 .overlay(
                     Circle()
                         .fill(
@@ -38,10 +39,10 @@ private struct RadioButtonBackground: View {
                         .stroke(Color.radioButtonInnerDropShadow, lineWidth: 1)
                         .blur(radius: 1.67)
                         .offset(x: 0, y: 0.67)
-                        .mask(Circle()) // Ensures the inner shadow stays within the circle's shape
+                        .mask(Circle())  // Ensures the inner shadow stays within the circle's shape
                 )
 
-            // Outer shadow effect
+                // Outer shadow effect
                 .shadow(color: Color.radioButtonOuterDropShadow, radius: 0, x: 0, y: 0.99)
         }
     }

--- a/Nos/Views/Components/NosToggle.swift
+++ b/Nos/Views/Components/NosToggle.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+
 /// A toggle with the tint color set to green.
 struct NosToggle: View {
     @Binding var isOn: Bool
@@ -12,7 +13,7 @@ struct NosToggle: View {
                     .foregroundColor(.primaryTxt)
             }
         }
-        .tint(.green) // Fixes [#1251](https://github.com/planetary-social/nos/issues/1251)
+        .tint(.green)  // Fixes [#1251](https://github.com/planetary-social/nos/issues/1251)
     }
 }
 

--- a/Nos/Views/Components/NoteTextEditor.swift
+++ b/Nos/Views/Components/NoteTextEditor.swift
@@ -1,23 +1,23 @@
-import SwiftUI
 import Logger
+import SwiftUI
 
 /// A view similar to `TextEditor` for composing Nostr notes. Supports autocomplete of mentions.
 struct NoteTextEditor: View {
-    
+
     /// A controller for the entered text.
     @Binding private var controller: NoteEditorController
-    
+
     /// The smallest size of EditableNoteText
     var minHeight: CGFloat
-    
+
     var placeholder: LocalizedStringResource
-    
+
     init(controller: Binding<NoteEditorController>, minHeight: CGFloat, placeholder: LocalizedStringResource) {
         self._controller = controller
         self.minHeight = minHeight
         self.placeholder = placeholder
     }
-    
+
     var body: some View {
         NoteUITextViewRepresentable(
             controller: controller,
@@ -32,7 +32,7 @@ struct NoteTextEditor: View {
                 AuthorListView(isPresented: $controller.showMentionsAutocomplete) { [weak controller] author in
                     /// Guard against double presses
                     guard let controller, controller.showMentionsAutocomplete else { return }
-                    
+
                     controller.insertMention(of: author)
                     controller.showMentionsAutocomplete = false
                 }
@@ -42,11 +42,11 @@ struct NoteTextEditor: View {
 }
 
 #Preview {
-    
+
     var previewData = PreviewData()
     @State var controller = NoteEditorController()
     let placeholder: LocalizedStringResource = .localizable.newNotePlaceholder
-    
+
     return NavigationStack {
         NoteTextEditor(
             controller: $controller,
@@ -56,7 +56,7 @@ struct NoteTextEditor: View {
         Spacer()
     }
     .inject(previewData: previewData)
-    .onAppear { 
+    .onAppear {
         _ = previewData.alice
     }
 }

--- a/Nos/Views/Components/PagedNoteListView.swift
+++ b/Nos/Views/Components/PagedNoteListView.swift
@@ -1,14 +1,14 @@
-import SwiftUI
 import CoreData
 import Dependencies
 import Logger
+import SwiftUI
 
 /// The PagedNoteListView is designed to display an infinite list of notes in reverse-chronological order.
-/// It takes two filters: one to load events from our local database (Core Data) and one to load them from the 
+/// It takes two filters: one to load events from our local database (Core Data) and one to load them from the
 /// relays. As the user scrolls down we will keep adjusting the relay filter to get older events.
-/// 
+///
 /// Under the hood PagedNoteListView is using UICollectionView and NSFetchedResultsController. We leverage the
-/// UICollectionViewDataSourcePrefetching protocol to call Event.loadViewData() on events in advanced of them being 
+/// UICollectionViewDataSourcePrefetching protocol to call Event.loadViewData() on events in advanced of them being
 /// shown, which allows us to perform expensive tasks like downloading images, calculating attributed text, fetching
 /// author metadata and linked notes, etc. before the view is displayed.
 struct PagedNoteListView<Header: View, EmptyPlaceholder: View>: UIViewRepresentable {
@@ -19,18 +19,18 @@ struct PagedNoteListView<Header: View, EmptyPlaceholder: View>: UIViewRepresenta
     /// Allows us to refresh the PagedNoteListView from outside this view itself, such as with a separate button.
     @Binding var refreshController: RefreshController
 
-    /// A fetch request that specifies the events that should be shown. The events should be sorted in 
+    /// A fetch request that specifies the events that should be shown. The events should be sorted in
     /// reverse-chronological order and should match the events returned by `relayFilter`.
     let databaseFilter: NSFetchRequest<Event>
-    
+
     /// A Filter that specifies the events that should be shown. The Filter should not have `limit`, `since`, or `until`
     /// set as they will be overmanaged internally. The events downloaded by this filter should match the ones returned
-    /// by the `databaseFilter`. 
+    /// by the `databaseFilter`.
     let relayFilter: Filter
-    
+
     /// The relay to load data from. If `nil` then all the relays in the user's list will be used.
-    let relay: Relay? 
-    
+    let relay: Relay?
+
     /// The managed object context used to fetch events from Core Data.
     let managedObjectContext: NSManagedObjectContext
 
@@ -40,7 +40,7 @@ struct PagedNoteListView<Header: View, EmptyPlaceholder: View>: UIViewRepresenta
 
     /// A view that will be displayed as the collection view header.
     let header: () -> Header
-    
+
     /// A view that will be displayed below the header when no notes are being shown.
     let emptyPlaceholder: () -> EmptyPlaceholder
 
@@ -56,10 +56,10 @@ struct PagedNoteListView<Header: View, EmptyPlaceholder: View>: UIViewRepresenta
         collectionView.contentInset = .zero
         collectionView.layoutMargins = .zero
         let dataSource = context.coordinator.dataSource(
-            databaseFilter: databaseFilter, 
+            databaseFilter: databaseFilter,
             relayFilter: relayFilter,
             relay: relay,
-            collectionView: collectionView, 
+            collectionView: collectionView,
             managedObjectContext: self.managedObjectContext,
             header: header,
             emptyPlaceholder: emptyPlaceholder
@@ -69,8 +69,8 @@ struct PagedNoteListView<Header: View, EmptyPlaceholder: View>: UIViewRepresenta
 
         let refreshControl = UIRefreshControl()
         refreshControl.addTarget(
-            context.coordinator, 
-            action: #selector(Coordinator.refreshData(_:)), 
+            context.coordinator,
+            action: #selector(Coordinator.refreshData(_:)),
             for: .valueChanged
         )
         collectionView.refreshControl = refreshControl
@@ -83,7 +83,7 @@ struct PagedNoteListView<Header: View, EmptyPlaceholder: View>: UIViewRepresenta
 
         return collectionView
     }
-    
+
     func updateUIView(_ collectionView: UICollectionView, context: Context) {
         if let dataSource = collectionView.dataSource as? PagedNoteDataSource<Header, EmptyPlaceholder> {
             if relayFilter != dataSource.relayFilter || relay != dataSource.relay {
@@ -102,7 +102,7 @@ struct PagedNoteListView<Header: View, EmptyPlaceholder: View>: UIViewRepresenta
             }
         }
     }
-    
+
     static func dismantleUIView(_ uiView: UICollectionView, coordinator: Coordinator<Header, EmptyPlaceholder>) {
         tearDownObservers(coordinator: coordinator)
     }
@@ -120,7 +120,8 @@ struct PagedNoteListView<Header: View, EmptyPlaceholder: View>: UIViewRepresenta
         ) { [weak uiView] notification in
             // if the tab that's selected is the tab in which this `PagedNoteListView` is displayed, scroll to the top
             guard let selectedTab = notification.userInfo?["tab"] as? AppDestination,
-                selectedTab == tab else {
+                selectedTab == tab
+            else {
                 return
             }
             // scrolling to CGRect.zero does not work, so this seems to be the best we can do
@@ -149,33 +150,33 @@ struct PagedNoteListView<Header: View, EmptyPlaceholder: View>: UIViewRepresenta
         let section = NSCollectionLayoutSection(group: group)
         section.contentInsets = .zero
         section.interGroupSpacing = 16
-        
+
         let headerSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .estimated(300))
         let headerItem = NSCollectionLayoutBoundarySupplementaryItem(
-            layoutSize: headerSize, 
-            elementKind: UICollectionView.elementKindSectionHeader, 
+            layoutSize: headerSize,
+            elementKind: UICollectionView.elementKindSectionHeader,
             alignment: .top
         )
         headerItem.edgeSpacing = .none
-        
+
         let footerSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .estimated(300))
         let footerItem = NSCollectionLayoutBoundarySupplementaryItem(
-            layoutSize: footerSize, 
-            elementKind: UICollectionView.elementKindSectionFooter, 
+            layoutSize: footerSize,
+            elementKind: UICollectionView.elementKindSectionFooter,
             alignment: .bottom
         )
         headerItem.edgeSpacing = .none
-        
+
         section.boundarySupplementaryItems = [headerItem, footerItem]
-        
+
         return UICollectionViewCompositionalLayout(section: section)
     }
-    
+
     // swiftlint:disable generic_type_name
     /// The coordinator mainly holds a strong reference to the `dataSource` and proxies pull-to-refresh events.
     class Coordinator<CoordinatorHeader: View, CoordinatorEmptyPlaceholder: View> {
         // swiftlint:enable generic_type_name
-        
+
         /// Controls refresh actions. Used for setting the `lastRefreshDate` whenever the data is refreshed.
         let refreshController: RefreshController
 
@@ -200,15 +201,15 @@ struct PagedNoteListView<Header: View, EmptyPlaceholder: View>: UIViewRepresenta
             @ViewBuilder emptyPlaceholder: @escaping () -> CoordinatorEmptyPlaceholder
         ) -> PagedNoteDataSource<CoordinatorHeader, CoordinatorEmptyPlaceholder> {
             if let dataSource {
-                return dataSource 
+                return dataSource
             }
             self.collectionView = collectionView
 
             let dataSource = PagedNoteDataSource(
-                databaseFilter: databaseFilter, 
+                databaseFilter: databaseFilter,
                 relayFilter: relayFilter,
                 relay: relay,
-                collectionView: collectionView, 
+                collectionView: collectionView,
                 managedObjectContext: managedObjectContext,
                 header: header,
                 emptyPlaceholder: emptyPlaceholder
@@ -216,7 +217,7 @@ struct PagedNoteListView<Header: View, EmptyPlaceholder: View>: UIViewRepresenta
             self.dataSource = dataSource
             return dataSource
         }
-    
+
         @objc func refreshData(_ sender: Any) {
             DispatchQueue.main.async { [weak refreshController] in
                 refreshController?.lastRefreshDate = .now
@@ -244,7 +245,7 @@ extension Notification.Name {
     return PagedNoteListView(
         refreshController: $refreshController,
         databaseFilter: previewData.alice.allPostsRequest(onlyRootPosts: false),
-        relayFilter: Filter(), 
+        relayFilter: Filter(),
         relay: nil,
         managedObjectContext: previewData.previewContext,
         tab: .home,

--- a/Nos/Views/Components/PreviewContainer.swift
+++ b/Nos/Views/Components/PreviewContainer.swift
@@ -5,11 +5,11 @@ import SwiftUI
 struct StatefulPreviewContainer<Value, Content: View>: View {
     @State var value: Value
     var content: (Binding<Value>) -> Content
-    
+
     var body: some View {
         content($value)
     }
-    
+
     init(_ value: Value, content: @escaping (Binding<Value>) -> Content) {
         self._value = State(wrappedValue: value)
         self.content = content

--- a/Nos/Views/Components/RelayPicker.swift
+++ b/Nos/Views/Components/RelayPicker.swift
@@ -1,38 +1,38 @@
-import SwiftUI
 import CoreData
+import SwiftUI
 
 struct RelayPicker: View {
-    
+
     @Binding var selectedRelay: Relay?
     @Binding var isPresented: Bool
-    
+
     var defaultSelection: String
-    
+
     @FetchRequest var relays: FetchedResults<Relay>
-    
+
     init(selectedRelay: Binding<Relay?>, defaultSelection: String, author: Author, isPresented: Binding<Bool>) {
         self._selectedRelay = selectedRelay
         self.defaultSelection = defaultSelection
         _relays = FetchRequest(fetchRequest: Relay.relays(for: author))
         _isPresented = isPresented
     }
-    
+
     var body: some View {
         VStack(spacing: 0) {
-            
+
             let pickerRows = VStack(spacing: 0) {
                 // shadow effect at the top
                 Rectangle()
                     .frame(height: 1)
                     .foregroundStyle(.clear)
                     .shadow(radius: 15, y: 10)
-                
+
                 RelayPickerRow(string: defaultSelection, selection: $selectedRelay)
                 ForEach(relays) { relay in
-                    
+
                     BeveledSeparator()
                         .padding(.horizontal, 20)
-                    
+
                     RelayPickerRow(relay: relay, selection: $selectedRelay)
                         .fixedSize(horizontal: false, vertical: true)
                 }
@@ -42,9 +42,9 @@ struct RelayPicker: View {
                     .foregroundStyle(LinearGradient.cardBackground)
                     .cornerRadius(20, corners: [.bottomLeft, .bottomRight])
                     .shadow(radius: 15, y: 10)
-            ) 
+            )
             .readabilityPadding()
-            
+
             VStack(spacing: 0) {
                 ViewThatFits(in: .vertical) {
                     VStack {
@@ -52,7 +52,7 @@ struct RelayPicker: View {
                         Color.clear
                             .contentShape(Rectangle())
                             .frame(minHeight: 0)
-                            .onTapGesture { 
+                            .onTapGesture {
                                 withAnimation {
                                     isPresented = false
                                 }
@@ -66,26 +66,26 @@ struct RelayPicker: View {
         }
         .transition(.move(edge: .top))
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .zIndex(99) // Fixes dismissal animation
+        .zIndex(99)  // Fixes dismissal animation
     }
 }
 
 struct RelayPickerRow: View {
-    
+
     var relay: Relay?
     var defaultSelection: String?
     @Binding var selection: Relay?
-    
+
     internal init(relay: Relay? = nil, selection: Binding<Relay?>) {
         self.relay = relay
         self._selection = selection
     }
-    
+
     internal init(string: String, selection: Binding<Relay?>) {
         self.defaultSelection = string
         self._selection = selection
     }
-    
+
     var title: String {
         if let relay {
             return relay.host ?? String(localized: .localizable.error)
@@ -93,7 +93,7 @@ struct RelayPickerRow: View {
             return defaultSelection ?? String(localized: .localizable.error)
         }
     }
-    
+
     var isSelected: Bool {
         if let relay {
             return relay.objectID == selection?.objectID
@@ -101,7 +101,7 @@ struct RelayPickerRow: View {
             return selection == nil
         }
     }
-    
+
     var body: some View {
         Button {
             selection = relay
@@ -116,7 +116,7 @@ struct RelayPickerRow: View {
                             .shadow(radius: 4, y: 4)
                         Spacer()
                     }
-                    
+
                     if let description = relay?.relayDescription {
                         HStack {
                             Text(description)
@@ -148,7 +148,7 @@ struct RelayPickerRow: View {
 
     @State var selectedRelay: Relay?
     var previewData = PreviewData()
-    
+
     func createTestData() {
         let user = previewData.alice
         let addresses = ["wss://nostr.com", "wss://nos.social", "wss://alongdomainnametoseewhathappens.com"]
@@ -158,7 +158,7 @@ struct RelayPickerRow: View {
             relay?.addToAuthors(user)
         }
     }
-    
+
     return RelayPicker(
         selectedRelay: $selectedRelay,
         defaultSelection: String(localized: .localizable.allMyRelays),
@@ -174,7 +174,7 @@ struct RelayPickerRow: View {
 
     @State var selectedRelay: Relay?
     var previewData = PreviewData()
-    
+
     func createTestData() {
         let user = previewData.alice
         let addresses = Relay.allKnown
@@ -184,7 +184,7 @@ struct RelayPickerRow: View {
             relay?.addToAuthors(user)
         }
     }
-    
+
     return RelayPicker(
         selectedRelay: $selectedRelay,
         defaultSelection: String(localized: .localizable.allMyRelays),

--- a/Nos/Views/Components/SearchBar.swift
+++ b/Nos/Views/Components/SearchBar.swift
@@ -3,7 +3,7 @@ import SwiftUI
 struct SearchBar: View {
     @Binding var text: String
     var isSearching: FocusState<Bool>.Binding
-    
+
     var body: some View {
         HStack(spacing: 8) {
             HStack(spacing: 8) {
@@ -14,7 +14,7 @@ struct SearchBar: View {
                         .font(.clarity(.regular))
                         .foregroundColor(.primaryTxt)
                         .onTapGesture {
-                            isSearching.wrappedValue = true // Set focus to the search bar when tapped
+                            isSearching.wrappedValue = true  // Set focus to the search bar when tapped
                         }
                         .focused(isSearching)
                     Spacer()
@@ -23,15 +23,18 @@ struct SearchBar: View {
             }
             .background(Color.cardBgBottom)
             .cornerRadius(8)
-            
+
             if isSearching.wrappedValue {
-                Button(action: {
-                    text = "" // Clear the search text
-                    isSearching.wrappedValue = false // Remove focus from the search bar
-                }, label: {
-                    Text(.localizable.clear)
-                        .foregroundLinearGradient(.horizontalAccent)
-                })
+                Button(
+                    action: {
+                        text = ""  // Clear the search text
+                        isSearching.wrappedValue = false  // Remove focus from the search bar
+                    },
+                    label: {
+                        Text(.localizable.clear)
+                            .foregroundLinearGradient(.horizontalAccent)
+                    }
+                )
                 .transition(.move(edge: .trailing))
                 .animation(.spring(), value: isSearching.wrappedValue)
             }
@@ -41,32 +44,32 @@ struct SearchBar: View {
 }
 
 struct SearchBar_Previews: PreviewProvider {
-    
+
     @State static var emptyText: String = ""
     @State static var text: String = "Martin"
-    @FocusState static var isSearching: Bool 
-    
+    @FocusState static var isSearching: Bool
+
     static var previews: some View {
         Group {
             VStack {
                 SearchBar(text: $emptyText, isSearching: $isSearching)
-                ForEach(0..<5) { _ in 
+                ForEach(0..<5) { _ in
                     Text(String.loremIpsum(1))
                 }
             }
             .background(Color.appBg)
         }
-        
+
         Group {
             VStack {
                 SearchBar(text: $text, isSearching: $isSearching)
-                ForEach(0..<5) { _ in 
+                ForEach(0..<5) { _ in
                     Text(String.loremIpsum(1))
                 }
             }
             .background(Color.appBg)
             .onAppear {
-                isSearching = true // this doesn't work for some reason
+                isSearching = true  // this doesn't work for some reason
             }
         }
     }

--- a/Nos/Views/Components/ThreadRootView.swift
+++ b/Nos/Views/Components/ThreadRootView.swift
@@ -32,7 +32,7 @@ struct ThreadRootView<Reply: View>: View {
         self.tapAction = tapAction
         self.reply = reply()
     }
-    
+
     var body: some View {
         ZStack(alignment: .top) {
             NoteButton(
@@ -59,12 +59,12 @@ struct ThreadRootView<Reply: View>: View {
 
 struct ThreadRootView_Previews: PreviewProvider {
     static var previewData = PreviewData()
-    
+
     static var previews: some View {
         ScrollView {
             VStack {
                 ThreadRootView(
-                    root: previewData.longNote, 
+                    root: previewData.longNote,
                     tapAction: { _ in },
                     reply: {
                         NoteButton(

--- a/Nos/Views/Components/ThreadView.swift
+++ b/Nos/Views/Components/ThreadView.swift
@@ -1,24 +1,26 @@
 import SwiftUI
 
 struct ThreadView: View {
-    
+
     var root: Event
 
     var thread: [Event] = []
-    
+
     @EnvironmentObject private var router: Router
-    
+
     /// Takes a root `Event`, and an array of all replies to the parent note of this thread,
     /// and builds the longest possible thread from that array of all replies.
     init(root: Event, allReplies: [Event]) {
         self.root = root
-        
+
         var currentEvent: Event = root
         while true {
-            if let nextEvent = allReplies
+            if let nextEvent =
+                allReplies
                 .first(where: {
                     ($0.eventReferences.lastObject as? EventReference)?.eventId == currentEvent.identifier
-                }) {
+                })
+            {
                 thread.append(nextEvent)
                 currentEvent = nextEvent
             } else {
@@ -26,7 +28,7 @@ struct ThreadView: View {
             }
         }
     }
-    
+
     var body: some View {
         LazyVStack {
             NoteButton(
@@ -70,27 +72,27 @@ struct ThreadView_Previews: PreviewProvider {
     static var persistenceController = PersistenceController.preview
     static var previewContext = persistenceController.viewContext
     static var router = Router()
-    
+
     static var emptyPersistenceController = PersistenceController.empty
     static var emptyPreviewContext = emptyPersistenceController.viewContext
     static var emptyRelayService = previewData.relayService
     static var currentUser = previewData.currentUser
-    
+
     static var alice: Author = {
         let author = Author(context: previewContext)
         author.hexadecimalPublicKey = KeyFixture.alice.publicKeyHex
         author.name = "Alice"
         return author
     }()
-    
+
     static var bob: Author = {
         let author = Author(context: previewContext)
         author.hexadecimalPublicKey = KeyFixture.bob.publicKeyHex
         author.name = "Bob"
-        
+
         return author
     }()
-        
+
     static var rootNote: Event {
         let bobNote = Event(context: previewContext)
         bobNote.content = "Hello, world!"
@@ -105,14 +107,14 @@ struct ThreadView_Previews: PreviewProvider {
         }
         return bobNote
     }
-    
+
     static var replyNote: Event {
         let replyNote = Event(context: previewContext)
         replyNote.content = "Top of the morning to you, bob! This text should be truncated."
         replyNote.kind = 1
         replyNote.createdAt = .now
         replyNote.author = alice
-    
+
         let eventRef = EventReference(context: previewContext)
         eventRef.eventId = "root"
         eventRef.referencedEvent = rootNote
@@ -126,14 +128,14 @@ struct ThreadView_Previews: PreviewProvider {
         }
         return replyNote
     }
-    
+
     static var secondReply: Event {
         let replyNote = Event(context: previewContext)
         replyNote.content = "Top of the morning to you, bob! This text should be truncated."
         replyNote.kind = 1
         replyNote.createdAt = .now
         replyNote.author = alice
-    
+
         let eventRef = EventReference(context: previewContext)
         eventRef.eventId = "root"
         eventRef.referencedEvent = rootNote
@@ -147,7 +149,7 @@ struct ThreadView_Previews: PreviewProvider {
         }
         return replyNote
     }
-    
+
     static var previews: some View {
         ThreadView(root: rootNote, allReplies: [replyNote, secondReply])
             .environment(\.managedObjectContext, emptyPreviewContext)

--- a/Nos/Views/Components/WarningView.swift
+++ b/Nos/Views/Components/WarningView.swift
@@ -1,11 +1,11 @@
-import SwiftUI
 import Logger
+import SwiftUI
 
 /// A view that puts a note behind a content warning if appropriate.
 struct WarningView: View {
-    
+
     @Bindable var controller: NoteWarningController
-    
+
     var body: some View {
         if !controller.showWarning {
             EmptyView()
@@ -18,32 +18,35 @@ struct WarningView: View {
 }
 
 struct OutOfNetworkView: View {
-    
+
     @Bindable var controller: NoteWarningController
-    
+
     @State private var isTextBoxShown = false
     @State private var isOverlayHelpTextBoxShown = false
-    
+
     var body: some View {
         VStack(alignment: .leading) {
             HStack {
                 Spacer()
-                Button(action: {
-                    self.isOverlayHelpTextBoxShown.toggle()
-                }, label: {
-                    (isTextBoxShown ? Image.x : Image.info)
-                        .resizable()
-                        .frame(width: 24, height: 24)
-                })
+                Button(
+                    action: {
+                        self.isOverlayHelpTextBoxShown.toggle()
+                    },
+                    label: {
+                        (isTextBoxShown ? Image.x : Image.info)
+                            .resizable()
+                            .frame(width: 24, height: 24)
+                    }
+                )
                 .padding(.trailing, 24)
             }
             .frame(maxWidth: .infinity, alignment: .trailing)
             .padding(.top, 24)
-            
+
             // Center align the content
             VStack(alignment: .center) {
-                Spacer() // pushes content to the center
-                
+                Spacer()  // pushes content to the center
+
                 if self.isOverlayHelpTextBoxShown {
                     Text(.localizable.outsideNetworkExplanation)
                         .font(.body)
@@ -57,51 +60,54 @@ struct OutOfNetworkView: View {
                         .padding(.horizontal, 24)
                         .fixedSize(horizontal: false, vertical: true)
                 }
-                
+
                 SecondaryActionButton(title: .localizable.viewThisPostAnyway) {
                     withAnimation {
                         controller.userHidWarning = true
                     }
                 }
-                .padding(.top, 10) // Move the button closer to the text
-                
-                Spacer() // pushes content to the center
+                .padding(.top, 10)  // Move the button closer to the text
+
+                Spacer()  // pushes content to the center
             }
-            .frame(maxWidth: .infinity) // Allow the VStack to take full width
-            Spacer(minLength: 30) // Ensure there's some spacing at the bottom
+            .frame(maxWidth: .infinity)  // Allow the VStack to take full width
+            Spacer(minLength: 30)  // Ensure there's some spacing at the bottom
         }
     }
 }
 
 struct OverlayContentReportView: View {
-    
+
     @Bindable var controller: NoteWarningController
-    
+
     @State private var isTextBoxShown = false
     @State var isOverlayHelpTextBoxShown = false
-    
+
     var body: some View {
         VStack(alignment: .leading) {
             HStack {
                 Spacer()
-                Button(action: {
-                    withAnimation {
-                        self.isOverlayHelpTextBoxShown.toggle()
+                Button(
+                    action: {
+                        withAnimation {
+                            self.isOverlayHelpTextBoxShown.toggle()
+                        }
+                    },
+                    label: {
+                        (isTextBoxShown ? Image.x : Image.info)
+                            .resizable()
+                            .frame(width: 24, height: 24)
                     }
-                }, label: {
-                    (isTextBoxShown ? Image.x : Image.info)
-                        .resizable()
-                        .frame(width: 24, height: 24)
-                })
+                )
                 .padding(.trailing, 24)
             }
             .frame(maxWidth: .infinity, alignment: .trailing)
             .padding(.top, 24)
-            
+
             // Center align the content
             VStack(alignment: .center) {
-                Spacer() // pushes content to the center
-                
+                Spacer()  // pushes content to the center
+
                 // TextBox or Image based on isTextBoxShown
                 if self.isOverlayHelpTextBoxShown {
                     Text(.localizable.contentWarningExplanation)
@@ -111,12 +117,12 @@ struct OverlayContentReportView: View {
                         .fixedSize(horizontal: false, vertical: true)
                         .layoutPriority(1)
                 } else {
-                    
+
                     Image.warningEye
                         .scaledToFit()
-                        .frame(width: 48, height: 48) // Set the width and height to 48
+                        .frame(width: 48, height: 48)  // Set the width and height to 48
                         .padding(.bottom, 20)
-                    
+
                     if controller.noteReports.count > 0 {
                         ContentWarningMessage(reports: controller.noteReports, type: .note)
                     } else if controller.authorReports.count > 0 {
@@ -128,24 +134,24 @@ struct OverlayContentReportView: View {
                         controller.userHidWarning = true
                     }
                 }
-                .padding(.top, 10) // Move the button closer to the text
-                
-                Spacer() // pushes content to the center
+                .padding(.top, 10)  // Move the button closer to the text
+
+                Spacer()  // pushes content to the center
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
-            Spacer(minLength: 30) // Ensure there's some spacing at the bottom
-            
+            Spacer(minLength: 30)  // Ensure there's some spacing at the bottom
+
         }
     }
 }
 
 struct ContentWarningMessage: View {
-    
+
     var reports: [Event]
     var type: ContentWarningType
-    
+
     @State private var controller = ContentWarningController()
-    
+
     var body: some View {
         Text(controller.localizedContentWarning)
             .font(.body)
@@ -166,7 +172,7 @@ struct ContentWarningMessage: View {
 
 #Preview {
     var previewData = PreviewData()
-    
+
     return VStack {
         ContentWarningMessage(reports: [previewData.shortNoteReportOne], type: .author)
         ContentWarningMessage(reports: [previewData.shortNoteReportOne, previewData.shortNoteReportTwo], type: .author)
@@ -174,7 +180,7 @@ struct ContentWarningMessage: View {
             reports: [
                 previewData.shortNoteReportOne,
                 previewData.shortNoteReportTwo,
-                previewData.shortNoteReportThree
+                previewData.shortNoteReportThree,
             ],
             type: .author
         )
@@ -184,7 +190,7 @@ struct ContentWarningMessage: View {
             reports: [
                 previewData.shortNoteReportOne,
                 previewData.shortNoteReportTwo,
-                previewData.shortNoteReportThree
+                previewData.shortNoteReportThree,
             ],
             type: .note
         )

--- a/Nos/Views/Components/WebView.swift
+++ b/Nos/Views/Components/WebView.swift
@@ -3,7 +3,7 @@ import WebKit
 
 struct WebView: UIViewRepresentable {
     let url: URL
-    
+
     func makeUIView(context: Context) -> WKWebView {
         let webView = WKWebView()
         webView.isOpaque = false
@@ -11,7 +11,7 @@ struct WebView: UIViewRepresentable {
         webView.load(URLRequest(url: url))
         return webView
     }
-    
+
     func updateUIView(_ uiView: WKWebView, context: Context) {
         uiView.load(URLRequest(url: url))
     }
@@ -19,14 +19,14 @@ struct WebView: UIViewRepresentable {
 
 struct URLView: View {
     let url: URL
-    
+
     var body: some View {
         WebView(url: url)
             .toolbar {
-                ToolbarItem(placement: .navigationBarTrailing) { 
-                    Button { 
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button {
                         UIApplication.shared.open(url)
-                    } label: { 
+                    } label: {
                         Image(systemName: "safari")
                     }
                 }

--- a/Nos/Views/Components/Wizard/WizardSheetDescriptionText.swift
+++ b/Nos/Views/Components/Wizard/WizardSheetDescriptionText.swift
@@ -11,7 +11,7 @@ struct WizardSheetDescriptionText: View {
     private enum Description {
         case plainText(LocalizedStringResource)
         case markdown(AttributedString)
-        
+
         var text: Text {
             switch self {
             case .plainText(let localizedStringResource):
@@ -27,15 +27,16 @@ struct WizardSheetDescriptionText: View {
     }
 
     init(_ attributedString: AttributedString, tint: Color) {
-        self.description = .markdown(attributedString
-            .replacingAttributes(
-                AttributeContainer(
-                    [.inlinePresentationIntent: InlinePresentationIntent.stronglyEmphasized.rawValue]
-                ),
-                with: AttributeContainer(
-                    [.foregroundColor: UIColor(tint)]
-                )
-            ))
+        self.description = .markdown(
+            attributedString
+                .replacingAttributes(
+                    AttributeContainer(
+                        [.inlinePresentationIntent: InlinePresentationIntent.stronglyEmphasized.rawValue]
+                    ),
+                    with: AttributeContainer(
+                        [.foregroundColor: UIColor(tint)]
+                    )
+                ))
     }
 
     init(

--- a/Nos/Views/Components/Wizard/WizardSheetTitleText.swift
+++ b/Nos/Views/Components/Wizard/WizardSheetTitleText.swift
@@ -5,7 +5,7 @@ import SwiftUI
 ///
 /// This View was implemented to be re-used in the wizards that set-up and delete usernames in EditProfile screen.
 struct WizardSheetTitleText: View {
-    
+
     private var localizedStringResource: LocalizedStringResource
 
     init(_ localizedStringResource: LocalizedStringResource) {

--- a/Nos/Views/Components/Wizard/WizardSheetVStack.swift
+++ b/Nos/Views/Components/Wizard/WizardSheetVStack.swift
@@ -13,7 +13,7 @@ struct WizardSheetVStack<Content>: View where Content: View {
     init(@ViewBuilder content: @escaping () -> Content) {
         self.content = content
     }
-    
+
     var body: some View {
         ZStack {
             // Gradient border

--- a/Nos/Views/Discover/DiscoverContentsView.swift
+++ b/Nos/Views/Discover/DiscoverContentsView.swift
@@ -1,6 +1,6 @@
+import Dependencies
 import Logger
 import SwiftUI
-import Dependencies
 
 struct DiscoverContentsView: View {
     @ObservedObject var searchController: SearchController
@@ -17,7 +17,7 @@ struct DiscoverContentsView: View {
     @State private var featuredAuthorIDs = [RawAuthorID]()
     @State private var subscriptions = [ObjectIdentifier: SubscriptionCancellable]()
     @State private var selectedCategory: FeaturedAuthorCategory = .all
-    
+
     @State private var featuredAuthorsPerformingInitialLoad = true
     let featuredAuthorsInitialLoadTime = 1
 
@@ -30,7 +30,7 @@ struct DiscoverContentsView: View {
         self.searchController = searchController
         self.selectedCategory = featuredAuthorCategory
     }
-    
+
     var body: some View {
         VStack {
             GeometryReader { geometry in
@@ -43,8 +43,8 @@ struct DiscoverContentsView: View {
                     case .loading, .stillLoading:
                         FullscreenProgressView(
                             isPresented: .constant(true),
-                            text: searchController.state == .stillLoading ?
-                            String(localized: .localizable.notFindingResults) : nil
+                            text: searchController.state == .stillLoading
+                                ? String(localized: .localizable.notFindingResults) : nil
                         )
                     case .results:
                         ScrollView {
@@ -75,13 +75,13 @@ struct DiscoverContentsView: View {
             }
         }
     }
-    
+
     var featuredAuthorsView: some View {
         ZStack {
             ScrollView {
                 LazyVStack {
                     categoryPicker
-                    
+
                     ForEach(featuredAuthorIDs) { authorID in
                         AuthorObservationView(authorID: authorID) { author in
                             AuthorCard(author: author) {
@@ -92,10 +92,10 @@ struct DiscoverContentsView: View {
                             .readabilityPadding()
                             .task {
                                 subscriptions[author.id] =
-                                await relayService.requestMetadata(
-                                    for: author.hexadecimalPublicKey,
-                                    since: author.lastUpdatedMetadata
-                                )
+                                    await relayService.requestMetadata(
+                                        for: author.hexadecimalPublicKey,
+                                        since: author.lastUpdatedMetadata
+                                    )
                             }
                         }
                     }
@@ -107,10 +107,10 @@ struct DiscoverContentsView: View {
                     proxy.scrollTo(firstAuthorID, anchor: .bottom)
                 }
             }
-            
+
             if featuredAuthorsPerformingInitialLoad {
                 FullscreenProgressView(
-                    isPresented: $featuredAuthorsPerformingInitialLoad, 
+                    isPresented: $featuredAuthorsPerformingInitialLoad,
                     hideAfter: .now() + .seconds(featuredAuthorsInitialLoadTime)
                 )
                 .onAppear {
@@ -136,27 +136,26 @@ struct DiscoverContentsView: View {
         HStack(spacing: 2) {
             Spacer()
             ForEach(FeaturedAuthorCategory.allCases, id: \.self) { category in
-                Button(action: {
-                    selectedCategory = category
-                }, label: {
-                    Text(category.text)
-                        .font(.callout)
-                        .padding(.vertical, 4)
-                        .padding(.horizontal, 8)
-                        .background(
-                            selectedCategory == category ?
-                            Color.pickerBackgroundSelected :
-                                Color.clear
-                        )
-                        .foregroundColor(
-                            selectedCategory == category ?
-                            Color.primaryTxt :
-                                Color.secondaryTxt
-                        )
-                        .cornerRadius(20)
-                        .padding(4)
-                        .frame(minWidth: 44, minHeight: 44)
-                })
+                Button(
+                    action: {
+                        selectedCategory = category
+                    },
+                    label: {
+                        Text(category.text)
+                            .font(.callout)
+                            .padding(.vertical, 4)
+                            .padding(.horizontal, 8)
+                            .background(
+                                selectedCategory == category ? Color.pickerBackgroundSelected : Color.clear
+                            )
+                            .foregroundColor(
+                                selectedCategory == category ? Color.primaryTxt : Color.secondaryTxt
+                            )
+                            .cornerRadius(20)
+                            .padding(4)
+                            .frame(minWidth: 44, minHeight: 44)
+                    }
+                )
                 .onChange(of: selectedCategory) { _, _ in
                     updateDisplayedFeaturedAuthors()
                 }

--- a/Nos/Views/Discover/DiscoverTab.swift
+++ b/Nos/Views/Discover/DiscoverTab.swift
@@ -1,11 +1,11 @@
-import SwiftUI
 import Combine
 import CoreData
 import Dependencies
+import SwiftUI
 
-struct DiscoverTab: View {    
+struct DiscoverTab: View {
     // MARK: - Properties
-    
+
     @EnvironmentObject private var router: Router
     @Environment(CurrentUser.self) var currentUser
     @Dependency(\.analytics) private var analytics
@@ -13,7 +13,7 @@ struct DiscoverTab: View {
     @State var showInfoPopover = false
 
     @State var columns: Int = 0
-    
+
     @State private var isVisible = false
 
     @StateObject private var searchController = SearchController()
@@ -21,7 +21,7 @@ struct DiscoverTab: View {
     @State var predicate: NSPredicate = .false
 
     // MARK: - View
-    
+
     var body: some View {
         NosNavigationStack(path: $router.discoverPath) {
             ZStack {
@@ -31,8 +31,8 @@ struct DiscoverTab: View {
                 )
             }
             .searchable(
-                text: $searchController.query, 
-                placement: .toolbar, 
+                text: $searchController.query,
+                placement: .toolbar,
                 prompt: Text(.localizable.searchBar)
             )
             .autocorrectionDisabled()
@@ -71,26 +71,26 @@ struct SizePreferenceKey: PreferenceKey {
 }
 
 struct DiscoverTab_Previews: PreviewProvider {
-    
+
     static var previewData = PreviewData()
     static var persistenceController = PersistenceController.preview
     static var previewContext = persistenceController.viewContext
 
     static var currentUser = previewData.currentUser
     static var router = Router()
-    
+
     static var user: Author {
         let author = Author(context: previewContext)
         author.hexadecimalPublicKey = KeyFixture.alice.publicKeyHex
         return author
     }
-    
+
     static func createTestData(in context: NSManagedObjectContext) {
         let shortNote = Event(context: previewContext)
         shortNote.identifier = "1"
         shortNote.author = user
         shortNote.content = "Hello, world!"
-        
+
         let longNote = Event(context: previewContext)
         longNote.identifier = "2"
         longNote.author = user
@@ -105,7 +105,7 @@ struct DiscoverTab_Previews: PreviewProvider {
             .environmentObject(router)
             .environment(currentUser)
             .onAppear { createTestData(in: previewContext) }
-        
+
         DiscoverTab()
             .environment(\.managedObjectContext, previewContext)
             .environmentObject(router)

--- a/Nos/Views/Discover/FeaturedAuthor.swift
+++ b/Nos/Views/Discover/FeaturedAuthor.swift
@@ -12,19 +12,19 @@ struct FeaturedAuthor {
     /// The categories in which to show the author on the Discover tab.
     /// No need to include the `.all` category; that's done automatically.
     let categories: [FeaturedAuthorCategory]
-    
+
     let rawID: RawAuthorID
-    
+
     init(name: String, npub: String, categories: [FeaturedAuthorCategory]) {
         self.name = name
         self.npub = npub
         self.categories = categories
-        
+
         guard let rawID = PublicKey(npub: npub)?.hex else {
             assertionFailure("A FeaturedAuthor has a invalid npub: \(npub)")
             self.rawID = ""
             return
-        } 
+        }
         self.rawID = rawID
     }
 }

--- a/Nos/Views/Discover/FeaturedAuthorCategory.swift
+++ b/Nos/Views/Discover/FeaturedAuthorCategory.swift
@@ -7,10 +7,10 @@ enum FeaturedAuthorCategory: CaseIterable {
     /// A special type of category that includes all other categories.
     case all
     /// A special type of category that includes all authors from the latest cohort.
-    case new // swiftlint:disable:this identifier_name
+    case new  // swiftlint:disable:this identifier_name
     case music
     case news
-    case art // swiftlint:disable:this identifier_name
+    case art  // swiftlint:disable:this identifier_name
     case activists
     case tech
     case health

--- a/Nos/Views/Fixtures/PreviewData.swift
+++ b/Nos/Views/Fixtures/PreviewData.swift
@@ -1,77 +1,81 @@
-import SwiftUI
-import Foundation
-import Dependencies
 import CoreData
+import Dependencies
+import Foundation
+import SwiftUI
 
 // swiftlint:disable line_length force_try
 
-/// A set of test data and an environment that can be used to display Core Data objects in SwiftUI Previews. This 
+/// A set of test data and an environment that can be used to display Core Data objects in SwiftUI Previews. This
 /// includes an in-memory persistent store and mocked versions of other singletons like `Router` and `RelayService`.
-/// 
+///
 /// Instantiate an instance as a `static var` in a preview
 /// and inject it into the view using the `inject(previewData:)` view modifier.
 struct PreviewData {
-    
-    let currentUserKey: KeyPair 
-    
+
+    let currentUserKey: KeyPair
+
     init(currentUserKey: KeyPair = KeyFixture.keyPair) {
         self.currentUserKey = currentUserKey
         Task { [currentUser] in
             await currentUser.setPrivateKeyHex(currentUserKey.privateKeyHex)
         }
     }
-    
+
     // MARK: - Environment
-    @Dependency(\.persistenceController) var persistenceController 
+    @Dependency(\.persistenceController) var persistenceController
     @Dependency(\.router) var router
     @Dependency(\.relayService) var relayService
     @Dependency(\.currentUser) var currentUser
-    
+
     lazy var previewContext: NSManagedObjectContext = {
-        persistenceController.viewContext  
+        persistenceController.viewContext
     }()
-    
+
     // MARK: - Authors
-    
+
     lazy var previewAuthor: Author = {
         alice
     }()
-    
+
     lazy var alice: Author = {
         let author = try! Author.findOrCreate(by: KeyFixture.alice.publicKeyHex, context: previewContext)
         author.name = "Alice"
         author.nip05 = "alice@nos.social"
-        author.profilePhotoURL = URL(string: "https://github.com/planetary-social/nos/assets/1165004/07f83f00-4555-4db3-85fc-f1a05b1908a2")
+        author.profilePhotoURL = URL(
+            string: "https://github.com/planetary-social/nos/assets/1165004/07f83f00-4555-4db3-85fc-f1a05b1908a2")
         author.about = """
-        Bitcoin Maximalist extraordinaire! 🚀 HODLing since the days of Satoshi's personal phone number. Always clad in my 'Bitcoin or Bust' t-shirt, preaching the gospel of the Orange Coin. 🍊 Lover of decentralized currencies, disruptive technology, and long walks on the blockchain. 💪 When I'm not evangelizing BTC, you'll find me stacking sats, perfecting my lambo moonwalk, and dreaming of a world ruled by blockchain memes. 💸 Join me on this rollercoaster ride to financial freedom, where we laugh at the mere mortals still stuck with fiat. #BitcoinFTW #WhenLambo 🚀
-        """
+            Bitcoin Maximalist extraordinaire! 🚀 HODLing since the days of Satoshi's personal phone number. Always clad in my 'Bitcoin or Bust' t-shirt, preaching the gospel of the Orange Coin. 🍊 Lover of decentralized currencies, disruptive technology, and long walks on the blockchain. 💪 When I'm not evangelizing BTC, you'll find me stacking sats, perfecting my lambo moonwalk, and dreaming of a world ruled by blockchain memes. 💸 Join me on this rollercoaster ride to financial freedom, where we laugh at the mere mortals still stuck with fiat. #BitcoinFTW #WhenLambo 🚀
+            """
         return author
     }()
-    
+
     lazy var bob: Author = {
         let author = try! Author.findOrCreate(by: KeyFixture.bob.publicKeyHex, context: previewContext)
         author.hexadecimalPublicKey = KeyFixture.bob.publicKeyHex
         author.name = "Bob"
-        author.profilePhotoURL = URL(string: "https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Ftse1.mm.bing.net%2Fth%3Fid%3DOIP.r1ZOH5E3M6WiK6aw5GRdlAHaEK%26pid%3DApi&f=1&ipt=42ae9de7730da3bda152c5980cd64b14ccef37d8f55b8791e41b4667fc38ddf1&ipo=images")
-        
+        author.profilePhotoURL = URL(
+            string:
+                "https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Ftse1.mm.bing.net%2Fth%3Fid%3DOIP.r1ZOH5E3M6WiK6aw5GRdlAHaEK%26pid%3DApi&f=1&ipt=42ae9de7730da3bda152c5980cd64b14ccef37d8f55b8791e41b4667fc38ddf1&ipo=images"
+        )
+
         return author
     }()
-    
+
     lazy var eve: Author = {
         let author = try! Author.findOrCreate(by: KeyFixture.eve.publicKeyHex, context: previewContext)
         author.name = "Eve"
         author.uns = "eve"
         author.nip05 = "eve@nos.social"
-        
+
         return author
     }()
-    
+
     lazy var unsAuthor: Author = {
         eve
     }()
-    
+
     // MARK: - Notes
-    
+
     lazy var shortNote: Event = {
         let note = Event(context: previewContext)
         note.identifier = "1"
@@ -82,7 +86,7 @@ struct PreviewData {
         try? previewContext.save()
         return note
     }()
-    
+
     lazy var expiringNote: Event = {
         let note = Event(context: previewContext)
         note.identifier = "10"
@@ -90,16 +94,16 @@ struct PreviewData {
         note.content = "Hello, world!"
         note.author = previewAuthor
         note.createdAt = .now
-        let currentDate = Date() 
-        let calendar = Calendar.current 
-        var dateComponents = DateComponents() 
-        dateComponents.day = 1 
+        let currentDate = Date()
+        let calendar = Calendar.current
+        var dateComponents = DateComponents()
+        dateComponents.day = 1
         let tomorrow = calendar.date(byAdding: dateComponents, to: currentDate)!
         note.expirationDate = tomorrow
         try? previewContext.save()
         return note
     }()
-    
+
     lazy var imageNote: Event = {
         let note = Event(context: previewContext)
         note.identifier = "2"
@@ -110,29 +114,31 @@ struct PreviewData {
         try? previewContext.save()
         return note
     }()
-    
+
     lazy var verticalImageNote: Event = {
         let note = Event(context: previewContext)
         note.identifier = "3"
         note.kind = EventKind.text.rawValue
-        note.content = "Hello, world!https://nostr.build/i/nostr.build_1b958a2af7a2c3fcb2758dd5743912e697ba34d3a6199bfb1300fa6be1dc62ee.jpeg"
+        note.content =
+            "Hello, world!https://nostr.build/i/nostr.build_1b958a2af7a2c3fcb2758dd5743912e697ba34d3a6199bfb1300fa6be1dc62ee.jpeg"
         note.author = previewAuthor
         note.createdAt = .now
         try? previewContext.save()
         return note
     }()
-    
+
     lazy var veryWideImageNote: Event = {
         let note = Event(context: previewContext)
         note.identifier = "4"
         note.kind = EventKind.text.rawValue
-        note.content = "Hello, world! https://nostr.build/i/nostr.build_db8287dde9aedbc65df59972386fde14edf9e1afc210e80c764706e61cd1cdfa.png"
+        note.content =
+            "Hello, world! https://nostr.build/i/nostr.build_db8287dde9aedbc65df59972386fde14edf9e1afc210e80c764706e61cd1cdfa.png"
         note.author = previewAuthor
         note.createdAt = .now
         try? previewContext.save()
         return note
     }()
-    
+
     lazy var longNote: Event = {
         let note = Event(context: previewContext)
         note.identifier = "5"
@@ -143,76 +149,79 @@ struct PreviewData {
         try? previewContext.save()
         return note
     }()
-    
+
     lazy var longFormNote: Event = {
         let note = Event(context: previewContext)
         note.identifier = "6"
         note.createdAt = .now
         note.kind = EventKind.longFormContent.rawValue
-        note.content = 
-        """
-        # This note
-        
-        is **formatted** with
-        > _markdown_
-        
-        And it has a link to [nos.social](https://nos.social).
-        """
+        note.content =
+            """
+            # This note
+
+            is **formatted** with
+            > _markdown_
+
+            And it has a link to [nos.social](https://nos.social).
+            """
         note.author = previewAuthor
         try? previewContext.save()
         return note
     }()
-    
+
     lazy var doubleImageNote: Event = {
         let note = Event(context: previewContext)
         note.identifier = "7"
         note.kind = EventKind.text.rawValue
         note.content = """
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore 
-        magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. 
-        
-        Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
-        https://cdn.ymaws.com/nacfm.com/resource/resmgr/images/blog_photos/footprints.jpg
-        https://nostr.build/i/nostr.build_1b958a2af7a2c3fcb2758dd5743912e697ba34d3a6199bfb1300fa6be1dc62ee.jpeg
-        """
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore 
+            magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. 
+
+            Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+            https://cdn.ymaws.com/nacfm.com/resource/resmgr/images/blog_photos/footprints.jpg
+            https://nostr.build/i/nostr.build_1b958a2af7a2c3fcb2758dd5743912e697ba34d3a6199bfb1300fa6be1dc62ee.jpeg
+            """
         note.author = previewAuthor
         note.createdAt = .now
         try? previewContext.save()
         return note
     }()
-    
+
     lazy var linkNote: Event = {
         let note = Event(context: previewContext)
         note.identifier = "8"
         note.kind = EventKind.text.rawValue
         note.content = """
-        Wsg fam! 🤙🫂
-        Free sats await at the end, please read carefully ✨️
-        
-        We are officially out of the top 40 on nostr:npub1yfg0d955c2jrj2080ew7pa4xrtj7x7s7umt28wh0zurwmxgpyj9shwv6vg
-        Helluva drop from #7
-        
-        I need your help! 🥺
-        
-        Please, go boost my songs (as little as 1 sat) 💜
-        
-        https://www.wavlake.com/chu-t
-        
-        I'll give 100 sats to everyone who boosts this post
-        
-        Love y'all 🫶
-        """
+            Wsg fam! 🤙🫂
+            Free sats await at the end, please read carefully ✨️
+
+            We are officially out of the top 40 on nostr:npub1yfg0d955c2jrj2080ew7pa4xrtj7x7s7umt28wh0zurwmxgpyj9shwv6vg
+            Helluva drop from #7
+
+            I need your help! 🥺
+
+            Please, go boost my songs (as little as 1 sat) 💜
+
+            https://www.wavlake.com/chu-t
+
+            I'll give 100 sats to everyone who boosts this post
+
+            Love y'all 🫶
+            """
         note.author = previewAuthor
         note.createdAt = .now
         try? previewContext.save()
         return note
     }()
-    
+
     lazy var repost: Event = {
         let originalPostAuthor = Author(context: previewContext)
         originalPostAuthor.hexadecimalPublicKey = KeyFixture.bob.publicKeyHex
         originalPostAuthor.name = "Bob"
-        originalPostAuthor.profilePhotoURL = URL(string: "https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Ftse1.mm.bing.net%2Fth%3Fid%3DOIP.r1ZOH5E3M6WiK6aw5GRdlAHaEK%26pid%3DApi&f=1&ipt=42ae9de7730da3bda152c5980cd64b14ccef37d8f55b8791e41b4667fc38ddf1&ipo=images")
+        originalPostAuthor.profilePhotoURL = URL(
+            string:
+                "https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Ftse1.mm.bing.net%2Fth%3Fid%3DOIP.r1ZOH5E3M6WiK6aw5GRdlAHaEK%26pid%3DApi&f=1&ipt=42ae9de7730da3bda152c5980cd64b14ccef37d8f55b8791e41b4667fc38ddf1&ipo=images"
+        )
 
         let repostedNote = Event(context: previewContext)
         repostedNote.identifier = "3"
@@ -228,7 +237,7 @@ struct PreviewData {
             print(error)
             reference = EventReference(context: previewContext)
         }
-        
+
         let repost = Event(context: previewContext)
         repost.identifier = "4"
         repost.kind = EventKind.repost.rawValue
@@ -238,30 +247,30 @@ struct PreviewData {
         try? previewContext.save()
         return repost
     }()
-    
+
     lazy var reply: Event = {
         let rootNote = longNote
-        
+
         let note = Event(context: previewContext)
         note.identifier = "11"
         note.kind = EventKind.text.rawValue
         note.content = "Well that's pretty neat"
         note.author = bob
         note.createdAt = .now
-        
+
         let rootReference = EventReference(context: previewContext)
         rootReference.eventId = rootNote.identifier
         rootReference.marker = "root"
         rootReference.referencedEvent = rootNote
-        
+
         note.insertIntoEventReferences(rootReference, at: 0)
-        
+
         try? previewContext.save()
         return note
     }()
-    
+
     // MARK: Reports
-    
+
     lazy var shortNoteReportOne: Event = {
         let note = Event(context: previewContext)
         note.identifier = "r1"
@@ -269,16 +278,16 @@ struct PreviewData {
         note.content = "impersonation"
         note.author = bob
         note.createdAt = .now
-        
+
         let reference = EventReference(context: previewContext)
         reference.eventId = "1"
         reference.referencedEvent = shortNote
         note.insertIntoEventReferences(reference, at: 0)
-        
+
         try? previewContext.save()
         return note
     }()
-    
+
     lazy var reportBobTwo: Event = {
         let note = Event(context: previewContext)
         note.identifier = "r4"
@@ -286,32 +295,33 @@ struct PreviewData {
         note.content = "harassment"
         note.author = bob
         note.createdAt = .now
-        
+
         let reference = EventReference(context: previewContext)
         reference.eventId = "1"
         reference.referencedEvent = shortNote
         note.insertIntoEventReferences(reference, at: 0)
-        
+
         try? previewContext.save()
         return note
     }()
-    
+
     lazy var shortNoteReportTwo: Event = {
         let note = Event(context: previewContext)
         note.identifier = "r2"
         note.kind = EventKind.report.rawValue
         note.content = "harassment"
-        note.allTags = [
-            [ "p", "6b165e83a3b7d333a6e7db1f200dc627e31eb5170285c29ded271be203c5da37", "other"]
-        ] as NSObject
+        note.allTags =
+            [
+                ["p", "6b165e83a3b7d333a6e7db1f200dc627e31eb5170285c29ded271be203c5da37", "other"]
+            ] as NSObject
         note.author = eve
         note.createdAt = .now
-        
+
         let reference = EventReference(context: previewContext)
         reference.eventId = "1"
         reference.referencedEvent = shortNote
         note.insertIntoEventReferences(reference, at: 0)
-        
+
         try? previewContext.save()
         return note
     }()
@@ -321,10 +331,11 @@ struct PreviewData {
         note.identifier = "r3"
         note.kind = EventKind.report.rawValue
         note.content = "this person is spammy"
-        note.allTags = [
-            [ "p", "6b165e83a3b7d333a6e7db1f200dc627e31eb5170285c29ded271be203c5da37", "spam" ],
-            [ "e", "ad0cea87d9c81e3bc5b15ddf561b1a2bbbff3d8318d4ea9ccd4644def9e035b8", "spam" ],
-        ] as NSObject
+        note.allTags =
+            [
+                ["p", "6b165e83a3b7d333a6e7db1f200dc627e31eb5170285c29ded271be203c5da37", "spam"],
+                ["e", "ad0cea87d9c81e3bc5b15ddf561b1a2bbbff3d8318d4ea9ccd4644def9e035b8", "spam"],
+            ] as NSObject
         note.author = alice
         note.createdAt = .now
 
@@ -339,9 +350,9 @@ struct PreviewData {
 }
 
 struct InjectPreviewData: ViewModifier {
-    
+
     @State var previewData: PreviewData
-    
+
     func body(content: Content) -> some View {
         content
             .environment(\.managedObjectContext, previewData.persistenceController.viewContext)

--- a/Nos/Views/Home/HomeFeedView.swift
+++ b/Nos/Views/Home/HomeFeedView.swift
@@ -1,34 +1,34 @@
-import SwiftUI
-import CoreData
 import Combine
+import CoreData
 import Dependencies
+import SwiftUI
 
 struct HomeFeedView: View {
-    
+
     @Environment(\.managedObjectContext) private var viewContext
     @EnvironmentObject private var router: Router
     @ObservationIgnored @Dependency(\.analytics) private var analytics
 
     @State private var refreshController = RefreshController(lastRefreshDate: Date.now + Self.staticLoadTime)
     @State private var isVisible = false
-    
+
     /// When set to true this will display a fullscreen progress wheel for a set amount of time to give us a chance
     /// to get some data from relay. The amount of time is defined in `staticLoadTime`.
     @State private var showTimedLoadingIndicator = true
-    
-    /// The amount of time (in seconds) the loading indicator will be shown when showTimedLoadingIndicator is set to 
+
+    /// The amount of time (in seconds) the loading indicator will be shown when showTimedLoadingIndicator is set to
     /// true.
     static let staticLoadTime: TimeInterval = 2
 
     let user: Author
 
     @State private var showRelayPicker = false
-    @State private var selectedRelay: Relay? 
+    @State private var selectedRelay: Relay?
 
     init(user: Author) {
         self.user = user
     }
-    
+
     var homeFeedFetchRequest: NSFetchRequest<Event> {
         Event.homeFeed(
             for: user,
@@ -49,10 +49,10 @@ struct HomeFeedView: View {
         var filter = Filter(kinds: [.text, .delete, .repost, .longFormContent, .report])
         if selectedRelay == nil {
             filter.authorKeys = user.followedKeys.sorted()
-        } 
+        }
         return filter
     }
-    
+
     var navigationBarTitle: LocalizedStringResource {
         if let relayName = selectedRelay?.host {
             LocalizedStringResource(stringLiteral: relayName)
@@ -92,8 +92,8 @@ struct HomeFeedView: View {
                     isPresented: $showTimedLoadingIndicator,
                     hideAfter: .now() + .seconds(Int(Self.staticLoadTime))
                 )
-            } 
-            
+            }
+
             if showRelayPicker {
                 RelayPicker(
                     selectedRelay: $selectedRelay,
@@ -141,11 +141,11 @@ struct HomeFeedView: View {
         .nosNavigationBar(title: navigationBarTitle)
         .onAppear {
             if router.selectedTab == .home {
-                isVisible = true 
+                isVisible = true
             }
         }
         .onDisappear { isVisible = false }
-        .onChange(of: isVisible) { 
+        .onChange(of: isVisible) {
             if isVisible {
                 analytics.showedHome()
             }
@@ -155,7 +155,7 @@ struct HomeFeedView: View {
 
 #Preview {
     var previewData = PreviewData()
-    
+
     func createTestData() {
         let user = previewData.alice
         let addresses = Relay.recommended
@@ -164,10 +164,10 @@ struct HomeFeedView: View {
             relay?.relayDescription = "A Nostr relay that aims to cultivate a healthy community."
             relay?.addToAuthors(user)
         }
-        
+
         _ = previewData.shortNote
     }
-    
+
     return NavigationStack {
         HomeFeedView(user: previewData.alice)
     }

--- a/Nos/Views/Home/HomeTab.swift
+++ b/Nos/Views/Home/HomeTab.swift
@@ -1,12 +1,12 @@
-import SwiftUI
 import Dependencies
+import SwiftUI
 
 struct HomeTab: View {
-    
+
     @ObservedObject var user: Author
-    
+
     @EnvironmentObject private var router: Router
-    
+
     var body: some View {
         NosNavigationStack(path: $router.homeFeedPath) {
             HomeFeedView(user: user)
@@ -15,9 +15,9 @@ struct HomeTab: View {
 }
 
 struct HomeTab_Previews: PreviewProvider {
-    
+
     static var previewData = PreviewData()
-    
+
     static var previews: some View {
         NavigationView {
             HomeFeedView(user: previewData.currentUser.author!)

--- a/Nos/Views/Media/AspectRatioContainer.swift
+++ b/Nos/Views/Media/AspectRatioContainer.swift
@@ -5,7 +5,7 @@ import SwiftUI
 struct AspectRatioContainer<Content: View>: View {
     /// The orientation, which determines the aspect ratio of this container.
     let orientation: MediaOrientation
-    
+
     /// The content to be displayed in the container.
     let content: () -> Content
 

--- a/Nos/Views/Media/GalleryView.swift
+++ b/Nos/Views/Media/GalleryView.swift
@@ -6,19 +6,19 @@ import SwiftUI
 struct GalleryView: View {
     /// The URLs of the content to display.
     let urls: [URL]
-    
+
     /// The currently-selected tab in the tab view.
     @State private var selectedTab = 0
-    
+
     /// The orientation of all media in this gallery view. Initially set to `.landscape` until we load the first URL and
     /// determine its orientation, then updated to match the first item's orientation.
     @State private var orientation: MediaOrientation?
-    
+
     /// This essential first image determines the orientation of the gallery view. Whatever orientation this is, so the
     /// rest shall be.
     /// Oh, but also: it's not always an image, so this won't work if it's a video or web link. Oopsie.
     @State private var firstImage: Image?
-    
+
     /// The media service that loads content from URLs and determines the orientation for this gallery.
     @Dependency(\.mediaService) private var mediaService
 
@@ -33,7 +33,7 @@ struct GalleryView: View {
             loadingView()
         }
     }
-    
+
     /// Produces a tab view with custom paging indicators in the given orientation.
     /// - Parameter orientation: The orientation to use for the gallery.
     /// - Returns: A gallery view in the given orientation.
@@ -62,7 +62,7 @@ struct GalleryView: View {
         }
         .padding(.bottom, 10)
     }
-    
+
     /// Produces a ``LinkView`` with the given URL in the given orientation.
     /// - Parameters:
     ///   - url: The URL to display in the ``LinkView``.
@@ -73,7 +73,7 @@ struct GalleryView: View {
             LinkView(url: url)
         }
     }
-    
+
     /// A loading view that fills the space for the given `loadingOrientation` and loads the first URL to determine the
     /// orientation for the gallery.
     /// - Parameter loadingOrientation: The ``MediaOrientation`` to use to display the loading view.
@@ -97,19 +97,19 @@ struct GalleryView: View {
 // Thanks for the [example](https://betterprogramming.pub/custom-paging-ui-in-swiftui-13f1347cf529) Alexandru Turcanu!
 
 /// Custom paging indicators for a `GalleryView`.
-fileprivate struct GalleryIndexView: View {
+private struct GalleryIndexView: View {
     /// The number of pages in the tab view.
     let numberOfPages: Int
 
     /// The currently-selected tab in the tab view.
     let currentIndex: Int
-    
+
     /// The size of the circle representing the currently-selected tab.
     private let circleSize: CGFloat = 8.0
 
     /// The space between circles.
     private let circleSpacing: CGFloat = 6.0
-    
+
     /// The fill style of the circle indicating which tab is selected.
     private let primaryFill = LinearGradient.horizontalAccent
 

--- a/Nos/Views/Media/LinkPreview.swift
+++ b/Nos/Views/Media/LinkPreview.swift
@@ -1,10 +1,10 @@
-import SwiftUI
 import LinkPresentation
 import SDWebImageSwiftUI
+import SwiftUI
 
 struct ImageLinkButton: View {
     let url: URL
-    
+
     @State private var isViewerPresented = false
 
     var body: some View {
@@ -55,9 +55,9 @@ struct HeroImageButton: View {
 }
 
 struct LinkPreview: View {
-    
+
     let url: URL
-    
+
     var body: some View {
         if url.isImage {
             ImageLinkButton(url: url)
@@ -71,7 +71,7 @@ struct LinkPreview: View {
 struct LPLinkViewRepresentable: UIViewRepresentable {
 
     let url: URL
-    
+
     func makeUIView(context: Context) -> LPLinkView {
         let linkView = LPLinkView(url: url)
         linkView.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
@@ -79,7 +79,7 @@ struct LPLinkViewRepresentable: UIViewRepresentable {
         linkView.sizeToFit()
         return linkView
     }
-    
+
     func updateUIView(_ uiView: LPLinkView, context: Context) {
         let provider = LPMetadataProvider()
         provider.startFetchingMetadata(for: url) { metadata, error in
@@ -92,12 +92,12 @@ struct LPLinkViewRepresentable: UIViewRepresentable {
 }
 
 struct LinkPreviewCarousel: View {
-    
+
     var links: [URL]
-    
+
     var body: some View {
         if links.count == 1, let url = links.first {
-            
+
             if url.isImage {
                 HeroImageButton(url: url)
             } else {
@@ -117,7 +117,7 @@ struct LinkPreviewCarousel: View {
             .tabViewStyle(.page)
             .frame(height: 320)
             .padding(.bottom, 15)
-        } 
+        }
     }
 }
 
@@ -126,14 +126,26 @@ struct LinkPreview_Previews: PreviewProvider {
         Group {
             // swiftlint:disable line_length
             LinkPreviewCarousel(links: [
-                URL(string: "https://image.nostr.build/77713e6c2ef5186d516a6f16fb197fca53a20677c6756a9de1afc2d5e6d96548.jpg")!,
-                URL(string: "https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Ftse1.mm.bing.net%2Fth%3Fid%3DOIP.r1ZOH5E3M6WiK6aw5GRdlAHaEK%26pid%3DApi&f=1&ipt=42ae9de7730da3bda152c5980cd64b14ccef37d8f55b8791e41b4667fc38ddf1&ipo=images")!,
+                URL(
+                    string:
+                        "https://image.nostr.build/77713e6c2ef5186d516a6f16fb197fca53a20677c6756a9de1afc2d5e6d96548.jpg"
+                )!,
+                URL(
+                    string:
+                        "https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Ftse1.mm.bing.net%2Fth%3Fid%3DOIP.r1ZOH5E3M6WiK6aw5GRdlAHaEK%26pid%3DApi&f=1&ipt=42ae9de7730da3bda152c5980cd64b14ccef37d8f55b8791e41b4667fc38ddf1&ipo=images"
+                )!,
                 URL(string: "https://youtu.be/5qvdbyRH9wA?si=y_KTgLR22nH0-cs8")!,
-                URL(string: "https://image.nostr.build/d5e38e7d864a344872d922d7f78daf67b0d304932fcb7fe22d35263c2fcf11c2.jpg")!,
+                URL(
+                    string:
+                        "https://image.nostr.build/d5e38e7d864a344872d922d7f78daf67b0d304932fcb7fe22d35263c2fcf11c2.jpg"
+                )!,
             ])
-            
+
             LinkPreviewCarousel(links: [
-                URL(string: "https://image.nostr.build/d5e38e7d864a344872d922d7f78daf67b0d304932fcb7fe22d35263c2fcf11c2.jpg")!
+                URL(
+                    string:
+                        "https://image.nostr.build/d5e38e7d864a344872d922d7f78daf67b0d304932fcb7fe22d35263c2fcf11c2.jpg"
+                )!
             ])
             // swiftlint:enable line_length
         }

--- a/Nos/Views/Media/SquareImage.swift
+++ b/Nos/Views/Media/SquareImage.swift
@@ -1,11 +1,11 @@
-import SwiftUI
 import SDWebImageSwiftUI
+import SwiftUI
 
 struct SquareImage: View {
     var url: URL
-    
+
     var onTap: (() -> Void)?
-    
+
     var body: some View {
         Color.clear
             .aspectRatio(1, contentMode: .fit)

--- a/Nos/Views/Media/ZoomableContainer.swift
+++ b/Nos/Views/Media/ZoomableContainer.swift
@@ -27,7 +27,7 @@ struct ZoomableContainer<ContainerContent: View>: View {
     }
 }
 
-fileprivate struct ZoomableScrollView<ScrollViewContent: View>: UIViewRepresentable {
+private struct ZoomableScrollView<ScrollViewContent: View>: UIViewRepresentable {
     private var content: ScrollViewContent
     private let maxAllowedScale: CGFloat
 
@@ -49,7 +49,7 @@ fileprivate struct ZoomableScrollView<ScrollViewContent: View>: UIViewRepresenta
     func makeUIView(context: Context) -> UIScrollView {
         // Setup the UIScrollView
         let scrollView = UIScrollView()
-        scrollView.delegate = context.coordinator // for viewForZooming(in:)
+        scrollView.delegate = context.coordinator  // for viewForZooming(in:)
         scrollView.maximumZoomScale = maxAllowedScale
         scrollView.minimumZoomScale = 1
         scrollView.bouncesZoom = true
@@ -76,9 +76,9 @@ fileprivate struct ZoomableScrollView<ScrollViewContent: View>: UIViewRepresenta
         // Update the hosting controller's SwiftUI content
         context.coordinator.hostingController.rootView = content
 
-        if uiView.zoomScale > uiView.minimumZoomScale { // Scale out
+        if uiView.zoomScale > uiView.minimumZoomScale {  // Scale out
             uiView.setZoomScale(currentScale, animated: true)
-        } else if tapLocation != .zero { // Scale in to a specific point
+        } else if tapLocation != .zero {  // Scale in to a specific point
             uiView.zoom(to: zoomRect(for: uiView, scale: uiView.maximumZoomScale, center: tapLocation), animated: true)
             // Reset the location to prevent scaling to it in case of a negative scale (manual pinch)
             // Use the main thread to prevent unexpected behavior

--- a/Nos/Views/Moderation/ContentFlagView.swift
+++ b/Nos/Views/Moderation/ContentFlagView.swift
@@ -123,7 +123,7 @@ struct ContentFlagView: View {
                 ContentFlagView(
                     selectedFlagOptionCategory: $selectedFlagOptionCategory,
                     selectedSendOptionCategory: $selectedSendOptionCategory,
-                    showSuccessView: $showSuccessView, 
+                    showSuccessView: $showSuccessView,
                     flagTarget: .note(event),
                     sendAction: {}
                 )

--- a/Nos/Views/Modifiers/LinearGradient+Planetary.swift
+++ b/Nos/Views/Modifiers/LinearGradient+Planetary.swift
@@ -1,31 +1,31 @@
 import SwiftUI
 
 extension LinearGradient {
-    
+
     public static let horizontalAccent = LinearGradient(
-        colors: [ Color.actionPrimaryGradientTop, Color.actionPrimaryGradientBottom],
+        colors: [Color.actionPrimaryGradientTop, Color.actionPrimaryGradientBottom],
         startPoint: .leading,
         endPoint: .trailing
     )
-    
+
     public static let diagonalAccent = LinearGradient(
-        colors: [ Color.actionPrimaryGradientTop, Color.actionPrimaryGradientBottom],
+        colors: [Color.actionPrimaryGradientTop, Color.actionPrimaryGradientBottom],
         startPoint: .topLeading,
         endPoint: .bottomTrailing
     )
-    
+
     public static let diagonalAccent2 = LinearGradient(
-        colors: [ Color.actionPrimaryGradientTop, Color.actionPrimaryGradientBottom],
+        colors: [Color.actionPrimaryGradientTop, Color.actionPrimaryGradientBottom],
         startPoint: .bottomLeading,
         endPoint: .topTrailing
     )
-    
+
     public static let verticalAccentPrimary = LinearGradient(
         colors: [.actionPrimaryGradientTop, .actionPrimaryGradientBottom],
         startPoint: .top,
         endPoint: .bottom
     )
-    
+
     public static let verticalAccentSecondary = LinearGradient(
         colors: [.actionSecondaryGradientTop, .actionSecondaryGradientBottom],
         startPoint: .top,

--- a/Nos/Views/Modifiers/ReadabilityPadding.swift
+++ b/Nos/Views/Modifiers/ReadabilityPadding.swift
@@ -11,19 +11,19 @@ extension View {
 struct ReadabilityPadding: ViewModifier {
     let isEnabled: Bool
     @ScaledMetric private var unit: CGFloat = 20
-    
+
     func body(content: Content) -> some View {
         content.frame(maxWidth: maxReadableWidth())
     }
-    
+
     private func maxReadableWidth() -> CGFloat {
         guard isEnabled else { return 0 }
-        
+
         // The internet seems to think the optimal readable width is 50-75
-        // characters wide; I chose 70 here. The `unit` variable is the 
+        // characters wide; I chose 70 here. The `unit` variable is the
         // approximate size of the system font and is wrapped in
-        // @ScaledMetric to better support dynamic type. I assume that 
-        // the average character width is half of the size of the font. 
+        // @ScaledMetric to better support dynamic type. I assume that
+        // the average character width is half of the size of the font.
         let idealWidth = 70 * unit / 2
         return idealWidth
     }

--- a/Nos/Views/Modifiers/ReportMenuModifier.swift
+++ b/Nos/Views/Modifiers/ReportMenuModifier.swift
@@ -1,6 +1,6 @@
-import SwiftUI
 import Dependencies
 import Logger
+import SwiftUI
 import SwiftUINavigation
 
 /// The report menu can be added to another element and controlled with the `isPresented` variable. When `isPresented`
@@ -8,9 +8,9 @@ import SwiftUINavigation
 /// category and optionally mute the respective author.
 struct ReportMenuModifier: ViewModifier {
     @Binding var isPresented: Bool
-    
+
     var reportedObject: ReportTarget
-    
+
     @State private var userSelection: UserSelection?
     @State private var confirmReport = false
     @State private var showMuteDialog = false
@@ -44,7 +44,7 @@ struct ReportMenuModifier: ViewModifier {
                         ContentFlagView(
                             selectedFlagOptionCategory: $selectedFlagOption,
                             selectedSendOptionCategory: $selectedFlagSendOption,
-                            showSuccessView: $showFlagSuccessView, 
+                            showSuccessView: $showFlagSuccessView,
                             flagTarget: reportedObject,
                             sendAction: {
                                 if let selectCategory = selectedFlagOption?.category {
@@ -63,7 +63,7 @@ struct ReportMenuModifier: ViewModifier {
                             selectedFlagOption: $selectedFlagOption,
                             selectedSendOption: $selectedFlagSendOption,
                             selectedVisibilityOption: $selectedVisibilityOption,
-                            showSuccessView: $showFlagSuccessView, 
+                            showSuccessView: $showFlagSuccessView,
                             flagTarget: reportedObject,
                             sendAction: {
                                 let selectCategory = selectedVisibilityOption?.category ?? .visibility(.dontMute)
@@ -83,7 +83,7 @@ struct ReportMenuModifier: ViewModifier {
     @ViewBuilder
     func oldModerationFlow(content: Content) -> some View {
         content
-        // ReportCategory menu
+            // ReportCategory menu
             .confirmationDialog(unwrapping: $confirmationDialogState, action: processUserSelection)
             .alert(
                 String(localized: .localizable.confirmFlag),
@@ -91,7 +91,7 @@ struct ReportMenuModifier: ViewModifier {
                 actions: {
                     Button(String(localized: .localizable.confirm)) {
                         publishReport(userSelection)
-                        
+
                         if let author = reportedObject.author, !author.muted {
                             showMuteDialog = true
                         }
@@ -105,7 +105,7 @@ struct ReportMenuModifier: ViewModifier {
                     Text(text)
                 }
             )
-        // Mute user menu
+            // Mute user menu
             .alert(
                 String(localized: .localizable.muteUser),
                 isPresented: $showMuteDialog,
@@ -152,11 +152,11 @@ struct ReportMenuModifier: ViewModifier {
 
     func processUserSelection(_ userSelection: UserSelection?) {
         self.userSelection = userSelection
-        
+
         guard let userSelection else {
             return
         }
-        
+
         switch userSelection {
         case .noteCategorySelected(let category):
             Task {
@@ -169,11 +169,11 @@ struct ReportMenuModifier: ViewModifier {
                         },
                         ButtonState(action: .send(.flagPublicly(category))) {
                             TextState("Flag Publicly")
-                        }
+                        },
                     ]
                 )
             }
-            
+
         case .authorCategorySelected(let category):
             Task {
                 confirmationDialogState = ConfirmationDialogState(
@@ -185,16 +185,16 @@ struct ReportMenuModifier: ViewModifier {
                         },
                         ButtonState(action: .send(.flagPublicly(category))) {
                             TextState("Flag Publicly")
-                        }
+                        },
                     ]
                 )
             }
-            
+
         case .sendToNos, .flagPublicly:
             confirmReport = true
         }
     }
-    
+
     func mute(author: Author) async {
         do {
             try await author.mute(viewContext: viewContext)
@@ -222,7 +222,7 @@ struct ReportMenuModifier: ViewModifier {
         case authorCategorySelected(ReportCategory)
         case sendToNos(ReportCategory)
         case flagPublicly(ReportCategory)
-        
+
         func confirmationAlertMessage(for reportedObject: ReportTarget) -> String {
             switch self {
             case .sendToNos(let category):
@@ -232,24 +232,24 @@ struct ReportMenuModifier: ViewModifier {
                 case .author:
                     return String(localized: .localizable.reportAuthorSendToNosConfirmation)
                 }
-                
+
             case .flagPublicly(let category):
                 return String(localized: .localizable.reportFlagPubliclyConfirmation(category.displayName))
-                
+
             case .noteCategorySelected(let category),
                 .authorCategorySelected(let category):
                 return String(localized: .localizable.reportFlagPubliclyConfirmation(category.displayName))
             }
         }
     }
-    
+
     /// List of the top-level report categories we care about.
     func topLevelButtons() -> [ButtonState<UserSelection>] {
         switch reportedObject {
         case .note:
             ReportCategory.noteCategories.map { category in
                 let userSelection = UserSelection.noteCategorySelected(category)
-                
+
                 return ButtonState(action: .send(userSelection)) {
                     TextState(verbatim: category.displayName)
                 }
@@ -257,7 +257,7 @@ struct ReportMenuModifier: ViewModifier {
         case .author:
             ReportCategory.authorCategories.map { category in
                 let userSelection = UserSelection.authorCategorySelected(category)
-                
+
                 return ButtonState(action: .send(userSelection)) {
                     TextState(verbatim: category.displayName)
                 }
@@ -307,7 +307,7 @@ struct ReportMenuModifier: ViewModifier {
             Log.error("Invalid user selection")
         }
     }
-    
+
     func sendToNos(_ selectedCategory: ReportCategory) {
         ReportPublisher().publishPrivateReport(
             for: reportedObject,
@@ -315,7 +315,7 @@ struct ReportMenuModifier: ViewModifier {
             context: viewContext
         )
     }
-    
+
     func flagPublicly(_ selectedCategory: ReportCategory) {
         ReportPublisher().publishPublicReport(
             for: reportedObject,
@@ -323,7 +323,7 @@ struct ReportMenuModifier: ViewModifier {
             context: viewContext
         )
     }
-    
+
     func getAlertMessage(for userSelection: UserSelection?, with reportedObject: ReportTarget) -> String {
         userSelection?.confirmationAlertMessage(for: reportedObject) ?? String(localized: .localizable.error)
     }

--- a/Nos/Views/Modifiers/Text+Gradient.swift
+++ b/Nos/Views/Modifiers/Text+Gradient.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 extension Text {
-    
+
     /// Colors the text with the given gradient
     public func foregroundLinearGradient(_ gradient: LinearGradient) -> some View {
         self.overlay {

--- a/Nos/Views/Modifiers/View+HandleURLsInRouter.swift
+++ b/Nos/Views/Modifiers/View+HandleURLsInRouter.swift
@@ -1,5 +1,5 @@
-import SwiftUI
 import CoreData
+import SwiftUI
 
 extension View {
     /// Forwards any URLs the user taps in this view to `Router.open(url:with:)`.
@@ -9,14 +9,16 @@ extension View {
 }
 
 struct HandleURLsInRouter: ViewModifier {
-    
+
     @EnvironmentObject private var router: Router
-    
+
     func body(content: Content) -> some View {
         content
-            .environment(\.openURL, OpenURLAction { url in
-                router.open(url: url)
-                return .handled
-            })
+            .environment(
+                \.openURL,
+                OpenURLAction { url in
+                    router.open(url: url)
+                    return .handled
+                })
     }
 }

--- a/Nos/Views/Modifiers/View+ListRowGradientBackground.swift
+++ b/Nos/Views/Modifiers/View+ListRowGradientBackground.swift
@@ -11,10 +11,11 @@ extension View {
 struct ListRowGradientBackground: ViewModifier {
     func body(content: Content) -> some View {
         content
-            .listRowBackground(LinearGradient(
-                colors: [Color.cardBgTop, Color.cardBgBottom],
-                startPoint: .top,
-                endPoint: .bottom
-            ))
+            .listRowBackground(
+                LinearGradient(
+                    colors: [Color.cardBgTop, Color.cardBgBottom],
+                    startPoint: .top,
+                    endPoint: .bottom
+                ))
     }
 }

--- a/Nos/Views/Modifiers/View+RoundedCorner.swift
+++ b/Nos/Views/Modifiers/View+RoundedCorner.swift
@@ -5,7 +5,7 @@ extension View {
     /// Allows you to round specific corners of views with different radii.
     /// https://stackoverflow.com/a/58606176/982195
     func cornerRadius(_ radius: CGFloat, corners: UIRectCorner) -> some View {
-        clipShape( RoundedCorner(radius: radius, corners: corners) )
+        clipShape(RoundedCorner(radius: radius, corners: corners))
     }
 }
 

--- a/Nos/Views/Modifiers/View+StyledBorder.swift
+++ b/Nos/Views/Modifiers/View+StyledBorder.swift
@@ -18,7 +18,7 @@ struct StyledBorder: ViewModifier {
                         LinearGradient(
                             gradient: Gradient(colors: [
                                 .styledBorderGradientTop,
-                                .styledBorderGradientBottom
+                                .styledBorderGradientBottom,
                             ]),
                             startPoint: .top,
                             endPoint: .bottom

--- a/Nos/Views/Note/CompactNoteView.swift
+++ b/Nos/Views/Note/CompactNoteView.swift
@@ -1,24 +1,24 @@
-import SwiftUI
-import Logger
 import Dependencies
+import Logger
+import SwiftUI
 
 /// A view that displays the text of a note (kind: 1 Nostr event) and truncates it with a "Read more" button if
 /// it is too long
 struct CompactNoteView: View {
-    
+
     /// The note whose content will be displayed
     private let note: Event
-    
+
     /// The maximum number of lines to show before truncating (if `showFullMessage` is false)
     private let truncationLineLimit = 12
-    
-    /// If true this view will truncate long notes and show a "Read more" button to view the whole thing. If false 
+
+    /// If true this view will truncate long notes and show a "Read more" button to view the whole thing. If false
     /// the full note will always be displayed
     private var shouldTruncate: Bool
-    
+
     /// Whether link previews should be displayed for links found in the note text.
     private var showLinkPreviews: Bool
-    
+
     /// If true links will be highlighted and open when tapped. If false the text will change to a secondary color
     /// and links will not be tappable.
     private var allowUserInteraction: Bool
@@ -29,17 +29,17 @@ struct CompactNoteView: View {
     /// Whether this view is currently displayed in a truncated state
     @State private var isTextTruncated = true
 
-    /// The size of the full note text 
+    /// The size of the full note text
     @State private var intrinsicSize = CGSize.zero
-    
+
     /// The size of the note text truncated to `truncationLineLimit` lines.
     @State private var truncatedSize = CGSize.zero
-    
+
     @EnvironmentObject private var router: Router
-    
+
     internal init(
-        note: Event, 
-        shouldTruncate: Bool = false, 
+        note: Event,
+        shouldTruncate: Bool = false,
         showLinkPreviews: Bool = true,
         allowUserInteraction: Bool = true
     ) {
@@ -48,33 +48,35 @@ struct CompactNoteView: View {
         self.showLinkPreviews = showLinkPreviews
         self.allowUserInteraction = allowUserInteraction
     }
-    
+
     /// Calculates whether the note text is long enough to need truncation given `truncationLineLimit`.
     var noteNeedsTruncation: Bool {
-        shouldTruncate && intrinsicSize.height > truncatedSize.height + 30 
+        shouldTruncate && intrinsicSize.height > truncatedSize.height + 30
     }
-    
-    /// Calculates whether the Read More button should be shown. 
+
+    /// Calculates whether the Read More button should be shown.
     var showReadMoreButton: Bool {
         noteNeedsTruncation && isTextTruncated
     }
-    
+
     var formattedText: some View {
         noteText
             .font(.body)
             .foregroundColor(allowUserInteraction ? .primaryTxt : .secondaryTxt)
-            .tint(allowUserInteraction ? .accent : .secondaryTxt) 
+            .tint(allowUserInteraction ? .accent : .secondaryTxt)
             .padding(15)
             .textSelection(.enabled)
-            .environment(\.openURL, OpenURLAction { url in
-                guard allowUserInteraction else {
+            .environment(
+                \.openURL,
+                OpenURLAction { url in
+                    guard allowUserInteraction else {
+                        return .handled
+                    }
+                    router.open(url: url)
                     return .handled
-                }
-                router.open(url: url)
-                return .handled
-            })
+                })
     }
-    
+
     var noteText: some View {
         Group {
             switch note.attributedContent {
@@ -114,8 +116,8 @@ struct CompactNoteView: View {
                         }
                     }
                     .background {
-                        // To calculate whether the text should be truncated we create this hidden view of 
-                        // `formattedText` and record its size. It is compared to `truncatedSize` and used in the 
+                        // To calculate whether the text should be truncated we create this hidden view of
+                        // `formattedText` and record its size. It is compared to `truncatedSize` and used in the
                         // calculation of `noteNeedsTruncation`.
                         formattedText
                             .fixedSize(horizontal: false, vertical: true)
@@ -165,20 +167,20 @@ struct CompactNoteView: View {
     }
 }
 
-fileprivate struct IntrinsicSizePreferenceKey: PreferenceKey {
+private struct IntrinsicSizePreferenceKey: PreferenceKey {
     static var defaultValue: CGSize = .zero
     static func reduce(value: inout CGSize, nextValue: () -> CGSize) {}
 }
 
-fileprivate struct TruncatedSizePreferenceKey: PreferenceKey {
+private struct TruncatedSizePreferenceKey: PreferenceKey {
     static var defaultValue: CGSize = .zero
     static func reduce(value: inout CGSize, nextValue: () -> CGSize) {}
 }
 
 struct CompactNoteView_Previews: PreviewProvider {
-    
+
     static var previewData = PreviewData()
-    
+
     static var previews: some View {
         Group {
             CompactNoteView(note: previewData.linkNote, allowUserInteraction: false)

--- a/Nos/Views/Note/NoteCard.swift
+++ b/Nos/Views/Note/NoteCard.swift
@@ -1,7 +1,7 @@
-import SwiftUI
-import Logger
 import CoreData
 import Dependencies
+import Logger
+import SwiftUI
 
 /// This view displays the information we have for a message suitable for being used in a list or grid.
 ///
@@ -10,7 +10,7 @@ struct NoteCard: View {
 
     @ObservedObject var note: Event
     @State private var quotedNote: Event?
-    
+
     let style: CardStyle
 
     @State private var warningController = NoteWarningController()
@@ -19,18 +19,18 @@ struct NoteCard: View {
 
     private let shouldTruncate: Bool
     private let repliesDisplayType: RepliesDisplayType
-    
+
     /// Indicates whether the number of likes is displayed.
     private let showsLikeCount: Bool
 
     /// Indicates whether the number of reposts is displayed.
     private let showsRepostCount: Bool
-    
+
     private let hideOutOfNetwork: Bool
     private let rendersQuotedNotes: Bool
     private let showsActions: Bool
     private let replyAction: ((Event) -> Void)?
-    
+
     /// Initializes a NoteCard object.
     ///
     /// - Parameter note: Note event to display.
@@ -67,7 +67,7 @@ struct NoteCard: View {
         self.showsRepostCount = showsRepostCount
         self.replyAction = replyAction
     }
-    
+
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             switch style {
@@ -100,21 +100,21 @@ struct NoteCard: View {
                             .padding(30)
                         } else {
                             CompactNoteView(
-                                note: note, 
-                                shouldTruncate: shouldTruncate, 
+                                note: note,
+                                shouldTruncate: shouldTruncate,
                                 showLinkPreviews: !warningController.showWarning
                             )
                             .blur(radius: warningController.showWarning ? 6 : 0)
                             .frame(maxWidth: .infinity)
-                            
+
                             if rendersQuotedNotes, let quotedNote {
                                 Button {
                                     router.push(quotedNote)
                                 } label: {
                                     NoteCard(
-                                        note: quotedNote, 
-                                        hideOutOfNetwork: false, 
-                                        rendersQuotedNotes: false, 
+                                        note: quotedNote,
+                                        hideOutOfNetwork: false,
+                                        rendersQuotedNotes: false,
                                         showsActions: false
                                     )
                                     .withStyledBorder()
@@ -179,12 +179,12 @@ struct NoteCard: View {
         )
         .listRowInsets(EdgeInsets())
     }
-    
+
     private func loadQuotedNote() {
         guard rendersQuotedNotes, let quotedNoteID = note.quotedNoteID else {
             return
         }
-        
+
         @Dependency(\.persistenceController) var persistenceController
         quotedNote = try? Event.findOrCreateStubBy(
             id: quotedNoteID,
@@ -203,7 +203,7 @@ struct NoteCard: View {
 }
 
 struct NoteCard_Previews: PreviewProvider {
-    
+
     static var previewData = PreviewData()
     static var previews: some View {
         Group {

--- a/Nos/Views/Note/NoteCardHeader.swift
+++ b/Nos/Views/Note/NoteCardHeader.swift
@@ -1,10 +1,10 @@
 import SwiftUI
 
 struct NoteCardHeader: View {
-    
+
     @ObservedObject var note: Event
     @ObservedObject var author: Author
-    
+
     var body: some View {
         HStack(alignment: .center) {
             AuthorLabel(author: author, note: note)

--- a/Nos/Views/NoteComposer/ComposerActionBar.swift
+++ b/Nos/Views/NoteComposer/ComposerActionBar.swift
@@ -129,11 +129,13 @@ struct ComposerActionBar: View {
                 ExpirationTimeButton(
                     model: option,
                     showClearButton: true,
-                    isSelected: Binding(get: {
-                        self.expirationTime == option.timeInterval
-                    }, set: {
-                        self.expirationTime = $0 ? option.timeInterval : nil
-                    })
+                    isSelected: Binding(
+                        get: {
+                            self.expirationTime == option.timeInterval
+                        },
+                        set: {
+                            self.expirationTime = $0 ? option.timeInterval : nil
+                        })
                 )
                 .accessibilityLabel(Text(.localizable.expirationDate))
                 .padding(12)
@@ -192,7 +194,7 @@ struct ComposerActionBar: View {
     private func startUploadingImage() {
         self.isUploadingImage = true
     }
-    
+
     private func endUploadingImage() {
         self.isUploadingImage = false
         self.subMenu = .none
@@ -221,7 +223,7 @@ struct ComposerActionBar: View {
                 .default(
                     TextState(String(localized: .imagePicker.getAccount)),
                     action: .send(.getAccount)
-                )
+                ),
             ]
         } else if case let FileStorageAPIClientError.uploadFailed(errorMessage) = error, let errorMessage {
             message = String(localized: .imagePicker.errorUploadingFileWithMessage(errorMessage))
@@ -238,25 +240,25 @@ struct ComposerActionBar: View {
 }
 
 struct ComposerActionBar_Previews: PreviewProvider {
-    
+
     @State static var controller = NoteEditorController()
     @State static var emptyExpirationTime: TimeInterval?
     @State static var setExpirationTime: TimeInterval? = 60 * 60
     @State static var showPreview = false
-    
+
     static var previews: some View {
         VStack {
             Spacer()
             ComposerActionBar(
-                editingController: $controller, 
-                expirationTime: $emptyExpirationTime, 
+                editingController: $controller,
+                expirationTime: $emptyExpirationTime,
                 isUploadingImage: .constant(false),
                 showPreview: $showPreview
             )
             Spacer()
             ComposerActionBar(
-                editingController: $controller, 
-                expirationTime: $setExpirationTime, 
+                editingController: $controller,
+                expirationTime: $setExpirationTime,
                 isUploadingImage: .constant(false),
                 showPreview: $showPreview
             )

--- a/Nos/Views/NoteComposer/ExpirationTimeButton.swift
+++ b/Nos/Views/NoteComposer/ExpirationTimeButton.swift
@@ -2,12 +2,12 @@ import SwiftUI
 
 /// A button that lets the user select an `ExpirationTimeOption` to specify when an event should be deleted.
 struct ExpirationTimeButton: View {
-    
+
     var model: ExpirationTimeOption
     @State var showClearButton = false
     var minSize: Binding<CGSize?>?
     @Binding var isSelected: Bool
-    
+
     var body: some View {
         ZStack {
             let textLayer = HStack(spacing: 3) {
@@ -19,7 +19,7 @@ struct ExpirationTimeButton: View {
                         .foregroundColor(.secondaryTxt)
                         .font(.clarity(.regular, textStyle: .caption2))
                 }
-                
+
                 if showClearButton {
                     Image(systemName: "xmark")
                         .font(.callout)
@@ -32,7 +32,7 @@ struct ExpirationTimeButton: View {
             .frame(minWidth: minSize?.wrappedValue?.width, minHeight: minSize?.wrappedValue?.height)
             .cornerRadius(5)
             .background(Color.buttonBevelBg)
-            
+
             if isSelected {
                 textLayer
                     // highlighted border
@@ -63,13 +63,13 @@ struct ExpirationTimeButton: View {
         .accessibilityLabel(Text(model.accessibilityLabel))
         .cornerRadius(5)
         .onTapGesture {
-            isSelected.toggle() 
+            isSelected.toggle()
         }
     }
 }
 
 struct ExpirationTimeButton_Previews: PreviewProvider {
-    
+
     static var previews: some View {
         VStack {
             HStack {
@@ -77,8 +77,8 @@ struct ExpirationTimeButton_Previews: PreviewProvider {
                 ExpirationTimeButton(model: ExpirationTimeOption.oneDay, isSelected: .constant(false))
                 ExpirationTimeButton(model: ExpirationTimeOption.sevenDays, isSelected: .constant(true))
                 ExpirationTimeButton(
-                    model: ExpirationTimeOption.oneHour, 
-                    showClearButton: true, 
+                    model: ExpirationTimeOption.oneHour,
+                    showClearButton: true,
                     isSelected: .constant(true)
                 )
             }

--- a/Nos/Views/NoteComposer/ExpirationTimePicker.swift
+++ b/Nos/Views/NoteComposer/ExpirationTimePicker.swift
@@ -1,12 +1,12 @@
-import SwiftUI
 import Foundation
+import SwiftUI
 
-/// A view that allows the user to pick an expiration date for an event. 
+/// A view that allows the user to pick an expiration date for an event.
 struct ExpirationTimePicker: View {
-    
+
     struct ExpirationTimeButtonSize: PreferenceKey {
         static let defaultValue: CGSize = .zero
-        
+
         static func reduce(value: inout CGSize, nextValue: () -> CGSize) {
             let next = nextValue()
             value = CGSize(
@@ -15,29 +15,32 @@ struct ExpirationTimePicker: View {
             )
         }
     }
-    
+
     @Binding var expirationTime: TimeInterval?
-    
+
     @State private var buttonSize: CGSize?
-   
+
     var body: some View {
         HStack {
             ForEach(ExpirationTimeOption.allCases) { option in
                 ExpirationTimeButton(
-                    model: option, 
+                    model: option,
                     minSize: $buttonSize,
-                    isSelected: Binding(get: { 
-                        expirationTime == option.timeInterval
-                    }, set: { 
-                        expirationTime = $0 ? option.timeInterval : nil
-                    })
+                    isSelected: Binding(
+                        get: {
+                            expirationTime == option.timeInterval
+                        },
+                        set: {
+                            expirationTime = $0 ? option.timeInterval : nil
+                        })
                 )
-                .background(GeometryReader { geometry in
-                    Color.clear.preference(
-                        key: ExpirationTimeButtonSize.self,
-                        value: geometry.size
-                    )
-                })
+                .background(
+                    GeometryReader { geometry in
+                        Color.clear.preference(
+                            key: ExpirationTimeButtonSize.self,
+                            value: geometry.size
+                        )
+                    })
             }
         }
         .onPreferenceChange(ExpirationTimeButtonSize.self) {
@@ -47,11 +50,11 @@ struct ExpirationTimePicker: View {
 }
 
 struct ExpirationTimePicker_Previews: PreviewProvider {
-    
-    @State static var emptyExpirationTime: TimeInterval? 
-    
+
+    @State static var emptyExpirationTime: TimeInterval?
+
     @State static var oneHourExpirationTime: TimeInterval? = 60 * 60
-    
+
     static var previews: some View {
         VStack {
             ExpirationTimePicker(expirationTime: $emptyExpirationTime)

--- a/Nos/Views/NoteComposer/ImagePickerButton.swift
+++ b/Nos/Views/NoteComposer/ImagePickerButton.swift
@@ -1,6 +1,6 @@
 import AVKit
-import SwiftUI
 import Dependencies
+import SwiftUI
 
 struct ImagePickerButton<Label>: View where Label: View {
 
@@ -22,9 +22,9 @@ struct ImagePickerButton<Label>: View where Label: View {
     /// Source used by ImagePicker when opening it
     @State
     private var imagePickerSource: UIImagePickerController.SourceType?
-    
+
     @Dependency(\.analytics) private var analytics
-    
+
     @EnvironmentObject private var router: Router
 
     private var showImagePicker: Binding<Bool> {
@@ -113,19 +113,19 @@ struct ImagePickerButton<Label>: View where Label: View {
         )
         .sheet(isPresented: showImagePicker) {
             ImagePickerUIViewController(
-                sourceType: imagePickerSource ?? .photoLibrary, 
+                sourceType: imagePickerSource ?? .photoLibrary,
                 mediaTypes: mediaTypes,
                 cameraDevice: cameraDevice,
                 onCompletion: userPicked
-            ) 
+            )
             .edgesIgnoringSafeArea(.bottom)
         }
     }
-    
+
     private var cameraButtonTitle: String {
         String(localized: mediaTypes.contains(.movie) ? .imagePicker.takePhotoOrVideo : .imagePicker.takePhoto)
     }
-    
+
     /// Called when a user chooses an image or video.
     /// - Parameter url: The URL of the image or video on disk.
     func userPicked(url: URL?) {

--- a/Nos/Views/NoteComposer/ImagePickerUIViewController.swift
+++ b/Nos/Views/NoteComposer/ImagePickerUIViewController.swift
@@ -3,12 +3,12 @@ import SwiftUI
 import UniformTypeIdentifiers
 
 struct ImagePickerUIViewController: UIViewControllerRepresentable {
-    
+
     let sourceType: UIImagePickerController.SourceType
     let mediaTypes: [UTType]
     let cameraDevice: UIImagePickerController.CameraDevice
     let onCompletion: ((URL?) -> Void)
-    
+
     init(
         sourceType: UIImagePickerController.SourceType = .photoLibrary,
         mediaTypes: [UTType] = [.image, .movie],
@@ -21,7 +21,7 @@ struct ImagePickerUIViewController: UIViewControllerRepresentable {
         self.cameraDevice = cameraDevice
         self.onCompletion = onCompletion
     }
-    
+
     func makeUIViewController(
         context: UIViewControllerRepresentableContext<ImagePickerUIViewController>
     ) -> UIImagePickerController {
@@ -40,7 +40,7 @@ struct ImagePickerUIViewController: UIViewControllerRepresentable {
     func updateUIViewController(
         _ uiViewController: UIImagePickerController,
         context: UIViewControllerRepresentableContext<ImagePickerUIViewController>
-    ) { }
+    ) {}
 
     func makeCoordinator() -> Coordinator {
         Coordinator(onCompletion: onCompletion)
@@ -52,7 +52,7 @@ struct ImagePickerUIViewController: UIViewControllerRepresentable {
         init(onCompletion: @escaping ((URL?) -> Void)) {
             self.onCompletion = onCompletion
         }
-        
+
         func imagePickerControllerDidCancel(_ picker: UIImagePickerController) {
             onCompletion(nil)
         }
@@ -64,7 +64,8 @@ struct ImagePickerUIViewController: UIViewControllerRepresentable {
             if let videoURL = info[.mediaURL] as? URL {
                 onCompletion(videoURL)
             } else if let image = info[.editedImage] as? UIImage ?? info[.originalImage] as? UIImage,
-                let imageData = image.jpegData(compressionQuality: 1.0) {
+                let imageData = image.jpegData(compressionQuality: 1.0)
+            {
                 let url = saveImage(imageData)
                 onCompletion(url)
             } else if let imageURL = info[.imageURL] as? URL {

--- a/Nos/Views/NoteComposer/NoteComposer.swift
+++ b/Nos/Views/NoteComposer/NoteComposer.swift
@@ -5,7 +5,7 @@ import SwiftUI
 import SwiftUINavigation
 
 struct NoteComposer: View {
-    
+
     @Environment(\.managedObjectContext) private var viewContext
     @EnvironmentObject private var relayService: RelayService
     @Environment(CurrentUser.self) var currentUser
@@ -18,18 +18,18 @@ struct NoteComposer: View {
     @State private var editingController = NoteEditorController()
 
     /// The height of the NoteTextEditor that fits all entered text.
-    /// This value will be updated by NoteTextEditor automatically, and should be used to set its frame from SwiftUI. 
-    /// This is done to work around some incompatibilities between UIKit and SwiftUI where the UITextView won't expand 
+    /// This value will be updated by NoteTextEditor automatically, and should be used to set its frame from SwiftUI.
+    /// This is done to work around some incompatibilities between UIKit and SwiftUI where the UITextView won't expand
     /// properly.
     @State private var scrollViewHeight: CGFloat = 0
 
     @State var expirationTime: TimeInterval?
-    
+
     @State private var alert: AlertState<Never>?
-    
+
     @State private var showRelayPicker = false
     @State private var selectedRelay: Relay?
-    
+
     /// Shows a note preview above the composer.
     @State private var showNotePreview = false
 
@@ -41,13 +41,13 @@ struct NoteComposer: View {
 
     var initialContents: String?
     @Binding var isPresented: Bool
-    
+
     /// The note that the user is replying to, if any.
     private var replyToNote: Event?
-    
+
     /// The id of a note the user is quoting, if any.
     private let quotedNoteID: RawEventID?
-    
+
     /// The quoted note, if any.
     @State private var quotedNote: Event?
 
@@ -62,16 +62,16 @@ struct NoteComposer: View {
         self.replyToNote = replyTo
         self.quotedNoteID = quotedNoteID
     }
-    
+
     /// The minimum height of the NoteTextEditor.
-    /// 
+    ///
     /// We do this because editor won't expand to fill available space when it's in a ScrollView.
     /// And we need it to because people try to tap below the text field bounds to paste if it doesn't
     /// fill the screen. We remove this minimum in the case that a user is quote-reposting another note.
     var minimumEditorHeight: CGFloat {
         quotedNote == nil ? max(scrollViewHeight - 12, 0) : 0
     }
-    
+
     var body: some View {
         NavigationStack {
             ZStack {
@@ -112,7 +112,7 @@ struct NoteComposer: View {
                                 .onAppear {
                                     Task {
                                         try await Task.sleep(for: .seconds(0.5))
-                                        withAnimation(.easeInOut(duration: 0.25)) { 
+                                        withAnimation(.easeInOut(duration: 0.25)) {
                                             proxy.scrollTo(0, anchor: nil)
                                         }
                                     }
@@ -120,10 +120,10 @@ struct NoteComposer: View {
                             }
                         }
                         .onChange(of: geometry.size.height) { _, newValue in
-                            scrollViewHeight = newValue 
+                            scrollViewHeight = newValue
                         }
                     }
-                    
+
                     composerActionBar
                 }
                 .onChange(of: showNotePreview) { _, newValue in
@@ -203,8 +203,7 @@ struct NoteComposer: View {
             .navigationBarItems(
                 leading: Button {
                     isPresented = false
-                }
-                label: {
+                } label: {
                     Text(.localizable.cancel)
                         .foregroundColor(.primaryTxt)
                 },
@@ -264,39 +263,47 @@ struct NoteComposer: View {
 
     private func postAction() async {
         guard currentUser.keyPair != nil, let author = currentUser.author else {
-            alert = AlertState(title: {
-                TextState(String(localized: .localizable.error))
-            }, message: {
-                TextState(String(localized: .localizable.youNeedToEnterAPrivateKeyBeforePosting))
-            })
+            alert = AlertState(
+                title: {
+                    TextState(String(localized: .localizable.error))
+                },
+                message: {
+                    TextState(String(localized: .localizable.youNeedToEnterAPrivateKeyBeforePosting))
+                })
             return
         }
         if let relay = selectedRelay {
             guard expirationTime == nil || relay.supportedNIPs?.contains(40) == true else {
-                alert = AlertState(title: {
-                    TextState(String(localized: .localizable.error))
-                }, message: {
-                    TextState(String(localized: .localizable.relayDoesNotSupportNIP40))
-                })
+                alert = AlertState(
+                    title: {
+                        TextState(String(localized: .localizable.error))
+                    },
+                    message: {
+                        TextState(String(localized: .localizable.relayDoesNotSupportNIP40))
+                    })
                 return
             }
         } else if expirationTime != nil {
             do {
                 let relays = try await Relay.find(supporting: 40, for: author, context: viewContext)
                 if relays.isEmpty {
-                    alert = AlertState(title: {
-                        TextState(String(localized: .localizable.error))
-                    }, message: {
-                        TextState(String(localized: .localizable.anyRelaysSupportingNIP40))
-                    })
+                    alert = AlertState(
+                        title: {
+                            TextState(String(localized: .localizable.error))
+                        },
+                        message: {
+                            TextState(String(localized: .localizable.anyRelaysSupportingNIP40))
+                        })
                     return
                 }
             } catch {
-                alert = AlertState(title: {
-                    TextState(String(localized: .localizable.error))
-                }, message: {
-                    TextState(error.localizedDescription)
-                })
+                alert = AlertState(
+                    title: {
+                        TextState(String(localized: .localizable.error))
+                    },
+                    message: {
+                        TextState(error.localizedDescription)
+                    })
                 return
             }
         }
@@ -305,12 +312,12 @@ struct NoteComposer: View {
         }
         isPresented = false
     }
-    
+
     private func loadQuotedNote() {
         guard let quotedNoteID else {
             return
         }
-        
+
         quotedNote = try? Event.findOrCreateStubBy(
             id: quotedNoteID,
             context: persistenceController.viewContext
@@ -320,7 +327,7 @@ struct NoteComposer: View {
     private var isPostEnabled: Bool {
         !isUploadingImage && (!editingController.isEmpty || quotedNote?.bech32NoteID.isEmptyOrNil == false)
     }
-    
+
     private var postText: AttributedString {
         var text = editingController.text ?? ""
         if let noteLink = quotedNote?.bech32NoteID {

--- a/Nos/Views/NoteComposer/NoteUITextViewRepresentable.swift
+++ b/Nos/Views/NoteComposer/NoteUITextViewRepresentable.swift
@@ -4,22 +4,22 @@ import UIKit
 
 extension NoteTextEditor {
     /// A UIViewRepresentable that wraps a UITextView and configures it for composing a Nostr note. The UITextView works
-    /// with the provided `NoteEditorController` to interface with other SwiftUI views, supporting autocomplete of 
+    /// with the provided `NoteEditorController` to interface with other SwiftUI views, supporting autocomplete of
     /// mentions, dynamic sizing, appending uploaded file URLs, etc.
-    /// 
-    /// This view is designed to be used inside `NoteTextEditor`.  
+    ///
+    /// This view is designed to be used inside `NoteTextEditor`.
     struct NoteUITextViewRepresentable: UIViewRepresentable {
-        
+
         @State var width: CGFloat
-        
+
         /// Whether we should present the keyboard when this view is shown. Unfortunately we can't rely on FocusState as
         /// it isn't working on macOS.
         private var showKeyboard: Bool
-        
+
         private var font = UIFont.preferredFont(forTextStyle: .body)
-        
+
         private var controller: NoteEditorController
-        
+
         init(
             controller: NoteEditorController,
             showKeyboard: Bool = false
@@ -28,7 +28,7 @@ extension NoteTextEditor {
             self.showKeyboard = showKeyboard
             _width = .init(initialValue: 0)
         }
-        
+
         func makeUIView(context: Context) -> UITextView {
             let view = UITextView(usingTextLayoutManager: false)
             view.isUserInteractionEnabled = true
@@ -44,41 +44,42 @@ extension NoteTextEditor {
             view.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
             view.typingAttributes = [
                 .font: font,
-                .foregroundColor: UIColor.primaryTxt
+                .foregroundColor: UIColor.primaryTxt,
             ]
-            
+
             if ProcessInfo.processInfo.isiOSAppOnMac {
                 view.autocorrectionType = .no
             }
-            
+
             if showKeyboard {
                 Task {
                     try await Task.sleep(for: .milliseconds(200))
                     view.becomeFirstResponder()
                 }
             }
-            
+
             controller.textView = view
-            
+
             return view
         }
-        
+
         func updateUIView(_ uiView: UITextView, context: Context) {
             controller.updateIntrinsicHeight(view: uiView)
         }
-        
+
         func sizeThatFits(_ proposal: ProposedViewSize, uiView: UITextView, context: Context) -> CGSize? {
             if width != uiView.frame.size.width {
-                DispatchQueue.main.async { // call in next render cycle.
+                DispatchQueue.main.async {  // call in next render cycle.
                     width = uiView.frame.size.width
                     controller.updateIntrinsicHeight(view: uiView)
                 }
             } else if width == 0,
-                uiView.frame.size.width == 0, 
-                let proposedWidth = proposal.width, 
+                uiView.frame.size.width == 0,
+                let proposedWidth = proposal.width,
                 proposedWidth > 0,
-                proposedWidth < CGFloat.infinity {
-                DispatchQueue.main.async { // call in next render cycle.
+                proposedWidth < CGFloat.infinity
+            {
+                DispatchQueue.main.async {  // call in next render cycle.
                     uiView.frame.size.width = proposedWidth
                     controller.updateIntrinsicHeight(view: uiView)
                 }

--- a/Nos/Views/NoteComposer/ReplyPreview.swift
+++ b/Nos/Views/NoteComposer/ReplyPreview.swift
@@ -1,11 +1,11 @@
 import SwiftUI
 
-/// This is a component of `NoteComposer` that displays a preview of the note being replied to. 
+/// This is a component of `NoteComposer` that displays a preview of the note being replied to.
 struct ReplyPreview: View {
-    
+
     var note: Event
     @Environment(CurrentUser.self) var currentUser
-    
+
     var body: some View {
         VStack(spacing: 8) {
             HStack {
@@ -19,10 +19,10 @@ struct ReplyPreview: View {
             }
             .padding(.horizontal, 24)
             .padding(.top, 24)
-            
+
             CompactNoteView(note: note, shouldTruncate: false, showLinkPreviews: false, allowUserInteraction: false)
                 .padding(.horizontal, 9)
-            
+
             HStack {
                 AvatarView(imageUrl: currentUser.author?.profilePhotoURL, size: 30)
                 Text(currentUser.author?.safeName ?? "")
@@ -39,7 +39,7 @@ struct ReplyPreview: View {
 
 #Preview {
     var previewData = PreviewData()
-    
+
     return ReplyPreview(note: previewData.longNote)
         .background(Color.appBg)
         .inject(previewData: previewData)

--- a/Nos/Views/Onboarding/BuildYourNetworkView.swift
+++ b/Nos/Views/Onboarding/BuildYourNetworkView.swift
@@ -4,7 +4,7 @@ import SwiftUI
 struct BuildYourNetworkView: View {
     /// The action to perform when the user taps the Find people button.
     let completion: @MainActor () -> Void
-    
+
     /// The padding around most of the views here -- the text and button -- but not the image.
     private let padding: CGFloat = 40
 

--- a/Nos/Views/Onboarding/OnboardingAgeVerificationView.swift
+++ b/Nos/Views/Onboarding/OnboardingAgeVerificationView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 struct OnboardingAgeVerificationView: View {
     @EnvironmentObject var state: OnboardingState
-    
+
     var body: some View {
         VStack {
             Text(.localizable.ageVerificationTitle)

--- a/Nos/Views/Onboarding/OnboardingLoginView.swift
+++ b/Nos/Views/Onboarding/OnboardingLoginView.swift
@@ -1,18 +1,18 @@
-import SwiftUI
 import Dependencies
 import Logger
+import SwiftUI
 
 struct OnboardingLoginView: View {
     let completion: @MainActor () -> Void
-    
+
     @Dependency(\.analytics) private var analytics
     @Environment(CurrentUser.self) var currentUser
-    
+
     @Environment(\.managedObjectContext) private var viewContext
-    
+
     @State var privateKeyString = ""
     @State var showError = false
-    
+
     @MainActor func importKey(_ keyPair: KeyPair) async {
         await currentUser.setKeyPair(keyPair)
         analytics.importedKey()
@@ -29,7 +29,7 @@ struct OnboardingLoginView: View {
 
         completion()
     }
-    
+
     var body: some View {
         VStack {
             Form {

--- a/Nos/Views/Onboarding/OnboardingNotOldEnoughView.swift
+++ b/Nos/Views/Onboarding/OnboardingNotOldEnoughView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 struct OnboardingNotOldEnoughView: View {
     @EnvironmentObject var state: OnboardingState
-    
+
     var body: some View {
         VStack {
             Text(.localizable.notOldEnoughTitle)

--- a/Nos/Views/Onboarding/OnboardingStartView.swift
+++ b/Nos/Views/Onboarding/OnboardingStartView.swift
@@ -1,10 +1,10 @@
-import SwiftUI
 import Dependencies
+import SwiftUI
 
 struct OnboardingStartView: View {
     @EnvironmentObject var state: OnboardingState
     @Dependency(\.analytics) private var analytics
-    
+
     var body: some View {
         VStack {
             Image.nosLogo

--- a/Nos/Views/Onboarding/OnboardingTermsOfServiceView.swift
+++ b/Nos/Views/Onboarding/OnboardingTermsOfServiceView.swift
@@ -6,10 +6,10 @@ struct OnboardingTermsOfServiceView: View {
     @Environment(CurrentUser.self) var currentUser
 
     @Dependency(\.crashReporting) private var crashReporting
-    
+
     /// Completion to be called when all onboarding steps are complete
     let completion: @MainActor () -> Void
-    
+
     var body: some View {
         VStack {
             Text(.localizable.termsOfServiceTitle)
@@ -64,10 +64,10 @@ struct OnboardingTermsOfServiceView: View {
 
 // swiftlint:disable line_length
 // We don't localize these for legal reasons
-fileprivate let termsOfService = """
+private let termsOfService = """
     Summary
     This top section summarizes the terms below. This summary is provided to help your understanding of the terms, but be sure to read the entire document, because when you agree to it, you are indicating you accept all of the terms, not just this summary.
-    
+
     Nos cloud services (the "Services") are a suite of services provided to you by Verse Communications Inc.
     The Services are provided "as is" and there are no warranties of any kind. There are significant limits on Verse's liability for any damages arising from your use of the Services.
     Terms of Service
@@ -147,5 +147,5 @@ fileprivate let termsOfService = """
 
     help@nos.social
     """
-    
+
 // swiftlint:enable line_length

--- a/Nos/Views/Onboarding/OnboardingView.swift
+++ b/Nos/Views/Onboarding/OnboardingView.swift
@@ -1,6 +1,6 @@
-import SwiftUI
 import Dependencies
 import Logger
+import SwiftUI
 
 class OnboardingState: ObservableObject {
     @Published var flow: OnboardingFlow = .createAccount
@@ -28,10 +28,10 @@ enum OnboardingStep {
 
 struct OnboardingView: View {
     @StateObject var state = OnboardingState()
-    
+
     /// Completion to be called when all onboarding steps are complete
     let completion: @MainActor () -> Void
-    
+
     var body: some View {
         NavigationStack(path: $state.path) {
             OnboardingStartView()

--- a/Nos/Views/Profile/Edit/CreateUsernameWizard/AlreadyHaveANIP05View.swift
+++ b/Nos/Views/Profile/Edit/CreateUsernameWizard/AlreadyHaveANIP05View.swift
@@ -124,7 +124,7 @@ struct AlreadyHaveANIP05View: View {
     }
 }
 
-fileprivate class UsernameObserver: ObservableObject {
+private class UsernameObserver: ObservableObject {
 
     @Published
     var debouncedText = ""
@@ -146,7 +146,7 @@ fileprivate class UsernameObserver: ObservableObject {
     }
 }
 
-fileprivate struct UsernameTextField: View {
+private struct UsernameTextField: View {
 
     @StateObject var usernameObserver: UsernameObserver
     @FocusState private var usernameFieldIsFocused: Bool

--- a/Nos/Views/Profile/Edit/CreateUsernameWizard/ClaimYourUniqueIdentitySheet.swift
+++ b/Nos/Views/Profile/Edit/CreateUsernameWizard/ClaimYourUniqueIdentitySheet.swift
@@ -23,7 +23,7 @@ struct ClaimYourUniqueIdentitySheet: View {
             }
             .frame(maxWidth: .infinity)
             .padding(.vertical, 10)
-            
+
             Spacer(minLength: 20)
         }
     }

--- a/Nos/Views/Profile/Edit/CreateUsernameWizard/ExcellentChoiceSheet.swift
+++ b/Nos/Views/Profile/Edit/CreateUsernameWizard/ExcellentChoiceSheet.swift
@@ -119,7 +119,7 @@ struct ExcellentChoiceSheet: View {
                 analytics.registeredNIP05Username()
             } catch {
                 Log.error(error.localizedDescription)
-                
+
                 // Do our best reverting the changes.
                 currentUser.author?.nip05 = oldNIP05
                 try? currentUser.viewContext.saveIfNeeded()

--- a/Nos/Views/Profile/Edit/CreateUsernameWizard/PickYourUsernameSheet.swift
+++ b/Nos/Views/Profile/Edit/CreateUsernameWizard/PickYourUsernameSheet.swift
@@ -114,7 +114,7 @@ struct PickYourUsernameSheet: View {
     }
 }
 
-fileprivate class UsernameObserver: ObservableObject {
+private class UsernameObserver: ObservableObject {
 
     @Published
     var debouncedText = ""
@@ -136,7 +136,7 @@ fileprivate class UsernameObserver: ObservableObject {
     }
 }
 
-fileprivate struct UsernameTextField: View {
+private struct UsernameTextField: View {
 
     @StateObject var usernameObserver: UsernameObserver
     @FocusState private var usernameFieldIsFocused: Bool

--- a/Nos/Views/Profile/Edit/DeleteUsernameWizard/ConfirmUsernameDeletionSheet.swift
+++ b/Nos/Views/Profile/Edit/DeleteUsernameWizard/ConfirmUsernameDeletionSheet.swift
@@ -9,7 +9,7 @@ struct ConfirmUsernameDeletionSheet: View {
 
     @Environment(CurrentUser.self) private var currentUser
     @Environment(\.managedObjectContext) private var viewContext
-    
+
     @Dependency(\.crashReporting) private var crashReporting
     @Dependency(\.namesAPI) private var namesAPI
     @Dependency(\.analytics) private var analytics
@@ -124,7 +124,7 @@ struct ConfirmUsernameDeletionSheet: View {
 }
 
 /// The current state of the delete request.
-fileprivate enum DeleteState {
+private enum DeleteState {
     /// There is no request in progress yet
     case idle
 
@@ -151,7 +151,7 @@ fileprivate enum DeleteState {
     }
 }
 
-fileprivate enum DeleteError: LocalizedError {
+private enum DeleteError: LocalizedError {
     case notLoggedIn
     case unableToDelete(Error)
 

--- a/Nos/Views/Profile/Edit/ProfileEditView.swift
+++ b/Nos/Views/Profile/Edit/ProfileEditView.swift
@@ -9,7 +9,7 @@ struct EditProfileDestination: Hashable {
 }
 
 struct ProfileEditView: View {
-    
+
     @EnvironmentObject private var router: Router
     @Environment(CurrentUser.self) private var currentUser
     @Environment(\.managedObjectContext) private var viewContext
@@ -17,7 +17,7 @@ struct ProfileEditView: View {
     @Dependency(\.crashReporting) private var crashReporting
 
     @ObservedObject var author: Author
-    
+
     @State private var displayNameText: String = ""
     @State private var bioText: String = ""
     @State private var avatarText: String = ""
@@ -28,10 +28,10 @@ struct ProfileEditView: View {
     @State private var unsController = UNSWizardController()
     @State private var showConfirmationDialog = false
     @State private var saveError: SaveError?
-    
+
     @State private var isUploadingPhoto = false
     @State private var alert: AlertState<AlertAction>?
-    
+
     fileprivate enum AlertAction {}
 
     private var showAlert: Binding<Bool> {
@@ -44,7 +44,7 @@ struct ProfileEditView: View {
 
     var body: some View {
         let avatarSize: CGFloat = 99
-        
+
         NosForm {
             EditableAvatarView(
                 size: avatarSize,
@@ -52,14 +52,14 @@ struct ProfileEditView: View {
                 isUploadingPhoto: $isUploadingPhoto
             )
             .padding(.top, 16)
-            
+
             NosFormSection(label: .localizable.profilePicture) {
                 NosTextField(label: .localizable.url, text: $avatarText)
                     #if os(iOS)
-                    .keyboardType(.URL)
+                        .keyboardType(.URL)
                     #endif
             }
-            
+
             NosFormSection(label: .localizable.basicInfo) {
                 NosTextField(label: .localizable.displayName, text: $displayNameText)
                 FormSeparator()
@@ -70,7 +70,7 @@ struct ProfileEditView: View {
                     )
                 } else if let nip05 = author.nip05, !nip05.isEmpty {
                     NIP05Field(
-                        nip05: nip05, 
+                        nip05: nip05,
                         showConfirmationDialog: $showConfirmationDialog
                     )
                 } else {
@@ -84,17 +84,17 @@ struct ProfileEditView: View {
                 FormSeparator()
                 NosTextField(label: .localizable.website, text: $website)
             }
-            
+
             HStack {
                 Text(.localizable.identityVerification)
                     .font(.clarity(.semibold, textStyle: .headline))
                     .foregroundColor(.primaryTxt)
                     .padding(.top, 16)
-                
+
                 Spacer()
             }
             .padding(.horizontal, 13)
-            
+
             if unsText.isEmpty {
                 SetUpUNSBanner(
                     text: .localizable.unsTagline,
@@ -109,9 +109,12 @@ struct ProfileEditView: View {
                 }
             }
         }
-        .sheet(isPresented: $showUniversalNameWizard, content: {
-            UNSWizard(controller: unsController, isPresented: $showUniversalNameWizard)
-        })
+        .sheet(
+            isPresented: $showUniversalNameWizard,
+            content: {
+                UNSWizard(controller: unsController, isPresented: $showUniversalNameWizard)
+            }
+        )
         .sheet(isPresented: $showNIP05Wizard) {
             CreateUsernameWizard(isPresented: $showNIP05Wizard)
         }
@@ -125,7 +128,7 @@ struct ProfileEditView: View {
             if !newValue {
                 unsText = currentUser.author?.uns ?? ""
                 unsController = UNSWizardController()
-                author.willChangeValue(for: \Author.uns) // Trigger ProfileView to load USBC balance
+                author.willChangeValue(for: \Author.uns)  // Trigger ProfileView to load USBC balance
             }
         }
         .scrollContentBackground(.hidden)
@@ -133,9 +136,11 @@ struct ProfileEditView: View {
         .nosNavigationBar(title: .localizable.profileTitle)
         .navigationBarBackButtonHidden()
         .navigationBarItems(
-            leading: Button(String(localized: .localizable.cancel), action: { 
-                router.pop()
-            }),
+            leading: Button(
+                String(localized: .localizable.cancel),
+                action: {
+                    router.pop()
+                }),
             trailing:
                 ActionButton(title: .localizable.done) {
                     await save()
@@ -172,7 +177,7 @@ struct ProfileEditView: View {
         website = author.website ?? ""
         unsText = author.uns ?? ""
     }
-    
+
     private func save() async {
         author.displayName = displayNameText
         author.about = bioText
@@ -208,8 +213,8 @@ struct ProfileEditView: View {
     }
 }
 
-fileprivate struct NosNIP05Field: View {
-    
+private struct NosNIP05Field: View {
+
     var username: String
     @Binding var showConfirmationDialog: Bool
 
@@ -232,7 +237,7 @@ fileprivate struct NosNIP05Field: View {
                                 LinearGradient(
                                     colors: [
                                         Color.nip05FieldFgGradientTop,
-                                        Color.nip05FieldFgGradientBottom
+                                        Color.nip05FieldFgGradientBottom,
                                     ],
                                     startPoint: .top,
                                     endPoint: .bottom
@@ -245,27 +250,24 @@ fileprivate struct NosNIP05Field: View {
                     }
                 }
                 .padding(.vertical, 15)
-                (
-                    Text(Image(systemName: "exclamationmark.triangle"))
-                        .foregroundStyle(Color.nip05FieldTextForeground) +
-                    Text(" ") +
-                    Text(.localizable.usernameWarningMessage)
-                        .foregroundStyle(Color.secondaryTxt)
-                )
-                .font(.footnote)
-                .multilineTextAlignment(.leading)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .fixedSize(horizontal: false, vertical: true)
+                (Text(Image(systemName: "exclamationmark.triangle"))
+                    .foregroundStyle(Color.nip05FieldTextForeground) + Text(" ")
+                    + Text(.localizable.usernameWarningMessage)
+                    .foregroundStyle(Color.secondaryTxt))
+                    .font(.footnote)
+                    .multilineTextAlignment(.leading)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .fixedSize(horizontal: false, vertical: true)
             }
         }
     }
 }
 
-fileprivate struct NIP05Field: View {
+private struct NIP05Field: View {
 
     var nip05: String
     @Binding var showConfirmationDialog: Bool
-    
+
     var body: some View {
         NosFormField(
             label: .localizable.username
@@ -283,7 +285,7 @@ fileprivate struct NIP05Field: View {
                                 LinearGradient(
                                     colors: [
                                         Color.nip05FieldFgGradientTop,
-                                        Color.nip05FieldFgGradientBottom
+                                        Color.nip05FieldFgGradientBottom,
                                     ],
                                     startPoint: .top,
                                     endPoint: .bottom
@@ -296,23 +298,20 @@ fileprivate struct NIP05Field: View {
                     }
                 }
                 .padding(.vertical, 15)
-                (
-                    Text(Image(systemName: "exclamationmark.triangle"))
-                        .foregroundStyle(Color.nip05FieldTextForeground) +
-                    Text(" ") +
-                    Text(.localizable.usernameWarningMessage)
-                        .foregroundStyle(Color.secondaryTxt)
-                )
-                .font(.footnote)
-                .multilineTextAlignment(.leading)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .fixedSize(horizontal: false, vertical: true)
+                (Text(Image(systemName: "exclamationmark.triangle"))
+                    .foregroundStyle(Color.nip05FieldTextForeground) + Text(" ")
+                    + Text(.localizable.usernameWarningMessage)
+                    .foregroundStyle(Color.secondaryTxt))
+                    .font(.footnote)
+                    .multilineTextAlignment(.leading)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .fixedSize(horizontal: false, vertical: true)
             }
         }
     }
 }
 
-fileprivate struct NosNIP05Banner: View {
+private struct NosNIP05Banner: View {
 
     @Binding var showNIP05Wizard: Bool
 
@@ -332,7 +331,7 @@ fileprivate struct NosNIP05Banner: View {
 }
 
 struct ProfileEditView_Previews: PreviewProvider {
-    
+
     static var previewData = PreviewData()
 
     static var previews: some View {

--- a/Nos/Views/Profile/FollowsView.swift
+++ b/Nos/Views/Profile/FollowsView.swift
@@ -39,10 +39,10 @@ struct FollowsView: View {
                         .readabilityPadding()
                         .task {
                             subscriptions[author.id] =
-                            await relayService.requestMetadata(
-                                for: author.hexadecimalPublicKey,
-                                since: author.lastUpdatedMetadata
-                            )
+                                await relayService.requestMetadata(
+                                    for: author.hexadecimalPublicKey,
+                                    since: author.lastUpdatedMetadata
+                                )
                         }
                     }
                 }

--- a/Nos/Views/Profile/MutesView.swift
+++ b/Nos/Views/Profile/MutesView.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-struct MutesDestination: Hashable { }
+struct MutesDestination: Hashable {}
 
 struct MutesView: View {
     @FetchRequest

--- a/Nos/Views/Profile/ProfileFeedType.swift
+++ b/Nos/Views/Profile/ProfileFeedType.swift
@@ -4,20 +4,20 @@ import CoreData
 enum ProfileFeedType {
     case activity
     case notes
-    
+
     func databaseFilter(author: Author, before date: Date) -> NSFetchRequest<Event> {
         author.allPostsRequest(before: date, onlyRootPosts: self == .notes)
     }
-    
+
     func relayFilter(author: Author) -> Filter {
         var kinds: [EventKind]
         switch self {
         case .activity:
-            kinds = [.text, .delete, .repost, .longFormContent] 
+            kinds = [.text, .delete, .repost, .longFormContent]
         case .notes:
             kinds = [.text, .delete]
         }
-        
+
         return Filter(authorKeys: [author.hexadecimalPublicKey ?? "error"], kinds: kinds)
     }
 }

--- a/Nos/Views/Profile/ProfileHeader.swift
+++ b/Nos/Views/Profile/ProfileHeader.swift
@@ -1,6 +1,6 @@
-import SwiftUI
 import CoreData
 import Logger
+import SwiftUI
 
 struct ProfileHeader: View {
     @ObservedObject var author: Author
@@ -14,11 +14,11 @@ struct ProfileHeader: View {
 
     var followersRequest: FetchRequest<Follow>
     var followersResult: FetchedResults<Follow> { followersRequest.wrappedValue }
-    
+
     var followers: Followed {
         followersResult.map { $0 }
     }
-    
+
     @EnvironmentObject private var router: Router
 
     init(author: Author, selectedTab: Binding<ProfileFeedType>) {
@@ -40,9 +40,8 @@ struct ProfileHeader: View {
             guard let source = $0.source else {
                 return false
             }
-            return source.hasHumanFriendlyName == true &&
-                source != author &&
-                (currentUser.isFollowing(author: source) || currentUser.isBeingFollowedBy(author: source))
+            return source.hasHumanFriendlyName == true && source != author
+                && (currentUser.isFollowing(author: source) || currentUser.isBeingFollowedBy(author: source))
         }
     }
 
@@ -270,7 +269,7 @@ struct ProfileHeader: View {
 
 #Preview {
     var previewData = PreviewData()
-    
+
     return Group {
         // ProfileHeader(author: author)
         ProfileHeader(author: previewData.previewAuthor, selectedTab: .constant(.activity))
@@ -291,8 +290,9 @@ struct ProfileHeader: View {
         author.name = "Sebastian Heit"
         author.nip05 = "chardot@nostr.fan"
         // author.uns = "chardot"
-        author.about = "Go programmer working on Nos/Planetary. You can find me at various European events related to" +
-        " Chaos Computer Club, the hacker community and free software."
+        author.about =
+            "Go programmer working on Nos/Planetary. You can find me at various European events related to"
+            + " Chaos Computer Club, the hacker community and free software."
         let first = Author(context: previewContext)
         first.name = "Craig Nichols"
 
@@ -311,7 +311,7 @@ struct ProfileHeader: View {
 
         return author
     }
-    
+
     return Group {
         ProfileHeader(author: author, selectedTab: .constant(.activity))
     }
@@ -323,7 +323,7 @@ struct ProfileHeader: View {
 
 #Preview("UNS") {
     var previewData = PreviewData()
-    
+
     return Group {
         ProfileHeader(author: previewData.unsAuthor, selectedTab: .constant(.activity))
             .inject(previewData: previewData)

--- a/Nos/Views/Profile/ProfileTab.swift
+++ b/Nos/Views/Profile/ProfileTab.swift
@@ -3,10 +3,10 @@ import SwiftUI
 
 /// A version of the ProfileView that is displayed in the main tab bar
 struct ProfileTab: View {
-    
+
     @Environment(CurrentUser.self) var currentUser
     @ObservedObject var author: Author
-    
+
     @Binding var path: NavigationPath
 
     var body: some View {

--- a/Nos/Views/Profile/ProfileView.swift
+++ b/Nos/Views/Profile/ProfileView.swift
@@ -1,11 +1,11 @@
-import SwiftUI
 import CoreData
 import Dependencies
-import SwiftUINavigation
 import Logger
+import SwiftUI
+import SwiftUINavigation
 
 struct ProfileView: View {
-    
+
     @ObservedObject var author: Author
     var addDoubleTapToPop = false
 
@@ -39,20 +39,20 @@ struct ProfileView: View {
 
     func downloadAuthorData() async {
         relaySubscriptions.removeAll()
-        
+
         guard let authorKey = author.hexadecimalPublicKey else {
             return
         }
-        
+
         // Profile data
         relaySubscriptions.append(
             await relayService.requestProfileData(
-                for: authorKey, 
-                lastUpdateMetadata: author.lastUpdatedMetadata, 
-                lastUpdatedContactList: nil // always grab contact list because we purge follows aggressively
+                for: authorKey,
+                lastUpdateMetadata: author.lastUpdatedMetadata,
+                lastUpdatedContactList: nil  // always grab contact list because we purge follows aggressively
             )
         )
-        
+
         // reports
         let reportFilter = Filter(
             kinds: [.report],
@@ -65,9 +65,10 @@ struct ProfileView: View {
     }
 
     private var title: AttributedString {
-        let prefix = isShowingLoggedInUser ?
-            String(localized: LocalizedStringResource.localizable.yourProfile) :
-            String(localized: LocalizedStringResource.localizable.profileTitle)
+        let prefix =
+            isShowingLoggedInUser
+            ? String(localized: LocalizedStringResource.localizable.yourProfile)
+            : String(localized: LocalizedStringResource.localizable.profileTitle)
         if author.muted {
             let suffix = "(\(String(localized: .localizable.muted).lowercased()))"
             var attributedString = AttributedString("\(prefix) \(suffix)")
@@ -89,7 +90,7 @@ struct ProfileView: View {
                     relayFilter: selectedTab.relayFilter(author: author),
                     relay: nil,
                     managedObjectContext: viewContext,
-                    tab: .profile, 
+                    tab: .profile,
                     header: {
                         ProfileHeader(author: author, selectedTab: $selectedTab)
                             .compositingGroup()
@@ -100,7 +101,7 @@ struct ProfileView: View {
                             Text(.localizable.noEventsOnProfile)
                                 .padding()
                                 .readabilityPadding()
-                            
+
                             SecondaryActionButton(title: .localizable.tapToRefresh) {
                                 refreshController.startRefresh = true
                             }
@@ -179,11 +180,13 @@ struct ProfileView: View {
                                         do {
                                             try await author.unmute(viewContext: viewContext)
                                         } catch {
-                                            alert = AlertState(title: {
-                                                TextState(String(localized: .localizable.error))
-                                            }, message: {
-                                                TextState(error.localizedDescription)
-                                            })
+                                            alert = AlertState(
+                                                title: {
+                                                    TextState(String(localized: .localizable.error))
+                                                },
+                                                message: {
+                                                    TextState(error.localizedDescription)
+                                                })
                                         }
                                     }
                                 }
@@ -193,16 +196,18 @@ struct ProfileView: View {
                                         do {
                                             try await author.mute(viewContext: viewContext)
                                         } catch {
-                                            alert = AlertState(title: {
-                                                TextState(String(localized: .localizable.error))
-                                            }, message: {
-                                                TextState(error.localizedDescription)
-                                            })
+                                            alert = AlertState(
+                                                title: {
+                                                    TextState(String(localized: .localizable.error))
+                                                },
+                                                message: {
+                                                    TextState(error.localizedDescription)
+                                                })
                                         }
                                     }
                                 }
                             }
-                            
+
                             Button(String(localized: .localizable.flagUser)) {
                                 showingReportMenu = true
                             }
@@ -212,7 +217,7 @@ struct ProfileView: View {
         )
         .alert(unwrapping: $alert)
         .onAppear {
-            Task { 
+            Task {
                 await downloadAuthorData()
             }
             analytics.showedProfile()
@@ -225,7 +230,7 @@ struct ProfileView: View {
 
 #Preview("Generic user") {
     var previewData = PreviewData()
-    
+
     return NavigationStack {
         ProfileView(author: previewData.previewAuthor)
     }
@@ -234,7 +239,7 @@ struct ProfileView: View {
 
 #Preview("UNS") {
     var previewData = PreviewData()
-    
+
     return NavigationStack {
         ProfileView(author: previewData.eve)
     }
@@ -242,15 +247,15 @@ struct ProfileView: View {
 }
 
 #Preview("Logged in User") {
-    
-    @Dependency(\.persistenceController) var persistenceController 
-    
+
+    @Dependency(\.persistenceController) var persistenceController
+
     lazy var previewContext: NSManagedObjectContext = {
-        persistenceController.viewContext  
+        persistenceController.viewContext
     }()
-    
+
     var previewData = PreviewData(currentUserKey: KeyFixture.eve)
-    
+
     return NavigationStack {
         ProfileView(author: previewData.eve)
     }

--- a/Nos/Views/Relay/RelayDetailView.swift
+++ b/Nos/Views/Relay/RelayDetailView.swift
@@ -56,10 +56,10 @@ struct RelayDetailView: View {
                     .font(.clarity(.bold))
             } footer: {
                 #if DEBUG
-                if let date = relay.metadataFetchedAt {
-                    Text("\(String(localized: .localizable.fetchedAt)): \(date.distanceString())")
-                        .font(.clarity(.regular))
-                }
+                    if let date = relay.metadataFetchedAt {
+                        Text("\(String(localized: .localizable.fetchedAt)): \(date.distanceString())")
+                            .font(.clarity(.regular))
+                    }
                 #endif
             }
             .listRowGradientBackground()
@@ -74,7 +74,7 @@ struct RelayDetailView_Previews: PreviewProvider {
     static var previewContext = PersistenceController.preview.viewContext
     static var relay: Relay {
         do {
-            return try Relay.findOrCreate(by: "wss://example.com", context: previewContext) 
+            return try Relay.findOrCreate(by: "wss://example.com", context: previewContext)
         } catch {
             return Relay(context: previewContext)
         }

--- a/Nos/Views/Relay/RelayView.swift
+++ b/Nos/Views/Relay/RelayView.swift
@@ -1,6 +1,6 @@
-import SwiftUI
 import CoreData
 import Dependencies
+import SwiftUI
 import SwiftUINavigation
 
 struct RelaysDestination: Hashable {
@@ -13,14 +13,14 @@ struct RelayView: View {
     @EnvironmentObject private var relayService: RelayService
     @Environment(CurrentUser.self) private var currentUser
     @ObservedObject var author: Author
-    
+
     @State var newRelayAddress: String = ""
-    
+
     @State private var alert: AlertState<Never>?
-    
+
     @Dependency(\.analytics) private var analytics
     @Dependency(\.crashReporting) private var crashReporting
-    
+
     @FetchRequest var relays: FetchedResults<Relay>
 
     private var sortedRelays: [Relay] {
@@ -30,13 +30,13 @@ struct RelayView: View {
     }
 
     var editable: Bool
-    
+
     init(author: Author, editable: Bool = true) {
         self.author = author
         self.editable = editable
         _relays = FetchRequest(fetchRequest: Relay.relays(for: author))
     }
-    
+
     var body: some View {
         List {
             Section {
@@ -82,7 +82,7 @@ struct RelayView: View {
                         }
                     }
                 }
-                
+
                 if author.relays.count == 0, editable {
                     Text(.localizable.noRelaysMessage)
                 }
@@ -98,7 +98,7 @@ struct RelayView: View {
             }
             .deleteDisabled(!editable)
             .listRowGradientBackground()
-            
+
             let authorRelayUrls = author.relays.compactMap { $0.address }
             let recommendedRelays = Relay.recommended
                 .filter { !authorRelayUrls.contains($0) }
@@ -129,7 +129,7 @@ struct RelayView: View {
                 }
                 .listRowGradientBackground()
             }
-            
+
             if editable {
                 Section {
                     HStack {
@@ -137,8 +137,8 @@ struct RelayView: View {
                             .foregroundColor(.primaryTxt)
                             .autocorrectionDisabled()
                             #if os(iOS)
-                            .textInputAutocapitalization(.never)
-                            .keyboardType(.URL)
+                                .textInputAutocapitalization(.never)
+                                .keyboardType(.URL)
                             #endif
                         SecondaryActionButton(title: .localizable.save) {
                             addRelay()
@@ -165,9 +165,9 @@ struct RelayView: View {
         .toolbar {
             if editable {
                 #if os(iOS)
-                ToolbarItem(placement: .navigationBarTrailing) {
-                    EditButton()
-                }
+                    ToolbarItem(placement: .navigationBarTrailing) {
+                        EditButton()
+                    }
                 #endif
             }
         }
@@ -176,7 +176,7 @@ struct RelayView: View {
             analytics.showedRelays()
         }
     }
-    
+
     func publishChanges() async {
         let followKeys = await Array(currentUser.socialGraph.followedKeys)
         await currentUser.publishContactList(tags: followKeys.pTags)
@@ -185,7 +185,7 @@ struct RelayView: View {
     private func addRelay() {
         withAnimation {
             guard !newRelayAddress.isEmpty else { return }
-            
+
             do {
                 var address = newRelayAddress.lowercased().trimmingCharacters(in: .whitespacesAndNewlines)
                 if !address.starts(with: "wss://") {
@@ -203,21 +203,23 @@ struct RelayView: View {
                 } else {
                     errorMessage = .localizable.saveRelayError
                 }
-                alert = AlertState(title: {
-                    TextState(String(localized: .localizable.error))
-                }, message: {
-                    TextState(String(localized: errorMessage))
-                })
+                alert = AlertState(
+                    title: {
+                        TextState(String(localized: .localizable.error))
+                    },
+                    message: {
+                        TextState(String(localized: errorMessage))
+                    })
             }
         }
     }
 }
 
 struct RelayView_Previews: PreviewProvider {
-    
+
     static var previewData = PreviewData()
     static var previewContext = PersistenceController.preview.viewContext
-    
+
     static var emptyContext = PersistenceController.empty.viewContext
 
     static var user: Author {
@@ -225,7 +227,7 @@ struct RelayView_Previews: PreviewProvider {
         author.hexadecimalPublicKey = "d0a1ffb8761b974cec4a3be8cbcb2e96a7090dcf465ffeac839aa4ca20c9a59e"
         return author
     }
-    
+
     static var previews: some View {
         NavigationStack {
             RelayView(author: user)

--- a/Nos/Views/Settings/PublishedEventsView.swift
+++ b/Nos/Views/Settings/PublishedEventsView.swift
@@ -1,44 +1,44 @@
 #if DEBUG
-import SwiftUI
+    import SwiftUI
 
-/// Only used for debugging. Settings > All published events.
-struct PublishedEventsView: View {
+    /// Only used for debugging. Settings > All published events.
+    struct PublishedEventsView: View {
 
-    var author: Author
+        var author: Author
 
-    @FetchRequest
-    private var events: FetchedResults<Event>
+        @FetchRequest
+        private var events: FetchedResults<Event>
 
-    init(author: Author) {
-        self.author = author
-        _events = FetchRequest(fetchRequest: author.allEventsRequest())
-    }
-    var body: some View {
-        List {
-            ForEach(events) { event in
-                Section {
-                    Text("id: \(event.identifier ?? String(localized: .localizable.error))")
-                    Text("kind: \(event.kind)")
-                    Text("content: \(event.content ?? String(localized: .localizable.error))")
-                    if let tags = event.allTags as? [[String]] {
-                        ForEach(tags, id: \.self) { tag in
-                            Text("tag: \(tag.joined(separator: ", "))")
+        init(author: Author) {
+            self.author = author
+            _events = FetchRequest(fetchRequest: author.allEventsRequest())
+        }
+        var body: some View {
+            List {
+                ForEach(events) { event in
+                    Section {
+                        Text("id: \(event.identifier ?? String(localized: .localizable.error))")
+                        Text("kind: \(event.kind)")
+                        Text("content: \(event.content ?? String(localized: .localizable.error))")
+                        if let tags = event.allTags as? [[String]] {
+                            ForEach(tags, id: \.self) { tag in
+                                Text("tag: \(tag.joined(separator: ", "))")
+                            }
                         }
                     }
+                    .listRowGradientBackground()
                 }
-                .listRowGradientBackground()
             }
+            .scrollContentBackground(.hidden)
+            .background(Color.appBg)
+            .nosNavigationBar(title: .localizable.allPublishedEvents)
         }
-        .scrollContentBackground(.hidden)
-        .background(Color.appBg)
-        .nosNavigationBar(title: .localizable.allPublishedEvents)
     }
-}
 
-struct PublishedEventsView_Previews: PreviewProvider {
-    static var previewData = PreviewData()
-    static var previews: some View {
-        PublishedEventsView(author: previewData.previewAuthor)
+    struct PublishedEventsView_Previews: PreviewProvider {
+        static var previewData = PreviewData()
+        static var previews: some View {
+            PublishedEventsView(author: previewData.previewAuthor)
+        }
     }
-}
 #endif

--- a/Nos/Views/Settings/SettingsView.swift
+++ b/Nos/Views/Settings/SettingsView.swift
@@ -1,11 +1,11 @@
-import SwiftUI
 import Dependencies
 import Logger
+import SwiftUI
 import SwiftUINavigation
 
 let showReportWarningsKey = "com.verse.nos.settings.showReportWarnings"
 let showOutOfNetworkWarningKey = "com.verse.nos.settings.showOutOfNetworkWarning"
-    
+
 struct SettingsView: View {
     @Dependency(\.analytics) private var analytics
     @Dependency(\.crashReporting) private var crashReporting
@@ -82,7 +82,7 @@ struct SettingsView: View {
                     .fixedSize(horizontal: true, vertical: false)
                     .padding(.vertical, 5)
                 }
-                
+
                 ActionButton(title: .localizable.logout) {
                     alert = AlertState(
                         title: { TextState(String(localized: .localizable.logout)) },
@@ -93,7 +93,7 @@ struct SettingsView: View {
                         },
                         message: { TextState(String(localized: .localizable.backUpYourKeyWarning)) }
                     )
-                }        
+                }
                 .padding(.vertical, 5)
             } header: {
                 VStack(alignment: .leading, spacing: 10) {
@@ -111,14 +111,14 @@ struct SettingsView: View {
                 .padding(.bottom, 20)
             }
             .listRowGradientBackground()
-            
+
             Section {
                 VStack {
                     NosToggle(isOn: $showReportWarnings, labelText: .localizable.useReportsFromFollows)
-                    .onChange(of: showReportWarnings) { _, newValue in
-                        userDefaults.set(newValue, forKey: showReportWarningsKey)
-                    }
-                    
+                        .onChange(of: showReportWarnings) { _, newValue in
+                            userDefaults.set(newValue, forKey: showReportWarningsKey)
+                        }
+
                     HStack {
                         Text(.localizable.useReportsFromFollowsDescription)
                             .foregroundColor(.secondaryTxt)
@@ -130,10 +130,10 @@ struct SettingsView: View {
 
                 VStack {
                     NosToggle(isOn: $showOutOfNetworkWarning, labelText: .localizable.showOutOfNetworkWarnings)
-                    .onChange(of: showOutOfNetworkWarning) { _, newValue in
-                        userDefaults.set(newValue, forKey: showOutOfNetworkWarningKey)
-                    }
-                    
+                        .onChange(of: showOutOfNetworkWarning) { _, newValue in
+                            userDefaults.set(newValue, forKey: showOutOfNetworkWarningKey)
+                        }
+
                     HStack {
                         Text(.localizable.showOutOfNetworkWarningsDescription)
                             .foregroundColor(.secondaryTxt)
@@ -155,7 +155,7 @@ struct SettingsView: View {
                 showReportWarnings = userDefaults.object(forKey: showReportWarningsKey) as? Bool ?? true
                 showOutOfNetworkWarning = userDefaults.object(forKey: showOutOfNetworkWarningKey) as? Bool ?? true
             }
-            
+
             Section {
                 Text("\(String(localized: .localizable.appVersion)) \(Bundle.current.versionAndBuild)")
                     .foregroundColor(.primaryTxt)
@@ -179,11 +179,13 @@ struct SettingsView: View {
                         do {
                             fileToShare = try await Zipper.zipDatabase(controller: persistenceController)
                         } catch {
-                            alert = AlertState(title: {
-                                TextState(String(localized: .localizable.error))
-                            }, message: {
-                                TextState(String(localized: .localizable.failedToShareDatabase))
-                            })
+                            alert = AlertState(
+                                title: {
+                                    TextState(String(localized: .localizable.error))
+                                },
+                                message: {
+                                    TextState(String(localized: .localizable.failedToShareDatabase))
+                                })
                         }
                     }
                 }
@@ -193,21 +195,23 @@ struct SettingsView: View {
                         do {
                             fileToShare = try await Zipper.zipLogs()
                         } catch {
-                            alert = AlertState(title: {
-                                TextState(String(localized: .localizable.error))
-                            }, message: {
-                                TextState(String(localized: .localizable.failedToExportLogs))
-                            })
+                            alert = AlertState(
+                                title: {
+                                    TextState(String(localized: .localizable.error))
+                                },
+                                message: {
+                                    TextState(String(localized: .localizable.failedToExportLogs))
+                                })
                         }
                     }
                 }
 
                 #if STAGING
-                stagingControls
+                    stagingControls
                 #endif
 
                 #if DEBUG
-                debugControls
+                    debugControls
                 #endif
             } header: {
                 Text(.localizable.debug)
@@ -218,7 +222,7 @@ struct SettingsView: View {
                     .padding(.vertical, 15)
             }
             .listRowGradientBackground()
-            
+
             ActionButton(
                 title: .localizable.deleteMyAccount,
                 font: .clarityBold(.title3),
@@ -254,7 +258,7 @@ struct SettingsView: View {
             analytics.showedSettings()
         }
     }
-    
+
     fileprivate func alertButtonTapped(_ action: AlertAction) async {
         switch action {
         case .logout:
@@ -271,66 +275,66 @@ struct SettingsView: View {
 
 // DEBUG builds will have everything that's in STAGING builds and more.
 #if STAGING || DEBUG
-extension SettingsView {
-    /// Whether the new moderation flow is enabled.
-    private var isNewModerationFlowEnabled: Binding<Bool> {
-        Binding<Bool>(
-            get: { featureFlags.isEnabled(.newModerationFlow) },
-            set: { featureFlags.setFeature(.newModerationFlow, enabled: $0) }
-        )
-    }
+    extension SettingsView {
+        /// Whether the new moderation flow is enabled.
+        private var isNewModerationFlowEnabled: Binding<Bool> {
+            Binding<Bool>(
+                get: { featureFlags.isEnabled(.newModerationFlow) },
+                set: { featureFlags.setFeature(.newModerationFlow, enabled: $0) }
+            )
+        }
 
-    /// A toggle for the new moderation flow that allows the user to turn the feature on or off.
-    private var newModerationFlowToggle: some View {
-        NosToggle(isOn: isNewModerationFlowEnabled, labelText: .localizable.enableNewModerationFlow)
+        /// A toggle for the new moderation flow that allows the user to turn the feature on or off.
+        private var newModerationFlowToggle: some View {
+            NosToggle(isOn: isNewModerationFlowEnabled, labelText: .localizable.enableNewModerationFlow)
+        }
     }
-}
 #endif
 
 #if STAGING
-extension SettingsView {
-    /// Controls that will appear when the app is built for STAGING.
-    @MainActor private var stagingControls: some View {
-        Group {
-            newModerationFlowToggle
-            deleteAccountToggle
+    extension SettingsView {
+        /// Controls that will appear when the app is built for STAGING.
+        @MainActor private var stagingControls: some View {
+            Group {
+                newModerationFlowToggle
+                deleteAccountToggle
+            }
         }
     }
-}
 #endif
 
 #if DEBUG
-extension SettingsView {
-    /// Controls that will appear when the app is built for DEBUG.
-    @MainActor private var debugControls: some View {
-        Group {
-            newModerationFlowToggle
-            Text(.localizable.sampleDataInstructions)
-                .foregroundColor(.primaryTxt)
-            Button(String(localized: .localizable.loadSampleData)) {
-                Task {
-                    do {
-                        try await persistenceController.loadSampleData(context: viewContext)
-                    } catch {
-                        print(error)
+    extension SettingsView {
+        /// Controls that will appear when the app is built for DEBUG.
+        @MainActor private var debugControls: some View {
+            Group {
+                newModerationFlowToggle
+                Text(.localizable.sampleDataInstructions)
+                    .foregroundColor(.primaryTxt)
+                Button(String(localized: .localizable.loadSampleData)) {
+                    Task {
+                        do {
+                            try await persistenceController.loadSampleData(context: viewContext)
+                        } catch {
+                            print(error)
+                        }
                     }
                 }
-            }
-            if let author = currentUser.author {
-                NavigationLink {
-                    PublishedEventsView(author: author)
-                } label: {
-                    Text(.localizable.allPublishedEvents)
+                if let author = currentUser.author {
+                    NavigationLink {
+                        PublishedEventsView(author: author)
+                    } label: {
+                        Text(.localizable.allPublishedEvents)
+                    }
                 }
             }
         }
     }
-}
 #endif
 
 #Preview {
     let previewData = PreviewData()
-    
+
     return NavigationStack {
         SettingsView()
     }

--- a/Nos/Views/SideMenu/AboutView.swift
+++ b/Nos/Views/SideMenu/AboutView.swift
@@ -14,7 +14,7 @@ struct AboutView: View {
                     .font(.custom("ClarityCity-Bold", size: 25.21))
                     .fontWeight(.heavy)
                     .foregroundStyle(LinearGradient.diagonalAccent2.blendMode(.normal))
-                
+
                 VStack {
                     HighlightedText(
                         String(localized: .localizable.aboutNos),

--- a/Nos/Views/SideMenu/ReportABugMailView.swift
+++ b/Nos/Views/SideMenu/ReportABugMailView.swift
@@ -1,18 +1,18 @@
+import Logger
 import MessageUI
 import SwiftUI
-import Logger
 
 struct ReportABugMailView: UIViewControllerRepresentable {
-    
+
     @Environment(\.presentationMode) var presentation
     @Binding var result: Result<MFMailComposeResult, Error>?
-    
+
     typealias UIViewControllerType = MFMailComposeViewController
-    
+
     class Coordinator: NSObject, MFMailComposeViewControllerDelegate {
         @Binding var presentation: PresentationMode
         @Binding var result: Result<MFMailComposeResult, Error>?
-        
+
         init(
             presentation: Binding<PresentationMode>,
             result: Binding<Result<MFMailComposeResult, Error>?>
@@ -35,11 +35,11 @@ struct ReportABugMailView: UIViewControllerRepresentable {
             }
         }
     }
-    
+
     func makeCoordinator() -> Coordinator {
         Coordinator(presentation: presentation, result: $result)
     }
-    
+
     func makeUIViewController(context: Context) -> MFMailComposeViewController {
         let mailViewController = MFMailComposeViewController()
         mailViewController.mailComposeDelegate = context.coordinator
@@ -53,7 +53,7 @@ struct ReportABugMailView: UIViewControllerRepresentable {
             do {
                 mailViewController.addAttachmentData(
                     try Data(contentsOf: try await Zipper.zipLogs()),
-                    mimeType: "application/zip", 
+                    mimeType: "application/zip",
                     fileName: "diagnostics.zip"
                 )
             } catch {
@@ -62,7 +62,7 @@ struct ReportABugMailView: UIViewControllerRepresentable {
         }
         return mailViewController
     }
-    
+
     func updateUIViewController(_ uiViewController: MFMailComposeViewController, context: Context) {
     }
 }

--- a/Nos/Views/SideMenu/SideMenu.swift
+++ b/Nos/Views/SideMenu/SideMenu.swift
@@ -1,25 +1,25 @@
+import Dependencies
 import Foundation
 import SwiftUI
-import Dependencies
 
 struct SideMenu: View {
-    
+
     enum Destination {
         case settings
         case relays
         case profile
         case about
     }
-    
+
     let menuWidth: CGFloat
     let menuOpened: Bool
-    
+
     let toggleMenu: @MainActor () -> Void
     let closeMenu: @MainActor () -> Void
-    
+
     @EnvironmentObject private var router: Router
     @Dependency(\.analytics) private var analytics
-    
+
     var body: some View {
         if menuOpened {
             ZStack {
@@ -51,17 +51,18 @@ struct SideMenu: View {
 }
 
 struct SideMenu_Previews: PreviewProvider {
-    
+
     static var previewData = PreviewData()
     static var menuOpened = true
-    
+
     static var previews: some View {
         SideMenu(
-            menuWidth: 300, 
-            menuOpened: menuOpened, 
-            toggleMenu: { 
+            menuWidth: 300,
+            menuOpened: menuOpened,
+            toggleMenu: {
                 menuOpened.toggle()
-            }, closeMenu: { 
+            },
+            closeMenu: {
                 menuOpened = false
             }
         )

--- a/Nos/Views/SideMenu/SideMenuContent.swift
+++ b/Nos/Views/SideMenu/SideMenuContent.swift
@@ -1,20 +1,20 @@
-import SwiftUI
-import MessageUI
 import Dependencies
+import MessageUI
+import SwiftUI
 
 struct SideMenuContent: View {
-    
+
     @EnvironmentObject private var router: Router
     @Environment(CurrentUser.self) private var currentUser
     @Dependency(\.analytics) private var analytics
-    
+
     @State private var isShowingReportABugMailView = false
     @State private var shareNosPressed = false
-    
+
     @State var result: Result<MFMailComposeResult, Error>?
-    
+
     let closeMenu: @MainActor () -> Void
-    
+
     @MainActor var profileHeader: some View {
         Group {
             if let author = currentUser.author, author.needsMetadata == true {
@@ -59,7 +59,7 @@ struct SideMenuContent: View {
             }
         }
     }
-    
+
     var body: some View {
         NosNavigationStack(path: $router.sideMenuPath) {
             ScrollView {
@@ -122,14 +122,14 @@ struct SideMenuContent: View {
 }
 
 struct SideMenuRow: View {
-    
+
     var title: LocalizedStringResource
     var image: Image
     var destination: SideMenu.Destination?
     var action: (() -> Void)?
-    
+
     @EnvironmentObject private var router: Router
-    
+
     var body: some View {
         Button {
             if let destination {
@@ -153,9 +153,9 @@ struct SideMenuRow: View {
 }
 
 struct SideMenuContent_Previews: PreviewProvider {
-    
+
     static var previewData = PreviewData()
-    static var emptyUserData = { 
+    static var emptyUserData = {
         var data = PreviewData()
         _ = data.currentUser
         Task {
@@ -164,15 +164,15 @@ struct SideMenuContent_Previews: PreviewProvider {
         return data
     }()
     static var menuOpened = true
-    
+
     static var previews: some View {
         Group {
-            SideMenuContent { 
+            SideMenuContent {
                 menuOpened = false
             }
             .inject(previewData: previewData)
-            
-            SideMenuContent { 
+
+            SideMenuContent {
                 menuOpened = false
             }
             .inject(previewData: emptyUserData)

--- a/Nos/Views/UNS/SetUpUNSBanner.swift
+++ b/Nos/Views/UNS/SetUpUNSBanner.swift
@@ -24,7 +24,7 @@ struct SetUpUNSBanner: View {
                         .foregroundColor(.white)
                     Spacer()
                 }
-                
+
                 HStack {
                     ActionButton(
                         title: button,
@@ -54,7 +54,7 @@ struct SetUpUNSBanner: View {
                 }
                 .offset(y: -2)
             )
-            
+
             .cornerRadius(20)
         }
         .fixedSize(horizontal: false, vertical: true)

--- a/Nos/Views/UNS/UNSErrorView.swift
+++ b/Nos/Views/UNS/UNSErrorView.swift
@@ -1,14 +1,14 @@
-import SwiftUI
 import Dependencies
 import Logger
+import SwiftUI
 
 struct UNSErrorView: View {
-    
+
     @ObservedObject var controller: UNSWizardController
     @Dependency(\.analytics) var analytics
     @Dependency(\.unsAPI) var api
     @Dependency(\.crashReporting) var crashReporting
-    
+
     var body: some View {
         NavigationStack {
             VStack {
@@ -16,7 +16,7 @@ struct UNSErrorView: View {
                     UNSStepImage { Image.unsVerificationCode.offset(x: 7, y: 5) }
                         .padding(40)
                         .padding(.top, 50)
-                    
+
                     Text(.localizable.oops)
                         .font(.clarityBold(.title))
                         .multilineTextAlignment(.center)
@@ -24,14 +24,14 @@ struct UNSErrorView: View {
                         .shadow(radius: 1, y: 1)
                         .padding(.top, 20)
                         .padding(.bottom, 3)
-                    
+
                     Text(.localizable.anErrorOccurred)
                         .font(.clarityBold(.title))
                         .multilineTextAlignment(.center)
                         .foregroundColor(.primaryTxt)
                         .shadow(radius: 1, y: 1)
                         .padding(.bottom, 20)
-                    
+
                     Text(.localizable.tryAgainOrContactSupport)
                         .fontWeight(.medium)
                         .multilineTextAlignment(.center)
@@ -41,12 +41,12 @@ struct UNSErrorView: View {
                         .shadow(radius: 1, y: 1)
                         .padding(.bottom, 20)
                 }
-                
+
                 Spacer()
-                
+
                 BigActionButton(title: .localizable.goBack) {
                     if api.accessToken != nil {
-                        do { 
+                        do {
                             try await controller.navigateToChooseOrRegisterName()
                         } catch {
                             Log.optional(error)
@@ -73,12 +73,12 @@ struct UNSErrorView: View {
                     crashReporting.report(errorMessage)
                 }
             }
-        } 
+        }
     }
 }
 
 #Preview {
     @State var controller = UNSWizardController(state: .error(nil))
-    
+
     return UNSErrorView(controller: controller)
 }

--- a/Nos/Views/UNS/UNSNamePicker.swift
+++ b/Nos/Views/UNS/UNSNamePicker.swift
@@ -1,14 +1,14 @@
 import SwiftUI
 
-fileprivate struct PickerRow<Label: View>: View {
+private struct PickerRow<Label: View>: View {
     @Binding var isSelected: Bool
     var label: Label
-    
+
     init(isSelected: Binding<Bool>, @ViewBuilder builder: () -> Label) {
         self._isSelected = isSelected
         self.label = builder()
     }
-    
+
     var body: some View {
         HStack {
             if isSelected {
@@ -20,13 +20,13 @@ fileprivate struct PickerRow<Label: View>: View {
                     .stroke(Color.secondaryTxt)
                     .frame(width: 16, height: 16)
             }
-            
+
             if isSelected {
-                label.foregroundStyle(LinearGradient.verticalAccentPrimary) 
+                label.foregroundStyle(LinearGradient.verticalAccentPrimary)
             } else {
-                label.foregroundStyle(Color.primaryTxt) 
+                label.foregroundStyle(Color.primaryTxt)
             }
-            
+
             Spacer()
         }
         .padding(.horizontal, 15)
@@ -35,30 +35,30 @@ fileprivate struct PickerRow<Label: View>: View {
 }
 
 struct UNSNamePicker: View {
-    
+
     @Binding var selectedName: UNSNameRecord?
     @Binding var desiredName: UNSName
     @ObservedObject var controller: UNSWizardController
     @FocusState private var isTextFieldFocused: Bool
-    
+
     var textFieldForegroundStyle: LinearGradient {
         if isTextFieldFocused {
             LinearGradient.verticalAccentPrimary
         } else {
             LinearGradient(colors: [Color.primaryTxt], startPoint: .top, endPoint: .bottom)
-        } 
+        }
     }
-    
+
     var body: some View {
         VStack {
             VStack {
                 if let names = controller.names {
                     ForEach(names) { name in
-                        Button { 
+                        Button {
                             selectedName = name
                             isTextFieldFocused = false
-                        } label: { 
-                            let isSelected = Binding { 
+                        } label: {
+                            let isSelected = Binding {
                                 selectedName == name && !isTextFieldFocused
                             } set: { isSelected in
                                 if isSelected {
@@ -67,7 +67,7 @@ struct UNSNamePicker: View {
                                     selectedName = nil
                                 }
                             }
-                            
+
                             PickerRow(isSelected: isSelected) {
                                 Text(name.name)
                                     .font(.clarity(.bold, textStyle: .title2))
@@ -80,7 +80,7 @@ struct UNSNamePicker: View {
                 }
             }
             .padding(.vertical, 15)
-            
+
             Rectangle()
                 .frame(height: 2)
                 .foregroundColor(.secondaryTxt)
@@ -95,7 +95,7 @@ struct UNSNamePicker: View {
                         .stroke(Color.secondaryTxt)
                         .frame(width: 16, height: 16)
                 }
-                
+
                 TextField(text: $desiredName) {
                     Text(.localizable.createNewName)
                         .foregroundColor(.secondaryTxt)
@@ -112,7 +112,7 @@ struct UNSNamePicker: View {
                         selectedName = nil
                     }
                 }
-                
+
                 Spacer()
             }
             .padding(.horizontal, 15)
@@ -121,7 +121,7 @@ struct UNSNamePicker: View {
             RoundedRectangle(cornerRadius: 8)
                 .stroke(Color.secondaryTxt, lineWidth: 2)
                 .background(Color.textFieldBg)
-        )    
+        )
     }
 }
 
@@ -134,7 +134,7 @@ struct UNSNamePicker: View {
         ])
         @State var selectedName: UNSNameRecord?
         @State var desiredName: UNSName = ""
-        
+
         var body: some View {
             VStack {
                 Spacer()

--- a/Nos/Views/UNS/UNSNameTakenView.swift
+++ b/Nos/Views/UNS/UNSNameTakenView.swift
@@ -1,11 +1,11 @@
-import SwiftUI
 import Dependencies
+import SwiftUI
 
 struct UNSNameTakenView: View {
-    
+
     @ObservedObject var controller: UNSWizardController
     @Dependency(\.analytics) var analytics
-    
+
     var body: some View {
         NavigationStack {
             VStack {
@@ -13,7 +13,7 @@ struct UNSNameTakenView: View {
                     UNSStepImage { Image.unsNameTaken.offset(x: 7, y: 5) }
                         .padding(40)
                         .padding(.top, 50)
-                    
+
                     Text(.localizable.oops)
                         .font(.clarityBold(.title))
                         .multilineTextAlignment(.center)
@@ -21,14 +21,14 @@ struct UNSNameTakenView: View {
                         .shadow(radius: 1, y: 1)
                         .padding(.top, 20)
                         .padding(.bottom, 3)
-                    
+
                     Text(.localizable.thatNameIsTaken)
                         .font(.clarityBold(.title))
                         .multilineTextAlignment(.center)
                         .foregroundColor(.primaryTxt)
                         .shadow(radius: 1, y: 1)
                         .padding(.bottom, 20)
-                    
+
                     Text(.localizable.tryAnotherName)
                         .fontWeight(.medium)
                         .multilineTextAlignment(.center)
@@ -38,9 +38,9 @@ struct UNSNameTakenView: View {
                         .shadow(radius: 1, y: 1)
                         .padding(.bottom, 20)
                 }
-                
+
                 Spacer()
-                
+
                 BigActionButton(title: .localizable.goBack) {
                     switch controller.state {
                     case .nameTaken(let previousState):
@@ -57,12 +57,12 @@ struct UNSNameTakenView: View {
             .onAppear {
                 analytics.choseInvalidUNSName()
             }
-        } 
+        }
     }
 }
 
 #Preview {
     @State var controller = UNSWizardController(state: .newName)
-    
+
     return UNSNameTakenView(controller: controller)
 }

--- a/Nos/Views/UNS/UNSNameView.swift
+++ b/Nos/Views/UNS/UNSNameView.swift
@@ -2,13 +2,13 @@ import SwiftUI
 
 /// Displays a Universal Name with a logo if the user has one.
 struct UNSNameView: View {
-    
+
     @ObservedObject var author: Author
     @EnvironmentObject private var relayService: RelayService
-    
+
     var body: some View {
         if !(author.uns ?? "").isEmpty {
-            
+
             Button {
                 if let url = relayService.unsURL(from: author.uns ?? "") {
                     UIApplication.shared.open(url)

--- a/Nos/Views/UNS/UNSNewNameView.swift
+++ b/Nos/Views/UNS/UNSNewNameView.swift
@@ -1,14 +1,14 @@
-import SwiftUI
 import Dependencies
 import Logger
+import SwiftUI
 
 struct UNSNewNameView: View {
-    
+
     @Dependency(\.analytics) var analytics
     @ObservedObject var controller: UNSWizardController
     @Dependency(\.unsAPI) var api
     @State var name: UNSName = ""
-    
+
     var body: some View {
         NavigationStack {
             ScrollView {
@@ -16,14 +16,14 @@ struct UNSNewNameView: View {
                     UNSStepImage { Image.unsName.offset(x: 7, y: 5) }
                         .padding(20)
                         .padding(.top, 50)
-                    
+
                     Text(.localizable.chooseYourName)
                         .font(.clarityBold(.title))
                         .multilineTextAlignment(.center)
                         .foregroundColor(.primaryTxt)
                         .shadow(radius: 1, y: 1)
                         .padding(20)
-                    
+
                     Text(.localizable.chooseYourNameDescription)
                         .fontWeight(.medium)
                         .multilineTextAlignment(.center)
@@ -31,11 +31,11 @@ struct UNSNewNameView: View {
                         .padding(.vertical, 17)
                         .padding(.horizontal, 20)
                         .shadow(radius: 1, y: 1)
-                    
+
                     Spacer()
                     UNSWizardTextField(text: $name)
                     Spacer()
-                    
+
                     BigActionButton(title: .localizable.next) {
                         await submit()
                     }
@@ -47,13 +47,13 @@ struct UNSNewNameView: View {
             .background(Color.appBg)
         }
     }
-    
+
     func submit() async {
         do {
             try await controller.register(desiredName: name)
         } catch {
             controller.state = .error(error)
-        }   
+        }
     }
 }
 

--- a/Nos/Views/UNS/UNSStepImage.swift
+++ b/Nos/Views/UNS/UNSStepImage.swift
@@ -1,16 +1,16 @@
 import SwiftUI
 
 struct UNSStepImage<Content: View>: View {
-    
+
     let image: Content
     let size: CGFloat = 178
-    
+
     @Environment(\.colorScheme) var colorScheme: ColorScheme
-    
+
     init(@ViewBuilder builder: () -> Content) {
         self.image = builder()
     }
-    
+
     var body: some View {
         ZStack {
             Circle()

--- a/Nos/Views/UNS/UNSSuccessView.swift
+++ b/Nos/Views/UNS/UNSSuccessView.swift
@@ -1,13 +1,13 @@
-import SwiftUI
 import Dependencies
+import SwiftUI
 
 struct UNSSuccessView: View {
-    
+
     @ObservedObject var controller: UNSWizardController
     @Binding var isPresented: Bool
     @Dependency(\.analytics) var analytics
     @Environment(\.colorScheme) var colorScheme: ColorScheme
-    
+
     var body: some View {
         NavigationStack {
             VStack {
@@ -28,14 +28,14 @@ struct UNSSuccessView: View {
                     .frame(width: 178, height: 178)
                     .padding(20)
                     .padding(.top, 50)
-                    
+
                     Text(.localizable.success)
                         .font(.clarityBold(.title))
                         .multilineTextAlignment(.center)
                         .foregroundColor(.primaryTxt)
                         .shadow(radius: 1, y: 1)
                         .padding(20)
-                    
+
                     Text(.localizable.unsSuccessDescription)
                         .fontWeight(.medium)
                         .multilineTextAlignment(.center)
@@ -45,9 +45,9 @@ struct UNSSuccessView: View {
                         .shadow(radius: 1, y: 1)
                         .padding(20)
                 }
-                
+
                 Spacer()
-                
+
                 BigActionButton(title: .localizable.done) {
                     isPresented = false
                 }
@@ -66,9 +66,11 @@ struct UNSSuccessView: View {
 #Preview {
     @State var isPresented = true
     @State var controller = UNSWizardController(nameRecord: UNSNameRecord(name: "Chardot", id: "1"))
-    
+
     return VStack {}
-        .sheet(isPresented: $isPresented, content: {
-            UNSSuccessView(controller: controller, isPresented: $isPresented)
-        })
+        .sheet(
+            isPresented: $isPresented,
+            content: {
+                UNSSuccessView(controller: controller, isPresented: $isPresented)
+            })
 }

--- a/Nos/Views/UNS/UNSVerifyCodeView.swift
+++ b/Nos/Views/UNS/UNSVerifyCodeView.swift
@@ -1,11 +1,11 @@
-import SwiftUI
 import Dependencies
+import SwiftUI
 
 struct UNSVerifyCodeView: View {
-    
+
     @Dependency(\.analytics) var analytics
     @Dependency(\.unsAPI) var api
-    
+
     @State var verificationCode: String = ""
     @ObservedObject var controller: UNSWizardController
     @FocusState private var focusedField: FocusedField?
@@ -13,7 +13,7 @@ struct UNSVerifyCodeView: View {
     enum FocusedField {
         case textEditor
     }
-    
+
     var body: some View {
         NavigationStack {
             ScrollView {
@@ -21,13 +21,13 @@ struct UNSVerifyCodeView: View {
                     UNSStepImage { Image.unsVerificationCode.offset(x: 7, y: 5) }
                         .padding(40)
                         .padding(.top, 50)
-                    
+
                     Text(.localizable.verification)
                         .font(.clarityBold(.title))
                         .multilineTextAlignment(.center)
                         .foregroundColor(.primaryTxt)
                         .shadow(radius: 1, y: 1)
-                    
+
                     let phoneString = controller.phoneNumber ?? "you."
                     HighlightedText(
                         String(localized: .localizable.verificationDescription(phoneString)),
@@ -41,14 +41,14 @@ struct UNSVerifyCodeView: View {
                     .multilineTextAlignment(.center)
                     .padding(.vertical, 17)
                     .padding(.horizontal, 20)
-                    
+
                     UNSWizardTextField(text: $verificationCode, placeholder: "123456")
                         .focused($focusedField, equals: .textEditor)
                         .keyboardType(.numberPad)
                         .autocorrectionDisabled()
-                    
+
                     Spacer()
-                    
+
                     BigActionButton(title: .localizable.submit) {
                         await submit()
                     }
@@ -63,14 +63,14 @@ struct UNSVerifyCodeView: View {
             }
         }
     }
-    
+
     private func submit() async {
         do {
             guard let phoneNumber = controller.phoneNumber else {
                 // Shouldn't end up here
                 throw UNSError.developer
             }
-            
+
             analytics.enteredUNSCode()
             try await api.verifyPhone(
                 phoneNumber: phoneNumber,
@@ -86,12 +86,12 @@ struct UNSVerifyCodeView: View {
 }
 
 struct UNSVerifyCodeView_Previews: PreviewProvider {
-    
+
     @State static var controller = UNSWizardController(
         state: .verificationCode,
         phoneNumber: "+1768555451"
     )
-    
+
     static var previews: some View {
         UNSVerifyCodeView(controller: controller)
     }

--- a/Nos/Views/UNS/UNSWizard.swift
+++ b/Nos/Views/UNS/UNSWizard.swift
@@ -1,19 +1,19 @@
-import SwiftUI
 import Dependencies
+import SwiftUI
 
 struct UNSWizard: View {
-        
+
     @ObservedObject var controller: UNSWizardController
     @Binding var isPresented: Bool
-    
+
     @Dependency(\.analytics) var analytics
 
     enum FocusedField {
         case textEditor
     }
-    
+
     @FocusState private var focusedField: FocusedField?
-    
+
     var body: some View {
         VStack {
             switch controller.state {
@@ -57,11 +57,11 @@ struct UNSWizard: View {
 }
 
 #Preview {
-    
+
     @State var controller = UNSWizardController()
     @State var isPresented = true
     @State var previewData = PreviewData()
-    
+
     return UNSWizard(controller: controller, isPresented: $isPresented)
         .inject(previewData: previewData)
 }

--- a/Nos/Views/UNS/UNSWizardChooseNameView.swift
+++ b/Nos/Views/UNS/UNSWizardChooseNameView.swift
@@ -1,12 +1,12 @@
-import SwiftUI
 import Dependencies
 import Logger
+import SwiftUI
 
 struct UNSWizardChooseNameView: View {
-    
+
     @Dependency(\.analytics) var analytics
     @Dependency(\.unsAPI) var api
-    @Dependency(\.currentUser) var currentUser 
+    @Dependency(\.currentUser) var currentUser
     @ObservedObject var controller: UNSWizardController
     @State var selectedName: UNSNameRecord?
     @State var desiredName: UNSName = ""
@@ -18,19 +18,19 @@ struct UNSWizardChooseNameView: View {
                     UNSStepImage { Image.unsChooseName.offset(x: 7, y: 5) }
                         .padding(20)
                         .padding(.top, 50)
-                    
+
                     Text(.localizable.chooseNameOrRegister)
                         .font(.clarityBold(.title))
                         .multilineTextAlignment(.center)
                         .foregroundColor(.primaryTxt)
                         .shadow(radius: 1, y: 1)
                         .padding(20)
-                    
+
                     Spacer()
                     UNSNamePicker(selectedName: $selectedName, desiredName: $desiredName, controller: controller)
                 }
                 Spacer()
-                
+
                 BigActionButton(title: .localizable.next) {
                     await submit()
                 }
@@ -40,15 +40,15 @@ struct UNSWizardChooseNameView: View {
             .readabilityPadding()
             .background(Color.appBg)
         }
-    }    
-    
+    }
+
     @MainActor func submit() async {
         do {
             if let selectedName {
                 try await controller.link(existingName: selectedName)
             } else if !desiredName.isEmpty {
                 try await controller.register(desiredName: desiredName)
-            } 
+            }
         } catch {
             Log.optional(error)
             controller.state = .error(error)
@@ -58,13 +58,13 @@ struct UNSWizardChooseNameView: View {
 
 #Preview {
     @State var controller = UNSWizardController(
-        state: .chooseName, 
+        state: .chooseName,
         names: [
             UNSNameRecord(name: "Fred", id: "1"),
             UNSNameRecord(name: "Sally", id: "2"),
             UNSNameRecord(name: "Hubert Blaine Wolfeschlegelsteinhausenbergerdorff Sr.", id: "3"),
         ]
     )
-    
+
     return UNSWizardChooseNameView(controller: controller)
 }

--- a/Nos/Views/UNS/UNSWizardIntroView.swift
+++ b/Nos/Views/UNS/UNSWizardIntroView.swift
@@ -1,23 +1,23 @@
 import SwiftUI
 
 struct UNSWizardIntroView: View {
-    
+
     @ObservedObject var controller: UNSWizardController
-    
+
     var body: some View {
         VStack {
             Image.unsIntro
                 .frame(width: 178, height: 178)
                 .padding(40)
                 .padding(.top, 50)
-            
+
             Text(.localizable.unsRegister)
                 .font(.clarityBold(.title))
                 .multilineTextAlignment(.center)
                 .foregroundColor(.primaryTxt)
                 .readabilityPadding()
                 .shadow(radius: 1, y: 1)
-            
+
             Text(.localizable.unsRegisterDescription)
                 .fontWeight(.medium)
                 .multilineTextAlignment(.center)
@@ -26,19 +26,19 @@ struct UNSWizardIntroView: View {
                 .padding(.vertical, 17)
                 .padding(.horizontal, 20)
                 .shadow(radius: 1, y: 1)
-            
-            Button { 
+
+            Button {
                 UIApplication.shared.open(URL(string: "https://universalname.space")!)
-            } label: { 
+            } label: {
                 Text(.localizable.unsLearnMore)
                     .foregroundStyle(LinearGradient.horizontalAccent)
                     .fontWeight(.medium)
                     .multilineTextAlignment(.center)
                     .shadow(radius: 1, y: 1)
             }
-            
+
             Spacer()
-            
+
             BigActionButton(title: .localizable.start) {
                 controller.state = .enterPhone
             }
@@ -51,11 +51,11 @@ struct UNSWizardIntroView: View {
 }
 
 struct UNSWizardIntro_Previews: PreviewProvider {
-    
+
     @State static var controller = UNSWizardController(
-        state: .intro 
+        state: .intro
     )
-    
+
     static var previews: some View {
         UNSWizardIntroView(controller: controller)
     }

--- a/Nos/Views/UNS/UNSWizardNeedsPaymentView.swift
+++ b/Nos/Views/UNS/UNSWizardNeedsPaymentView.swift
@@ -1,28 +1,28 @@
-import SwiftUI
 import Dependencies
+import SwiftUI
 
 /// Shows a screen informing the user the name they registered requires payment and gives them a link to pay.
 struct UNSWizardNeedsPaymentView: View {
-    
+
     @ObservedObject var controller: UNSWizardController
     @State var hasOpenedPortal = false
     @Dependency(\.analytics) var analytics
     @Dependency(\.unsAPI) var api
-    
+
     var body: some View {
         VStack {
             Image.unsPremium
                 .frame(width: 178, height: 178)
                 .padding(40)
                 .padding(.top, 50)
-            
+
             Text(.localizable.premiumName)
                 .font(.clarityBold(.title))
                 .multilineTextAlignment(.center)
                 .foregroundColor(.primaryTxt)
                 .readabilityPadding()
                 .shadow(radius: 1, y: 1)
-            
+
             Text(hasOpenedPortal ? .localizable.returnToChooseName : .localizable.premiumNameDescription)
                 .fontWeight(.medium)
                 .multilineTextAlignment(.center)
@@ -30,18 +30,18 @@ struct UNSWizardNeedsPaymentView: View {
                 .readabilityPadding()
                 .padding(.vertical, 17)
                 .padding(.horizontal, 20)
-            
+
             Spacer()
-            
+
             if case let .needsPayment(url) = controller.state, !hasOpenedPortal {
                 VStack {
-                    Button { 
+                    Button {
                         controller.state = .chooseName
-                    } label: { 
+                    } label: {
                         HighlightedText(
-                            text: .localizable.goBackAndRegister, 
-                            highlightedWord: String(localized: .localizable.registerADifferentName), 
-                            highlight: LinearGradient(colors: [.primaryTxt], startPoint: .top, endPoint: .bottom), 
+                            text: .localizable.goBackAndRegister,
+                            highlightedWord: String(localized: .localizable.registerADifferentName),
+                            highlight: LinearGradient(colors: [.primaryTxt], startPoint: .top, endPoint: .bottom),
                             textColor: .secondaryTxt,
                             font: .clarity(.medium),
                             link: nil
@@ -50,7 +50,7 @@ struct UNSWizardNeedsPaymentView: View {
                         .fixedSize(horizontal: false, vertical: true)
                     }
                     .padding(.vertical, 20)
-                    
+
                     BigActionButton(title: .localizable.registerPremiumName, backgroundGradient: .gold) {
                         await UIApplication.shared.open(url)
                         hasOpenedPortal = true
@@ -76,9 +76,9 @@ struct UNSWizardNeedsPaymentView: View {
 
 #Preview {
     @State var controller = UNSWizardController(
-        state: .needsPayment(URL(string: "https://www.universalname.space/name/frankie")!), 
+        state: .needsPayment(URL(string: "https://www.universalname.space/name/frankie")!),
         nameRecord: UNSNameRecord(name: "frankie", id: "1")
     )
-    
+
     return UNSWizardNeedsPaymentView(controller: controller)
 }

--- a/Nos/Views/UNS/UNSWizardPhoneView.swift
+++ b/Nos/Views/UNS/UNSWizardPhoneView.swift
@@ -1,19 +1,19 @@
-import SwiftUI
 import Dependencies
+import SwiftUI
 
 struct UNSWizardPhoneView: View {
-    
+
     @ObservedObject var controller: UNSWizardController
     @Dependency(\.analytics) var analytics
     @Dependency(\.unsAPI) var api
     @State var phoneNumber: String = ""
-    
+
     enum FocusedField {
         case textEditor
     }
-    
+
     @FocusState private var focusedField: FocusedField?
-    
+
     var body: some View {
         NavigationStack {
             ScrollView {
@@ -21,13 +21,13 @@ struct UNSWizardPhoneView: View {
                     UNSStepImage { Image.unsPhone.offset(x: 7, y: 5) }
                         .padding(40)
                         .padding(.top, 50)
-                    
+
                     Text(.localizable.registration)
                         .font(.clarityBold(.title))
                         .multilineTextAlignment(.center)
                         .foregroundColor(.primaryTxt)
                         .shadow(radius: 1, y: 1)
-                    
+
                     Text(.localizable.registrationDescription)
                         .fontWeight(.medium)
                         .multilineTextAlignment(.center)
@@ -35,14 +35,14 @@ struct UNSWizardPhoneView: View {
                         .padding(.vertical, 17)
                         .padding(.horizontal, 20)
                         .shadow(radius: 1, y: 1)
-                    
+
                     UNSWizardTextField(text: $phoneNumber, placeholder: "+1-234-567-8910")
                         .focused($focusedField, equals: .textEditor)
                         .keyboardType(.phonePad)
                         .autocorrectionDisabled()
-                    
+
                     Spacer()
-                    
+
                     BigActionButton(title: .localizable.sendCode) {
                         await submit()
                     }
@@ -57,7 +57,7 @@ struct UNSWizardPhoneView: View {
             }
         }
     }
-    
+
     private func submit() async {
         analytics.enteredUNSPhone()
         var number = phoneNumber
@@ -67,23 +67,23 @@ struct UNSWizardPhoneView: View {
         number = "+\(number)"
         controller.phoneNumber = number
         self.phoneNumber = ""
-        
+
         do {
             controller.state = .loading
             try await api.requestVerificationCode(phoneNumber: number)
             controller.state = .verificationCode
         } catch {
             controller.state = .error(error)
-        } 
+        }
     }
 }
 
 struct UNSWizardPhone_Previews: PreviewProvider {
-    
+
     @State static var controller = UNSWizardController(
-        state: .intro 
+        state: .intro
     )
-    
+
     static var previews: some View {
         UNSWizardPhoneView(controller: controller)
     }

--- a/Nos/Views/UNS/UNSWizardTextField.swift
+++ b/Nos/Views/UNS/UNSWizardTextField.swift
@@ -2,10 +2,10 @@ import SwiftUI
 import SwiftUINavigation
 
 struct UNSWizardTextField: View {
-    
+
     var text: Binding<String>
     var placeholder: String = ""
-    
+
     var body: some View {
         TextField(text: text) {
             Text(placeholder)
@@ -30,7 +30,7 @@ struct UNSWizardTextField: View {
         }
         .padding(.vertical, 40)
     }
-    
+
     private func hideKeyboard() {
         UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
     }

--- a/NosPerformanceTests/NosPerformanceTests.swift
+++ b/NosPerformanceTests/NosPerformanceTests.swift
@@ -1,5 +1,5 @@
-import XCTest
 import SDWebImageSwiftUI
+import XCTest
 
 final class NosPerformanceTests: XCTestCase {
 
@@ -18,13 +18,13 @@ final class NosPerformanceTests: XCTestCase {
         }
     }
 
-    func testScrollingAnimationPerformance() throws { 
+    func testScrollingAnimationPerformance() throws {
         let app = XCUIApplication()
         app.launch()
         let homeFeed = app.scrollViews["home feed"]
         SDImageCache.shared.clearMemory()
         SDImageCache.shared.clearDisk()
-            
+
         measure(metrics: [XCTOSSignpostMetric.scrollingAndDecelerationMetric]) {
             homeFeed.swipeUp(velocity: .fast)
             homeFeed.swipeUp(velocity: .fast)

--- a/NosTests/Controller/ContentWarningControllerTests.swift
+++ b/NosTests/Controller/ContentWarningControllerTests.swift
@@ -2,10 +2,10 @@ import SwiftUI
 import XCTest
 
 final class ContentWarningControllerTests: CoreDataTestCase {
-    
+
     // swiftlint:disable:next implicitly_unwrapped_optional
     var fixture: PreviewData!
-    
+
     @MainActor
     override func setUp() async throws {
         try await super.setUp()
@@ -16,104 +16,104 @@ final class ContentWarningControllerTests: CoreDataTestCase {
     func test_noReports() throws {
         // Act
         let sut = ContentWarningController(reports: [], type: .note)
-        
+
         // Assert
         XCTAssertEqual(String(localized: sut.localizedContentWarning), "An error occurred.")
     }
-    
-    func testReason_givenLabel() { 
+
+    func testReason_givenLabel() {
         // Act
         let sut = ContentWarningController(reports: [fixture.shortNoteReportThree], type: .note)
-        
+
         // Assert
         XCTAssertEqual(
-            String(localized: sut.localizedContentWarning), 
+            String(localized: sut.localizedContentWarning),
             "This note has been flagged by **Alice** for spam."
         )
     }
-    
-    func testReason_givenContent() { 
+
+    func testReason_givenContent() {
         // Act
         let sut = ContentWarningController(reports: [fixture.shortNoteReportOne], type: .note)
-        
+
         // Assert
         XCTAssertEqual(
-            String(localized: sut.localizedContentWarning), 
+            String(localized: sut.localizedContentWarning),
             "This note has been flagged by **Bob** for impersonation."
         )
     }
-    
-    func testReason_givenReportType() { 
+
+    func testReason_givenReportType() {
         // Act
         let sut = ContentWarningController(reports: [fixture.shortNoteReportThree], type: .note)
-        
+
         // Assert
         XCTAssertEqual(
-            String(localized: sut.localizedContentWarning), 
+            String(localized: sut.localizedContentWarning),
             "This note has been flagged by **Alice** for spam."
         )
     }
-    
-    func testWarning_givenNoteReport_oneAuthor_oneReport() { 
+
+    func testWarning_givenNoteReport_oneAuthor_oneReport() {
         // Act
         let sut = ContentWarningController(reports: [fixture.shortNoteReportOne], type: .note)
-        
+
         // Assert
         XCTAssertEqual(
-            String(localized: sut.localizedContentWarning), 
+            String(localized: sut.localizedContentWarning),
             "This note has been flagged by **Bob** for impersonation."
         )
     }
-    
-    func testWarning_givenOneAuthor_multipleReports() { 
-        // Arrange 
+
+    func testWarning_givenOneAuthor_multipleReports() {
+        // Arrange
         let reports = [fixture.shortNoteReportOne, fixture.reportBobTwo]
-        
+
         // Act
         let sut = ContentWarningController(reports: reports, type: .note)
-        
+
         // Assert
         XCTAssertEqual(
-            String(localized: sut.localizedContentWarning), 
+            String(localized: sut.localizedContentWarning),
             "This note has been flagged by **Bob** for harassment, impersonation."
         )
     }
-    
-    func testWarning_givenNoteReport_multipleAuthors_oneReport() { 
-        // Arrange 
+
+    func testWarning_givenNoteReport_multipleAuthors_oneReport() {
+        // Arrange
         let reports = [fixture.shortNoteReportOne, fixture.shortNoteReportTwo]
-        
+
         // Act
         let sut = ContentWarningController(reports: reports, type: .note)
-        
+
         // Assert
         XCTAssertEqual(
-            String(localized: sut.localizedContentWarning), 
+            String(localized: sut.localizedContentWarning),
             "This note has been flagged by **Bob** and **1 other** for harassment, impersonation."
         )
     }
-    
-    func testWarning_givenAuthorReport_oneAuthor_oneReport() { 
+
+    func testWarning_givenAuthorReport_oneAuthor_oneReport() {
         // Act
         let sut = ContentWarningController(reports: [fixture.shortNoteReportOne], type: .author)
-        
+
         // Assert
         XCTAssertEqual(
-            String(localized: sut.localizedContentWarning), 
+            String(localized: sut.localizedContentWarning),
             "This user has been flagged by **Bob** for impersonation."
-        ) 
+        )
     }
-    
-    func testWarning_givenAuthorReport_multipleAuthors_oneReport() { 
-        // Arrange 
+
+    func testWarning_givenAuthorReport_multipleAuthors_oneReport() {
+        // Arrange
         let reports = [fixture.shortNoteReportOne, fixture.shortNoteReportTwo]
-        
+
         // Act
         let sut = ContentWarningController(reports: reports, type: .author)
-        
+
         // Assert
         XCTAssertEqual(
-            String(localized: sut.localizedContentWarning), 
+            String(localized: sut.localizedContentWarning),
             "This user has been flagged by **Bob** and **1 other** for impersonation, other."
         )
     }

--- a/NosTests/Controller/NoteEditorControllerTests.swift
+++ b/NosTests/Controller/NoteEditorControllerTests.swift
@@ -1,19 +1,19 @@
-import XCTest
 import UIKit
+import XCTest
 
 // swiftlint:disable implicitly_unwrapped_optional
 final class NoteEditorControllerTests: CoreDataTestCase {
-    
+
     var subject: NoteEditorController!
     var textView: UITextView!
-    
+
     lazy var defaultAttributes: [NSAttributedString.Key: Any] = {
         [
             .font: UIFont.preferredFont(forTextStyle: .body),
-            .foregroundColor: UIColor.primaryTxt
+            .foregroundColor: UIColor.primaryTxt,
         ]
     }()
-    
+
     lazy var attributedSpace: NSMutableAttributedString = {
         NSMutableAttributedString(string: " ", attributes: defaultAttributes)
     }()
@@ -23,17 +23,17 @@ final class NoteEditorControllerTests: CoreDataTestCase {
         textView = UITextView()
         subject.textView = textView
     }
-    
+
     // MARK: - Show Mentions Search
-    
+
     func testShowMentionsAutocomplete_whenTypingAfterSpace_thenMentionsSearchIsShown() throws {
         // Arrange
         subject.append(text: " ")
         textView.selectedRange = NSRange(location: 1, length: 0)
-        
+
         // Act
         let shouldChange = subject.textView(textView, shouldChangeTextIn: textView.selectedRange, replacementText: "@")
-        
+
         // Assert
         XCTAssertEqual(subject.showMentionsAutocomplete, true)
         XCTAssertEqual(shouldChange, true)
@@ -43,42 +43,42 @@ final class NoteEditorControllerTests: CoreDataTestCase {
         // Arrange
         subject.append(text: "blah")
         textView.selectedRange = NSRange(location: 4, length: 0)
-        
+
         // Act
         let shouldChange = subject.textView(textView, shouldChangeTextIn: textView.selectedRange, replacementText: "@")
-        
+
         // Assert
         XCTAssertEqual(subject.showMentionsAutocomplete, false)
         XCTAssertEqual(shouldChange, true)
     }
-    
+
     func testShowMentionsAutocomplete_whenTypingInEmptyField_thenMentionsSearchIsShown() throws {
         // Arrange
         textView.selectedRange = NSRange(location: 0, length: 0)
-        
+
         // Act
         let shouldChange = subject.textView(textView, shouldChangeTextIn: textView.selectedRange, replacementText: "@")
-        
+
         // Assert
         XCTAssertEqual(subject.showMentionsAutocomplete, true)
         XCTAssertEqual(shouldChange, true)
     }
-    
+
     func testShowMentionsAutocomplete_whenTypingAtStartOfLine_thenMentionsSearchIsShown() throws {
         // Arrange
         subject.append(text: "\n")
         textView.selectedRange = NSRange(location: 1, length: 0)
-        
+
         // Act
         let shouldChange = subject.textView(textView, shouldChangeTextIn: textView.selectedRange, replacementText: "@")
-        
+
         // Assert
         XCTAssertEqual(subject.showMentionsAutocomplete, true)
         XCTAssertEqual(shouldChange, true)
     }
-    
-    // MARK: - mentions 
-    
+
+    // MARK: - mentions
+
     @MainActor func testMention() throws {
         // Arrange
         let name = "mattn"
@@ -88,18 +88,18 @@ final class NoteEditorControllerTests: CoreDataTestCase {
         author.displayName = name
         try testContext.save()
         subject.append(text: "@")
-        
+
         // Act
         subject.insertMention(of: author)
-        
+
         // Assert
-        
+
         let mention = NSMutableAttributedString(
-            string: "@mattn", 
+            string: "@mattn",
             attributes: [
                 .font: UIFont.preferredFont(forTextStyle: .body),
                 .foregroundColor: UIColor.primaryTxt,
-                .link: "nostr:\(npub)"
+                .link: "nostr:\(npub)",
             ]
         )
         mention.append(attributedSpace)
@@ -119,14 +119,14 @@ final class NoteEditorControllerTests: CoreDataTestCase {
 
         // Act
         subject.insertMention(of: author)
-        
+
         // Assert
         let mention = NSMutableAttributedString(
-            string: "@mattn 🍐", 
+            string: "@mattn 🍐",
             attributes: [
                 .font: UIFont.preferredFont(forTextStyle: .body),
                 .foregroundColor: UIColor.primaryTxt,
-                .link: "nostr:\(npub)"
+                .link: "nostr:\(npub)",
             ]
         )
         mention.append(attributedSpace)
@@ -143,17 +143,17 @@ final class NoteEditorControllerTests: CoreDataTestCase {
         author.displayName = name
         try testContext.save()
         subject.append(text: "@")
-        
+
         // Act
         subject.insertMention(of: author)
-        
+
         // Assert
         let mention = NSMutableAttributedString(
-            string: "@🍐 mattn 🍐", 
+            string: "@🍐 mattn 🍐",
             attributes: [
                 .font: UIFont.preferredFont(forTextStyle: .body),
                 .foregroundColor: UIColor.primaryTxt,
-                .link: "nostr:\(npub)"
+                .link: "nostr:\(npub)",
             ]
         )
         mention.append(attributedSpace)
@@ -170,26 +170,28 @@ final class NoteEditorControllerTests: CoreDataTestCase {
         author.displayName = name
         try testContext.save()
         subject.append(text: "@")
-        
+
         // Act
         subject.insertMention(of: author)
         subject.append(text: "@")
         subject.insertMention(of: author)
-        
+
         // Assert
-        let mention = NSAttributedString(string: "@🍐 mattn 🍐", attributes: [
-            .font: UIFont.preferredFont(forTextStyle: .body),
-            .foregroundColor: UIColor.primaryTxt,
-            .link: "nostr:\(npub)"
-        ])
-        
+        let mention = NSAttributedString(
+            string: "@🍐 mattn 🍐",
+            attributes: [
+                .font: UIFont.preferredFont(forTextStyle: .body),
+                .foregroundColor: UIColor.primaryTxt,
+                .link: "nostr:\(npub)",
+            ])
+
         let expectedText = NSMutableAttributedString(attributedString: mention)
         expectedText.append(attributedSpace)
         expectedText.append(mention)
         expectedText.append(attributedSpace)
         XCTAssertEqual(subject.text, AttributedString(expectedText))
     }
-    
+
     @MainActor func testRemoveLinkAttributesUnderCursor_whenDeletingLastCharacterOfMention() throws {
         // Arrange
         let name = "abc"
@@ -198,25 +200,25 @@ final class NoteEditorControllerTests: CoreDataTestCase {
         author.displayName = name
         try testContext.save()
         subject.append(text: "@")
-        
+
         // Act
         subject.insertMention(of: author)
         // simulate a backspace
         _ = subject.textView(textView, shouldChangeTextIn: NSRange(location: 3, length: 1), replacementText: "")
-        
+
         // Assert
         let mention = NSMutableAttributedString(
-            string: "@ab ", 
+            string: "@ab ",
             attributes: [
                 .font: UIFont.preferredFont(forTextStyle: .body),
                 .foregroundColor: UIColor.primaryTxt,
             ]
         )
         let expectedText = AttributedString(mention)
-        
+
         XCTAssertEqual(subject.text, expectedText)
     }
-    
+
     @MainActor func testRemoveLinkAttributesUnderCursor_whenDeletingACharacterAfterAMention() throws {
         // Arrange
         let name = "abc"
@@ -225,16 +227,16 @@ final class NoteEditorControllerTests: CoreDataTestCase {
         author.displayName = name
         try testContext.save()
         subject.append(text: "@")
-        
+
         // Act
         subject.insertMention(of: author)
         // simulate a backspace
         let shouldChange = subject.textView(
-            textView, 
-            shouldChangeTextIn: NSRange(location: 4, length: 1), 
+            textView,
+            shouldChangeTextIn: NSRange(location: 4, length: 1),
             replacementText: ""
         )
-        
+
         // Assert
         // The backspace should be handled by the UITextView, not our code.
         XCTAssertEqual(shouldChange, true)

--- a/NosTests/Extensions/AttributedString+QuotationsTests.swift
+++ b/NosTests/Extensions/AttributedString+QuotationsTests.swift
@@ -1,14 +1,14 @@
 import XCTest
 
 final class AttributedString_QuotationsTests: XCTestCase {
-    
+
     func testLocales() {
         let cases = [
             "en": "“test”",
             "fr": "«test»",
             "ja": "「test」",
         ]
-        
+
         for (localeIdentifier, expectedOutput) in cases {
             XCTAssertEqual(
                 wrappedTestString(with: localeIdentifier),
@@ -16,7 +16,7 @@ final class AttributedString_QuotationsTests: XCTestCase {
             )
         }
     }
-    
+
     private func wrappedTestString(with localeIdentifier: String) -> String {
         let content = AttributedString("test")
         let wrapped = content.wrappingWithQuotationMarks(locale: Locale(identifier: localeIdentifier))

--- a/NosTests/Extensions/URLExtensionTests.swift
+++ b/NosTests/Extensions/URLExtensionTests.swift
@@ -108,17 +108,17 @@ final class URLExtensionTests: XCTestCase {
         let url = URL(string: "https://subdomain.example.com")!
         XCTAssertEqual(url.truncatedMarkdownLink, "[subdomain.example.com](https://subdomain.example.com)")
     }
-    
+
     func test_truncatedMarkdownLink_withNonEmptyPathExtension() {
         let url = URL(string: "https://example.com/image.png")!
         XCTAssertEqual(url.truncatedMarkdownLink, "[example.com...](https://example.com/image.png)")
     }
-    
+
     func test_truncatedMarkdownLink_withNilHost() {
         let url = URL(string: "nostr:1248904")!
         XCTAssertEqual(url.truncatedMarkdownLink, "[nostr:1248904](nostr:1248904)")
     }
-    
+
     func test_truncatedMarkdownLink_withWWW_removesWWW() {
         let url = URL(string: "https://www.example.com")!
         XCTAssertEqual(url.truncatedMarkdownLink, "[example.com](https://www.example.com)")
@@ -128,12 +128,12 @@ final class URLExtensionTests: XCTestCase {
         let url = URL(string: "www.nostr.com/get-started")!
         XCTAssertEqual(url.truncatedMarkdownLink, "[nostr.com...](https://www.nostr.com/get-started)")
     }
-    
+
     func test_truncatedMarkdownLink_noScheme_withWWW_noPath_doesNotIncludeEllipsis() {
         let url = URL(string: "https://www.nos.social/about")!
         XCTAssertEqual(url.truncatedMarkdownLink, "[nos.social...](https://www.nos.social/about)")
     }
-    
+
     func test_truncatedMarkdownLink_withShortPath() {
         let url = URL(string: "https://nips.be/1")!
         XCTAssertEqual(url.truncatedMarkdownLink, "[nips.be...](https://nips.be/1)")

--- a/NosTests/Fixtures/EventFixture.swift
+++ b/NosTests/Fixtures/EventFixture.swift
@@ -1,8 +1,8 @@
-import Foundation
 import CoreData
+import Foundation
 
 enum EventFixture {
-    
+
     /// Builds an event with sensible defaults. Just pass the values you need to specify.
     static func build(
         in context: NSManagedObjectContext,
@@ -20,18 +20,18 @@ enum EventFixture {
         event.content = content
         event.kind = 1
         event.allTags = tags as? NSObject
-        
+
         let author = try Author.findOrCreate(by: publicKey, context: context)
         event.author = author
-        
+
         if let identifier {
             event.identifier = identifier
         } else {
             event.identifier = try event.calculateIdentifier()
         }
-        
+
         event.deletedOn = deletedOn
-        
+
         return event
     }
 }

--- a/NosTests/Fixtures/KeyFixture.swift
+++ b/NosTests/Fixtures/KeyFixture.swift
@@ -6,7 +6,7 @@ enum KeyFixture {
     static let privateKeyHex = "69222a82c30ea0ad472745b170a560f017cb3bcc38f927a8b27e3bab3d8f0f19"
     static let nsec = "nsec1dy3z4qkrp6s263e8gkchpftq7qtukw7v8ruj029j0ca6k0v0puvs2e22yy"
     static let keyPair = KeyPair(privateKeyHex: privateKeyHex)!
-    
+
     static let alice = KeyPair(nsec: "nsec1x0md460pkpmuwu5auvzhtfnx3vahkxu83n9w26m5dy9243q6mgls0zsffn")!
     static let bob = KeyPair(nsec: "nsec1kvlwl8reastryhd75tsj879da6mmk744kl56l7q0sl237x8dqy9qwqqz4g")!
     static let eve = KeyPair(nsec: "nsec16mw0dqelfjumkq3xxqh0zkfkzpyk06mk37a752x35wts7m30y6lsecl6zr")!

--- a/NosTests/IntegrationTests/EventProcessorIntegrationTests+InlineMetadata.swift
+++ b/NosTests/IntegrationTests/EventProcessorIntegrationTests+InlineMetadata.swift
@@ -36,7 +36,7 @@ extension EventProcessorIntegrationTests {
         XCTAssertEqual(squareImageMetadata.dimensions, CGSize(width: 854, height: 854))
         XCTAssertEqual(squareImageMetadata.orientation, .landscape)
 
-        let portraitImageURL = 
+        let portraitImageURL =
             "https://image.nostr.build/2787ad495941dfb068fbff77f087513095a3f981f9697fcb9e51c052c6198090.jpg"
         let portraitImageMetadata = try XCTUnwrap(inlineMetadata[portraitImageURL])
         XCTAssertEqual(portraitImageMetadata.dimensions, CGSize(width: 1263, height: 3985))

--- a/NosTests/IntegrationTests/EventProcessorIntegrationTests.swift
+++ b/NosTests/IntegrationTests/EventProcessorIntegrationTests.swift
@@ -5,9 +5,11 @@ import XCTest
 class EventProcessorIntegrationTests: CoreDataTestCase {
     // swiftlint:disable line_length
 
-    let sampleEventSignature = "31c710803d3b77cb2c61697c8e2a980a53ec66e980990ca34cc24f9018bf85bfd2b0669c1404f364de776a9d9ed31a5d6d32f5662ac77f2dc6b89c7762132d63"
+    let sampleEventSignature =
+        "31c710803d3b77cb2c61697c8e2a980a53ec66e980990ca34cc24f9018bf85bfd2b0669c1404f364de776a9d9ed31a5d6d32f5662ac77f2dc6b89c7762132d63"
     let sampleEventPubKey = "d0a1ffb8761b974cec4a3be8cbcb2e96a7090dcf465ffeac839aa4ca20c9a59e"
-    let sampleEventContent = "Spent today on our company retreat talking a lot about Nostr. The team seems very keen to build something in this space. It’s exciting to be opening our minds to so many possibilities after being deep in the Scuttlebutt world for so long."
+    let sampleEventContent =
+        "Spent today on our company retreat talking a lot about Nostr. The team seems very keen to build something in this space. It’s exciting to be opening our minds to so many possibilities after being deep in the Scuttlebutt world for so long."
 
     // swiftlint:enable line_length
 
@@ -181,7 +183,8 @@ class EventProcessorIntegrationTests: CoreDataTestCase {
         let context = persistenceController.viewContext
         let sampleRelay = "wss://nostr.lorentz.is"
         let sampleName = "Test Name"
-        let sampleContactListSignature = "a01fa191a0236ffe5ee1fbd9401cd7b1da7daad5e19a25962eb7ea4c9335522478bdff255f1de40ca6c98cdf8cf26aa1f5f1b6c263c5004b0b6dcdc12573cfd7" // swiftlint:disable:this line_length
+        let sampleContactListSignature =
+            "a01fa191a0236ffe5ee1fbd9401cd7b1da7daad5e19a25962eb7ea4c9335522478bdff255f1de40ca6c98cdf8cf26aa1f5f1b6c263c5004b0b6dcdc12573cfd7"  // swiftlint:disable:this line_length
 
         // Act
         let parsedEvent = try EventProcessor.parse(jsonEvent: jsonEvent, from: nil, in: context)!
@@ -258,7 +261,7 @@ class EventProcessorIntegrationTests: CoreDataTestCase {
     }
 
     // MARK: - Zap Receipt/Request parsing
-    
+
     /// When a zap receipt event is parsed, expect that its embedded zap request is also parsed.
     func testParseZapReceiptAndEmbeddedZapRequest() throws {
         // Arrange
@@ -266,33 +269,33 @@ class EventProcessorIntegrationTests: CoreDataTestCase {
         let zapReceiptJSONEvent = try JSONDecoder().decode(JSONEvent.self, from: zapReceiptData)
 
         let context = persistenceController.viewContext
-        
+
         // Act
         try EventProcessor.parse(jsonEvent: zapReceiptJSONEvent, from: nil, in: context)
-        
+
         // Assert
-        
+
         // zap receipt
         let zapReceiptEventID = "9e722b2b62772f9f48c786e084038ffc039f5600bace1f068bcc2307a5de1553"
         let zapReceiptEvent = try XCTUnwrap(Event.find(by: zapReceiptEventID, context: context))
-        
+
         XCTAssertEqual(zapReceiptEvent.kind, EventKind.zapReceipt.rawValue)
-        
+
         let walletPubKey = "8b7cd4981e30ed2dd6b5ef1f816763453b282b3e44f41ef2a3da77ff5ef8d141"
         XCTAssertEqual(zapReceiptEvent.author?.hexadecimalPublicKey, walletPubKey)
         XCTAssertEqual(zapReceiptEvent.createdAt?.timeIntervalSince1970, 1_722_712_858)
-        
+
         // embedded zap request
         let zapRequestEventID = "6715260809f6f62ea82f8b213ca4cc0abd0426dc860f1c963c0f0207f9fadddb"
         let zapRequestEvent = try XCTUnwrap(Event.find(by: zapRequestEventID, context: context))
-        
+
         XCTAssertEqual(zapRequestEvent.kind, EventKind.zapRequest.rawValue)
-        
+
         let zapSenderPubKey = "2656d1495cccf384035a59cce13451c6f280a329f0d1b3bb6758b4830f67909c"
         XCTAssertEqual(zapRequestEvent.author?.hexadecimalPublicKey, zapSenderPubKey)
         XCTAssertEqual(zapRequestEvent.createdAt?.timeIntervalSince1970, 1_722_712_850)
     }
-    
+
     // MARK: - Expiration
 
     func testParseExpirationDate() throws {
@@ -341,12 +344,13 @@ class EventProcessorIntegrationTests: CoreDataTestCase {
         let context = persistenceController.viewContext
 
         // Act & Assert
-        XCTAssertThrowsError(try EventProcessor.parse(
-            jsonEvent: jsonEvent,
-            from: nil,
-            in: context,
-            skipVerification: true
-        ))
+        XCTAssertThrowsError(
+            try EventProcessor.parse(
+                jsonEvent: jsonEvent,
+                from: nil,
+                in: context,
+                skipVerification: true
+            ))
     }
 
     // MARK: - Stub

--- a/NosTests/Models/CoreData/AuthorTests.swift
+++ b/NosTests/Models/CoreData/AuthorTests.swift
@@ -3,7 +3,7 @@ import XCTest
 
 /// Tests for the `Author` model.
 final class AuthorTests: CoreDataTestCase {
-    
+
     /// Verifies that the `followedKeys` property returns the correct set of keys followed by the author.
     /// Written for bug [#845](https://github.com/planetary-social/nos/issues/845).
     func testFollowedKeys() throws {
@@ -21,7 +21,7 @@ final class AuthorTests: CoreDataTestCase {
         XCTAssertEqual(author.follows.count, 700)
         XCTAssertEqual(Set(author.followedKeys), Set(expectedFollowedKeys))
     }
-    
+
     @MainActor func testFollowedKeysIgnoresInvalidKeys() throws {
         // inject bad data into the database
         let user = try Author.findOrCreate(by: "user", context: testContext)
@@ -29,7 +29,7 @@ final class AuthorTests: CoreDataTestCase {
         let follow = Follow(context: testContext)
         follow.source = user
         follow.destination = followee
-        
+
         let fetchedAuthor = try Author.find(by: "user", context: testContext)
         XCTAssertEqual(fetchedAuthor?.followedKeys, [])
     }
@@ -145,25 +145,25 @@ final class AuthorTests: CoreDataTestCase {
 
         XCTAssertEqual(author.formattedNIP05, expected)
     }
-    
+
     func test_weblink_with_nos_social_NIP05() throws {
         let context = persistenceController.viewContext
         let author = try Author.findOrCreate(by: "test", context: context)
         author.nip05 = "test@nos.social"
         let expected = "https://test.nos.social"
-        
+
         XCTAssertEqual(author.webLink, expected)
     }
-    
+
     func test_weblink_with_non_nos_social_NIP05() throws {
         let expected = "https://njump.me/user@test.net"
         let context = persistenceController.viewContext
         let author = try Author.findOrCreate(by: "test", context: context)
         author.nip05 = "user@test.net"
-        
+
         XCTAssertEqual(author.webLink, expected)
     }
-    
+
     func test_weblink_with_nil_NIP05() throws {
         let expected = "https://njump.me/\(KeyFixture.alice.npub)"
         let context = persistenceController.viewContext
@@ -171,70 +171,70 @@ final class AuthorTests: CoreDataTestCase {
         author.nip05 = nil
         XCTAssertEqual(author.webLink, expected)
     }
-    
+
     // MARK: Fetch requests
-    
+
     @MainActor func test_knownFollowers_givenMultipleFollowers() throws {
         // Arrange
         let alice = try Author.findOrCreate(by: "alice", context: testContext)
-        let bob   = try Author.findOrCreate(by: "bob", context: testContext)
-        bob.lastUpdatedContactList = Date(timeIntervalSince1970: 1) // for sorting
-        let carl  = try Author.findOrCreate(by: "carl", context: testContext)
-        carl.lastUpdatedContactList = Date(timeIntervalSince1970: 0) // for sorting
-        let eve   = try Author.findOrCreate(by: "eve", context: testContext)
-        
+        let bob = try Author.findOrCreate(by: "bob", context: testContext)
+        bob.lastUpdatedContactList = Date(timeIntervalSince1970: 1)  // for sorting
+        let carl = try Author.findOrCreate(by: "carl", context: testContext)
+        carl.lastUpdatedContactList = Date(timeIntervalSince1970: 0)  // for sorting
+        let eve = try Author.findOrCreate(by: "eve", context: testContext)
+
         // Act
         // Alice follows bob and carl who both follow eve
         _ = try Follow.findOrCreate(source: alice, destination: bob, context: testContext)
         _ = try Follow.findOrCreate(source: alice, destination: carl, context: testContext)
         _ = try Follow.findOrCreate(source: bob, destination: eve, context: testContext)
         _ = try Follow.findOrCreate(source: carl, destination: eve, context: testContext)
-        
+
         try testContext.saveIfNeeded()
-        
+
         // Assert
         XCTAssertEqual(try testContext.fetch(alice.knownFollowers(of: eve)), [bob, carl])
         XCTAssertEqual(try testContext.fetch(alice.knownFollowers(of: bob)), [])
         XCTAssertEqual(try testContext.fetch(alice.knownFollowers(of: carl)), [])
         XCTAssertEqual(try testContext.fetch(alice.knownFollowers(of: alice)), [])
     }
-    
+
     @MainActor func test_knownFollowers_givenFollowCircle() throws {
         // Arrange
         let alice = try Author.findOrCreate(by: "alice", context: testContext)
-        let bob   = try Author.findOrCreate(by: "bob", context: testContext)
-        let carl  = try Author.findOrCreate(by: "carl", context: testContext)
-        let eve   = try Author.findOrCreate(by: "eve", context: testContext)
-        
+        let bob = try Author.findOrCreate(by: "bob", context: testContext)
+        let carl = try Author.findOrCreate(by: "carl", context: testContext)
+        let eve = try Author.findOrCreate(by: "eve", context: testContext)
+
         // Act
         // Create a circle of follows.
         _ = try Follow.findOrCreate(source: alice, destination: bob, context: testContext)
         _ = try Follow.findOrCreate(source: bob, destination: carl, context: testContext)
         _ = try Follow.findOrCreate(source: carl, destination: eve, context: testContext)
         _ = try Follow.findOrCreate(source: eve, destination: alice, context: testContext)
-        
+
         try testContext.saveIfNeeded()
-        
+
         // Assert
         XCTAssertEqual(try testContext.fetch(alice.knownFollowers(of: carl)), [bob])
         XCTAssertEqual(try testContext.fetch(alice.knownFollowers(of: eve)), [])
         XCTAssertEqual(try testContext.fetch(alice.knownFollowers(of: bob)), [])
         XCTAssertEqual(try testContext.fetch(alice.knownFollowers(of: alice)), [])
     }
-    
+
     @MainActor func test_knownFollowers_givenSelfFollow() throws {
         // Arrange
         let alice = try Author.findOrCreate(by: "alice", context: testContext)
-        let eve   = try Author.findOrCreate(by: "eve", context: testContext)
-        
+        let eve = try Author.findOrCreate(by: "eve", context: testContext)
+
         // Act
         _ = try Follow.findOrCreate(source: alice, destination: alice, context: testContext)
         _ = try Follow.findOrCreate(source: alice, destination: eve, context: testContext)
         _ = try Follow.findOrCreate(source: eve, destination: alice, context: testContext)
         _ = try Follow.findOrCreate(source: eve, destination: eve, context: testContext)
-        
+
         try testContext.saveIfNeeded()
-        
+
         // Assert
         XCTAssertEqual(try testContext.fetch(alice.knownFollowers(of: eve)), [])
     }
@@ -252,26 +252,26 @@ final class AuthorTests: CoreDataTestCase {
         // Assert
         XCTAssertEqual(events.count, 0)
     }
-    
+
     @MainActor func test_outOfNetwork_givenCircleOfFollows() throws {
         // Arrange
         let alice = try Author.findOrCreate(by: "alice", context: testContext)
-        let bob   = try Author.findOrCreate(by: "bob", context: testContext)
-        let carl  = try Author.findOrCreate(by: "carl", context: testContext)
-        let eve   = try Author.findOrCreate(by: "eve", context: testContext)
-        
+        let bob = try Author.findOrCreate(by: "bob", context: testContext)
+        let carl = try Author.findOrCreate(by: "carl", context: testContext)
+        let eve = try Author.findOrCreate(by: "eve", context: testContext)
+
         // Act
         // Create a circle of follows alice -> bob -> carl -> eve -> alice
         _ = try Follow.findOrCreate(source: alice, destination: bob, context: testContext)
         _ = try Follow.findOrCreate(source: bob, destination: carl, context: testContext)
         _ = try Follow.findOrCreate(source: carl, destination: eve, context: testContext)
         _ = try Follow.findOrCreate(source: eve, destination: alice, context: testContext)
-        
+
         try testContext.saveIfNeeded()
-        
-        // Act 
+
+        // Act
         let authors = try testContext.fetch(Author.outOfNetwork(for: alice))
-        
+
         // Assert
         XCTAssertEqual(authors, [eve])
     }

--- a/NosTests/Models/CoreData/EventTests.swift
+++ b/NosTests/Models/CoreData/EventTests.swift
@@ -1,8 +1,8 @@
-import XCTest
 import CoreData
+import Dependencies
+import XCTest
 import secp256k1
 import secp256k1_bindings
-import Dependencies
 
 /// Tests for the Event model.
 final class EventTests: CoreDataTestCase {
@@ -14,14 +14,14 @@ final class EventTests: CoreDataTestCase {
         let event = try EventFixture.build(in: testContext, content: content, tags: tags)
         // swiftlint:disable line_length
         let expectedString = """
-        [0,"32730e9dfcab797caf8380d096e548d9ef98f3af3000542f9271a91a9e3b0001",1675264762,1,[["p","d0a1ffb8761b974cec4a3be8cbcb2e96a7090dcf465ffeac839aa4ca20c9a59e"]],"Testing nos #[0]"]
-        """.trimmingCharacters(in: .whitespacesAndNewlines)
+            [0,"32730e9dfcab797caf8380d096e548d9ef98f3af3000542f9271a91a9e3b0001",1675264762,1,[["p","d0a1ffb8761b974cec4a3be8cbcb2e96a7090dcf465ffeac839aa4ca20c9a59e"]],"Testing nos #[0]"]
+            """.trimmingCharacters(in: .whitespacesAndNewlines)
         // swiftlint:enable line_length
-        
+
         // Act
         let serializedData = try JSONSerialization.data(withJSONObject: event.serializedEventForSigning)
         let actualString = String(decoding: serializedData, as: UTF8.self)
-        
+
         // Assert
         XCTAssertEqual(actualString, expectedString)
     }
@@ -33,20 +33,20 @@ final class EventTests: CoreDataTestCase {
         let tags = [["p", "d0a1ffb8761b974cec4a3be8cbcb2e96a7090dcf465ffeac839aa4ca20c9a59e"]]
         let content = "Testing nos #[0]"
         let event = try EventFixture.build(in: testContext, content: content, tags: tags)
-        
+
         // Act
         XCTAssertEqual(
             try event.calculateIdentifier(),
             "931b425e55559541451ddb99bd228bd1e0190af6ed21603b6b98544b42ee3317"
         )
     }
-    
+
     @MainActor func testIdentifierCalculationWithEmptyAndNoTags() throws {
         // Arrange
         let content = "Testing nos #[0]"
         let nilTagsEvent = try EventFixture.build(in: testContext, content: content, tags: nil)
         let emptyTagsEvent = try EventFixture.build(in: testContext, content: content, tags: [])
-        
+
         // Act
         XCTAssertEqual(
             try nilTagsEvent.calculateIdentifier(),
@@ -57,44 +57,45 @@ final class EventTests: CoreDataTestCase {
             "bc45c3ac53de113e1400fca956048a816ad1c2e6ecceba6b1372ca597066fa9a"
         )
     }
-    
+
     // MARK: - Signatures and Verification
-    
+
     /// Verifies that we can sign an event and verify it.
     /// Since Schnorr signatures are non-deterministic we can't assert on constants. That's why all this test really
     /// does is verify that we are internally consistent in our signature logic.
     @MainActor func testSigningAndVerification() throws {
         // Arrange
         let event = try EventFixture.build(in: testContext)
-        
+
         // Act
         try event.sign(withKey: KeyFixture.keyPair)
-        
+
         // Assert
         XCTAssert(try event.verifySignature(for: KeyFixture.keyPair.publicKey))
     }
-    
+
     @MainActor func testVerificationOnBadId() throws {
         // Arrange
         let event = try EventFixture.build(in: testContext)
-        
+
         // Act
         try event.sign(withKey: KeyFixture.keyPair)
         event.identifier = "invalid"
-        
+
         // Assert
         XCTAssertFalse(try event.verifySignature(for: KeyFixture.keyPair.publicKey))
     }
-    
+
     @MainActor func testVerificationOnBadSignature() throws {
         // Arrange
         let event = try EventFixture.build(in: testContext)
         event.identifier = try event.calculateIdentifier()
-        
+
         // Act
-        event.signature = "31c710803d3b77cb2c61697c8e2a980a53ec66e980990ca34cc24f9018bf85bfd2b0" +
-            "669c1404f364de776a9d9ed31a5d6d32f5662ac77f2dc6b89c7762132d63"
-        
+        event.signature =
+            "31c710803d3b77cb2c61697c8e2a980a53ec66e980990ca34cc24f9018bf85bfd2b0"
+            + "669c1404f364de776a9d9ed31a5d6d32f5662ac77f2dc6b89c7762132d63"
+
         // Assert
         XCTAssertFalse(try event.verifySignature(for: KeyFixture.keyPair.publicKey))
     }
@@ -106,56 +107,56 @@ final class EventTests: CoreDataTestCase {
         try testContext.save()
         measure {
             for _ in 0..<1000 {
-                _ = Event.find(by: eventID, context: testContext)  
+                _ = Event.find(by: eventID, context: testContext)
             }
         }
     }
-    
+
     // MARK: - Replies
-    
+
     @MainActor func testReferencedNoteGivenMentionMarker() throws {
         let testEvent = try EventFixture.build(in: testContext)
-        
+
         let mention = try EventReference(
-            jsonTag: ["e", "646daa2f5d2d990dc98fb50a6ce8de65d77419cee689d7153c912175e85ca95d", "", "mention"], 
+            jsonTag: ["e", "646daa2f5d2d990dc98fb50a6ce8de65d77419cee689d7153c912175e85ca95d", "", "mention"],
             context: testContext
         )
         testEvent.addToEventReferences(mention)
-        
+
         XCTAssertNil(testEvent.referencedNote())
     }
-    
+
     @MainActor func testRepostedNote() throws {
         let testEvent = try EventFixture.build(in: testContext)
         testEvent.kind = 6
-        
+
         let mention = try EventReference(
-            jsonTag: ["e", "646daa2f5d2d990dc98fb50a6ce8de65d77419cee689d7153c912175e85ca95d"], 
+            jsonTag: ["e", "646daa2f5d2d990dc98fb50a6ce8de65d77419cee689d7153c912175e85ca95d"],
             context: testContext
         )
         testEvent.addToEventReferences(mention)
-        
+
         XCTAssertEqual(
-            testEvent.repostedNote()?.identifier, 
+            testEvent.repostedNote()?.identifier,
             "646daa2f5d2d990dc98fb50a6ce8de65d77419cee689d7153c912175e85ca95d"
         )
     }
-    
+
     @MainActor func testRepostedNoteGivenNonRepost() throws {
         let testEvent = try EventFixture.build(in: testContext)
         testEvent.kind = 1
-        
+
         let mention = try EventReference(
-            jsonTag: ["e", "646daa2f5d2d990dc98fb50a6ce8de65d77419cee689d7153c912175e85ca95d"], 
+            jsonTag: ["e", "646daa2f5d2d990dc98fb50a6ce8de65d77419cee689d7153c912175e85ca95d"],
             context: testContext
         )
         testEvent.addToEventReferences(mention)
-        
+
         XCTAssertEqual(testEvent.repostedNote()?.identifier, nil)
     }
-    
+
     // MARK: - Fetch requests
-    
+
     @MainActor func test_eventByIdentifierSeenOnRelay_givenAlreadySeen() throws {
         // Arrange
         let eventID = "foo"
@@ -163,28 +164,28 @@ final class EventTests: CoreDataTestCase {
         let relay = try Relay.findOrCreate(by: "wss://relay.nos.social", context: testContext)
         event.addToSeenOnRelays(relay)
         try testContext.saveIfNeeded()
-        
+
         // Act
         let events = try testContext.fetch(Event.event(by: eventID, seenOn: relay))
-        
+
         // Assert
         XCTAssertEqual(events.count, 1)
         XCTAssertEqual(events.first, event)
     }
-    
+
     @MainActor func test_eventByIdentifierSeenOnRelay_givenNotSeen() throws {
         // Arrange
         let eventID = "foo"
         _ = try Event.findOrCreateStubBy(id: eventID, context: testContext)
         let relay = try Relay.findOrCreate(by: "wss://relay.nos.social", context: testContext)
-        
+
         // Act
         let events = try testContext.fetch(Event.event(by: eventID, seenOn: relay))
-        
+
         // Assert
         XCTAssertEqual(events.count, 0)
     }
-    
+
     @MainActor func test_eventByIdentifierSeenOnRelay_givenSeenOnAnother() throws {
         // Arrange
         let eventID = "foo"
@@ -192,10 +193,10 @@ final class EventTests: CoreDataTestCase {
         let relayOne = try Relay.findOrCreate(by: "wss://relay.nos.social", context: testContext)
         event.addToSeenOnRelays(relayOne)
         let relayTwo = try Relay.findOrCreate(by: "wss://other.relay.com", context: testContext)
-        
+
         // Act
         let events = try testContext.fetch(Event.event(by: eventID, seenOn: relayTwo))
-        
+
         // Assert
         XCTAssertEqual(events.count, 0)
     }

--- a/NosTests/Models/JSONEventTests.swift
+++ b/NosTests/Models/JSONEventTests.swift
@@ -14,85 +14,85 @@ class JSONEventTests: XCTestCase {
         // Act & Assert
         XCTAssertEqual(subject.replaceableID, replaceableID)
     }
-    
+
     func test_contactList_withRelays() {
         let pTags = [
             ["p", "91cf94e5ca", "wss://alicerelay.com/", "alice"],
             ["p", "14aeb8dad4", "wss://bobrelay.com/nostr", "bob"],
-            ["p", "612aee610f", "ws://carolrelay.com/ws", "carol"]
+            ["p", "612aee610f", "ws://carolrelay.com/ws", "carol"],
         ]
         let relayAddresses = [
             "wss://relay1.lol",
-            "wss://relay2.lol"
+            "wss://relay2.lol",
         ]
-        
+
         let event = JSONEvent.contactList(
             pubKey: "",
             tags: pTags,
             relayAddresses: relayAddresses
         )
-        
+
         let expectedContent = """
-        {"wss://relay1.lol":{"write":true,"read":true},"wss://relay2.lol":{"write":true,"read":true}}
-        """
-        
+            {"wss://relay1.lol":{"write":true,"read":true},"wss://relay2.lol":{"write":true,"read":true}}
+            """
+
         XCTAssertEqual(event.kind, 3)
         XCTAssertEqual(event.tags, pTags)
         XCTAssertEqual(event.content, expectedContent)
     }
-    
+
     func test_contactList_withNoRelays() {
         let pTags = [
             ["p", "91cf94e5ca", "wss://alicerelay.com/", "alice"],
             ["p", "14aeb8dad4", "wss://bobrelay.com/nostr", "bob"],
-            ["p", "612aee610f", "ws://carolrelay.com/ws", "carol"]
+            ["p", "612aee610f", "ws://carolrelay.com/ws", "carol"],
         ]
-        
+
         let event = JSONEvent.contactList(
             pubKey: "",
             tags: pTags,
             relayAddresses: []
         )
-        
+
         let expectedContent = "{}"
-        
+
         XCTAssertEqual(event.kind, 3)
         XCTAssertEqual(event.tags, pTags)
         XCTAssertEqual(event.content, expectedContent)
     }
-    
+
     func test_requestToVanish_fromSpecificRelays() {
         let event = JSONEvent.requestToVanish(
             pubKey: "",
             relays: [
                 URL(string: "wss://relay1.lol")!,
                 URL(string: "wss://relay2.lol")!,
-                URL(string: "wss://relay3.lol")!
+                URL(string: "wss://relay3.lol")!,
             ],
             reason: "I'm done with this."
         )
-        
+
         let expectedTags = [
             ["relay", "wss://relay1.lol"],
             ["relay", "wss://relay2.lol"],
-            ["relay", "wss://relay3.lol"]
+            ["relay", "wss://relay3.lol"],
         ]
-        
+
         XCTAssertEqual(event.kind, 62)
         XCTAssertEqual(event.tags, expectedTags)
         XCTAssertEqual(event.content, "I'm done with this.")
     }
-    
+
     func test_requestToVanish_fromAllRelays() {
         let event = JSONEvent.requestToVanish(
             pubKey: "",
             reason: "I'm done with this."
         )
-        
+
         let expectedTags = [
             ["relay", "ALL_RELAYS"]
         ]
-        
+
         XCTAssertEqual(event.kind, 62)
         XCTAssertEqual(event.tags, expectedTags)
         XCTAssertEqual(event.content, "I'm done with this.")

--- a/NosTests/Models/KeyPairTests.swift
+++ b/NosTests/Models/KeyPairTests.swift
@@ -2,7 +2,7 @@ import XCTest
 import secp256k1
 
 final class KeyPairTests: XCTestCase {
-    
+
     func testInitPrivateKeyFromHex() throws {
         let keyPair = try XCTUnwrap(KeyPair(privateKeyHex: KeyFixture.privateKeyHex))
         XCTAssertEqual(keyPair.privateKeyHex, KeyFixture.privateKeyHex)
@@ -10,7 +10,7 @@ final class KeyPairTests: XCTestCase {
         XCTAssertEqual(keyPair.publicKeyHex, KeyFixture.pubKeyHex)
         XCTAssertEqual(keyPair.npub, KeyFixture.npub)
     }
-    
+
     func testInitPrivateKeyFromNsec() throws {
         let keyPair = try XCTUnwrap(KeyPair(nsec: KeyFixture.nsec))
         XCTAssertEqual(keyPair.privateKeyHex, KeyFixture.privateKeyHex)

--- a/NosTests/Models/NoteParserTests+NIP27.swift
+++ b/NosTests/Models/NoteParserTests+NIP27.swift
@@ -116,7 +116,7 @@ extension NoteParserTests {
             ["p", hex],
             ["p", "8c430bdaadc1a202e4dd11c86c82546bb108d755e374b7918181f533b94e312e"],
             ["e", "a9788ca56a90bb5b856e89f16f5f3b0da93c28ea625e845c9925a41377152a13", "", "root"],
-            ["e", "3d9503a2d4ad024749b138c041e99934474e2822e2a1c697792dab5b24acc285", "", "reply"]
+            ["e", "3d9503a2d4ad024749b138c041e99934474e2822e2a1c697792dab5b24acc285", "", "reply"],
         ]
 
         // Act
@@ -142,20 +142,18 @@ extension NoteParserTests {
 
     @MainActor func testNIP27MentionToProfileWithURLInName() throws {
         // Arrange
-        let name = "nos.social" // This should not break the parsing
+        let name = "nos.social"  // This should not break the parsing
         let npub = "npub1pu3vqm4vzqpxsnhuc684dp2qaq6z69sf65yte4p39spcucv5lzmqswtfch"
         let hex = "0f22c06eac1002684efcc68f568540e8342d1609d508bcd4312c038e6194f8b6"
 
-        let content = "Yep. Something like that. I, of course could implement it " +
-            "in nostr:\(npub) but haven’t yet."
-        let expected = "Yep. Something like that. I, of course could implement it " +
-            "in @\(name) but haven’t yet."
+        let content = "Yep. Something like that. I, of course could implement it " + "in nostr:\(npub) but haven’t yet."
+        let expected = "Yep. Something like that. I, of course could implement it " + "in @\(name) but haven’t yet."
 
         let tags = [
             ["p", hex],
             ["p", "8c430bdaadc1a202e4dd11c86c82546bb108d755e374b7918181f533b94e312e"],
             ["e", "a9788ca56a90bb5b856e89f16f5f3b0da93c28ea625e845c9925a41377152a13", "", "root"],
-            ["e", "3d9503a2d4ad024749b138c041e99934474e2822e2a1c697792dab5b24acc285", "", "reply"]
+            ["e", "3d9503a2d4ad024749b138c041e99934474e2822e2a1c697792dab5b24acc285", "", "reply"],
         ]
 
         // Act

--- a/NosTests/Models/NoteParserTests+Parse.swift
+++ b/NosTests/Models/NoteParserTests+Parse.swift
@@ -83,7 +83,7 @@ extension NoteParserTests {
         noteEditor.append(text: "two mentions @")
         noteEditor.insertMention(of: author)
         textView.selectedRange = NSRange(location: textView.text.count, length: 0)
-        
+
         // Act
         let expected = "nostr:\(npub) two mentions nostr:\(npub) "
         let (content, _) = sut.parse(attributedText: noteEditor.text!)

--- a/NosTests/Models/NoteParserTests.swift
+++ b/NosTests/Models/NoteParserTests.swift
@@ -1,15 +1,15 @@
 import CoreData
-import XCTest
 import Dependencies
+import XCTest
 
 final class NoteParserTests: CoreDataTestCase {
 
     // swiftlint:disable:next implicitly_unwrapped_optional
     var sut: NoteParser!
-    
+
     // swiftlint:disable:next implicitly_unwrapped_optional
     var noteEditor: NoteEditorController!
-    
+
     // swiftlint:disable:next implicitly_unwrapped_optional
     var textView: UITextView!
 
@@ -93,7 +93,7 @@ final class NoteParserTests: CoreDataTestCase {
         XCTAssertEqual(links[safe: 0]?.key, nip05)
         XCTAssertEqual(links[safe: 0]?.value, URL(string: webLink))
     }
-    
+
     /// Example taken from [NIP-27](https://github.com/nostr-protocol/nips/blob/master/27.md)
     func testMentionWithNPub() throws {
         let mention = "@mattn"
@@ -110,7 +110,7 @@ final class NoteParserTests: CoreDataTestCase {
         XCTAssertEqual(content, expectedContent)
         XCTAssertEqual(tags, expectedTags)
     }
-    
+
     @MainActor func testContentWithMixedMentions() throws {
         let content = "hello nostr:npub1937vv2nf06360qn9y8el6d8sevnndy7tuh5nzre4gj05xc32tnwqauhaj6 and #[1]"
         let displayName1 = "npub1937vv..."
@@ -162,7 +162,7 @@ final class NoteParserTests: CoreDataTestCase {
         XCTAssertTrue(attributedContent.links.isEmpty)
         XCTAssertEqual(components.quotedNoteID, hex)
     }
-    
+
     @MainActor func testContentWithUntaggedNIP27Note() throws {
         let content = "Check this nostr:note1h2mmqfjqle48j8ytmdar22v42g5y9n942aumyxatgtxpqj29pjjsjecraw"
         let hex = "bab7b02640fe6a791c8bdb7a352995522842ccb55779b21bab42cc1049450ca5"
@@ -176,14 +176,14 @@ final class NoteParserTests: CoreDataTestCase {
         XCTAssertTrue(attributedContent.links.isEmpty)
         XCTAssertEqual(components.quotedNoteID, hex)
     }
-    
+
     @MainActor func testContentWithUntaggedProfile() throws {
         let profile = "nprofile1qqszclxx9f5haga8sfjjrulaxncvkfekj097t6f3pu65f86rvg49ehqj6f9dh"
         let hex = "2c7cc62a697ea3a7826521f3fd34f0cb273693cbe5e9310f35449f43622a5cdc"
 
         let content = "hello \(profile)"
         let tags: [[String]] = [[]]
-        
+
         let expectedContent = content
         let components = sut.components(
             from: content,
@@ -203,7 +203,8 @@ final class NoteParserTests: CoreDataTestCase {
 
     @MainActor func testContentWithUntaggedEvent() throws {
         // swiftlint:disable line_length
-        let event = "nevent1qqst8cujky046negxgwwm5ynqwn53t8aqjr6afd8g59nfqwxpdhylpcpzamhxue69uhhyetvv9ujuetcv9khqmr99e3k7mg8arnc9"
+        let event =
+            "nevent1qqst8cujky046negxgwwm5ynqwn53t8aqjr6afd8g59nfqwxpdhylpcpzamhxue69uhhyetvv9ujuetcv9khqmr99e3k7mg8arnc9"
         // swiftlint:enable line_length
 
         let hex = "b3e392b11f5d4f28321cedd09303a748acfd0487aea5a7450b3481c60b6e4f87"
@@ -221,14 +222,15 @@ final class NoteParserTests: CoreDataTestCase {
 
         let parsedContent = String(attributedContent.characters)
         XCTAssertEqual(parsedContent, expectedContent)
-        
+
         XCTAssertTrue(attributedContent.links.isEmpty)
         XCTAssertEqual(components.quotedNoteID, hex)
     }
 
     @MainActor func testContentWithUntaggedEventWithADot() throws {
         // swiftlint:disable line_length
-        let event = "nevent1qqst8cujky046negxgwwm5ynqwn53t8aqjr6afd8g59nfqwxpdhylpcpzamhxue69uhhyetvv9ujuetcv9khqmr99e3k7mg8arnc9"
+        let event =
+            "nevent1qqst8cujky046negxgwwm5ynqwn53t8aqjr6afd8g59nfqwxpdhylpcpzamhxue69uhhyetvv9ujuetcv9khqmr99e3k7mg8arnc9"
         // swiftlint:enable line_length
 
         let hex = "b3e392b11f5d4f28321cedd09303a748acfd0487aea5a7450b3481c60b6e4f87"
@@ -245,14 +247,15 @@ final class NoteParserTests: CoreDataTestCase {
         let attributedContent = components.attributedContent
         let parsedContent = String(attributedContent.characters)
         XCTAssertEqual(parsedContent, expectedContent)
-        
+
         XCTAssertTrue(attributedContent.links.isEmpty)
         XCTAssertEqual(components.quotedNoteID, hex)
     }
 
     @MainActor func testContentWithMalformedEvent() throws {
         // swiftlint:disable line_length
-        let event = "nevent1qqst8cujky046negxgwwm5ynqwn53t8aqjr6afd8g59nfqwxpdhylpcpzamhxue69uhhyetvv9ujuetcv9khqmr99e3k7mg8arnc9"
+        let event =
+            "nevent1qqst8cujky046negxgwwm5ynqwn53t8aqjr6afd8g59nfqwxpdhylpcpzamhxue69uhhyetvv9ujuetcv9khqmr99e3k7mg8arnc9"
         // swiftlint:enable line_length
 
         let content = "check this \(event)andthisshouldbreakmaybe. Bye!"
@@ -268,61 +271,62 @@ final class NoteParserTests: CoreDataTestCase {
 
         let parsedContent = String(attributedContent.characters)
         XCTAssertEqual(parsedContent, expectedContent)
-        
+
         XCTAssertTrue(attributedContent.links.isEmpty)
     }
-    
+
     @MainActor func testContentWithNAddr() throws {
         let naddrLink = "$3355903008550074;fa984bd7dbb282f07e16e7ae87b26a2a7b9b90b7246a44771f0cf5ae58018f52;31890"
 
         // swiftlint:disable line_length
         let content = """
-        People are using Coracle's custom feeds! Here are some interesting ones:\n\nnostr:naddr1qvzqqqrujgpzp75cf0tahv5z7plpdeaws7ex52nmnwgtwfr2g3m37r844evqrr6jqyghwumn8ghj7vf5xqhxvdm69e5k7tcpzdmhxue69uhhqatjwpkx2urpvuhx2ue0qythwumn8ghj7un9d3shjtnswf5k6ctv9ehx2ap0qy2hwumn8ghj7un9d3shjtnyv9kh2uewd9hj7qg6waehxw309ac8junpd45kgtnxd9shg6npvchxxmmd9uq3xamnwvaz7tmjv4kxz7fwvcmh5tnfduhsz9thwden5te0wfjkccte9ejhs6t59ec82c30qyf8wumn8ghj7un9d3shjtn5dahkcue0qy88wumn8ghj7mn0wvhxcmmv9uqpqvenx56njvpnxqcrsdf4xqcrwdqufrevn\nnostr:naddr1qvzqqqrujgpzqlxr9zsgmke2lhuln0nhhml5eq6gnluhjuscyltz3f2z7v4zglqwqyghwumn8ghj7mn0wd68ytnhd9hx2tcpzfmhxue69uhkummnw3eryvfwvdhk6tcpr4mhxue69uhksmm5wf5kw6r5dehhwtnwdaehgu339e3k7mf0qydhwumn8ghj7argv4nx7un9wd6zumn0wd68yvfwvdhk6tcpr4mhxue69uhkummnw3ezumt4w35ku7thv9kxcet59e3k7mf0qyt8wumn8ghj7cn9wehjumn0wd68yvfwvdhk6tcprfmhxue69uhkummnw3ezuargv4ekzmt9vdshgtnfduhszxnhwden5te0wpex7enfd3jhxtnwdaehgu339e3k7mf0qy2hwumn8ghj7un9d3shjtnyv9kh2uewd9hj7qgwwaehxw309ahx7uewd3hkctcqzycrgvpsxy6nwwfhxqer2wpjxycrx895qk5\nnostr:naddr1qvzqqqrujgpzqczwjmsfnym2zpyg89vtqs95weewpuzgex9v0yln0llycusz084jqyghwumn8ghj7mn0wd68ytnhd9hx2tcpz4mhxue69uhhyetvv9ujuerpd46hxtnfduhszymhwden5te0wp6hyurvv4cxzeewv4ej7qghwaehxw309aex2mrp0yhxummnw3ezucnpdejz7qghwaehxw309aex2mrp0yh8qunfd4skctnwv46z7qgawaehxw309ahx7um5wghx6at5d9h8jampd3kx2apwvdhk6tcppemhxue69uhkummn9ekx7mp0qqgrvdps8ymnqvf3xcersdfhxqmryx9hdms\nnostr:naddr1qvzqqqrujgpzq3an3axnwgfep4dkhmmcmt3l8cug3mxm7xzylwenhzrjr5mx6hygqy2hwumn8ghj7un9d3shjtnyv9kh2uewd9hj7qghwaehxw309aex2mrp0yhxummnw3ezucnpdejz7qg3waehxw309ahx7um5wgh8w6twv5hsz9mhwden5te0wfjkccte9cc8scmgv96zucm0d5hszrnhwden5te0dehhxtnvdakz7qqsxgurwdpkxg6nwdf58qer2ve3xvwjjnjg\n\nI encourage you to try it out — create your own and paste its address into a reply to this note to share it.
-        """
+            People are using Coracle's custom feeds! Here are some interesting ones:\n\nnostr:naddr1qvzqqqrujgpzp75cf0tahv5z7plpdeaws7ex52nmnwgtwfr2g3m37r844evqrr6jqyghwumn8ghj7vf5xqhxvdm69e5k7tcpzdmhxue69uhhqatjwpkx2urpvuhx2ue0qythwumn8ghj7un9d3shjtnswf5k6ctv9ehx2ap0qy2hwumn8ghj7un9d3shjtnyv9kh2uewd9hj7qg6waehxw309ac8junpd45kgtnxd9shg6npvchxxmmd9uq3xamnwvaz7tmjv4kxz7fwvcmh5tnfduhsz9thwden5te0wfjkccte9ejhs6t59ec82c30qyf8wumn8ghj7un9d3shjtn5dahkcue0qy88wumn8ghj7mn0wvhxcmmv9uqpqvenx56njvpnxqcrsdf4xqcrwdqufrevn\nnostr:naddr1qvzqqqrujgpzqlxr9zsgmke2lhuln0nhhml5eq6gnluhjuscyltz3f2z7v4zglqwqyghwumn8ghj7mn0wd68ytnhd9hx2tcpzfmhxue69uhkummnw3eryvfwvdhk6tcpr4mhxue69uhksmm5wf5kw6r5dehhwtnwdaehgu339e3k7mf0qydhwumn8ghj7argv4nx7un9wd6zumn0wd68yvfwvdhk6tcpr4mhxue69uhkummnw3ezumt4w35ku7thv9kxcet59e3k7mf0qyt8wumn8ghj7cn9wehjumn0wd68yvfwvdhk6tcprfmhxue69uhkummnw3ezuargv4ekzmt9vdshgtnfduhszxnhwden5te0wpex7enfd3jhxtnwdaehgu339e3k7mf0qy2hwumn8ghj7un9d3shjtnyv9kh2uewd9hj7qgwwaehxw309ahx7uewd3hkctcqzycrgvpsxy6nwwfhxqer2wpjxycrx895qk5\nnostr:naddr1qvzqqqrujgpzqczwjmsfnym2zpyg89vtqs95weewpuzgex9v0yln0llycusz084jqyghwumn8ghj7mn0wd68ytnhd9hx2tcpz4mhxue69uhhyetvv9ujuerpd46hxtnfduhszymhwden5te0wp6hyurvv4cxzeewv4ej7qghwaehxw309aex2mrp0yhxummnw3ezucnpdejz7qghwaehxw309aex2mrp0yh8qunfd4skctnwv46z7qgawaehxw309ahx7um5wghx6at5d9h8jampd3kx2apwvdhk6tcppemhxue69uhkummn9ekx7mp0qqgrvdps8ymnqvf3xcersdfhxqmryx9hdms\nnostr:naddr1qvzqqqrujgpzq3an3axnwgfep4dkhmmcmt3l8cug3mxm7xzylwenhzrjr5mx6hygqy2hwumn8ghj7un9d3shjtnyv9kh2uewd9hj7qghwaehxw309aex2mrp0yhxummnw3ezucnpdejz7qg3waehxw309ahx7um5wgh8w6twv5hsz9mhwden5te0wfjkccte9cc8scmgv96zucm0d5hszrnhwden5te0dehhxtnvdakz7qqsxgurwdpkxg6nwdf58qer2ve3xvwjjnjg\n\nI encourage you to try it out — create your own and paste its address into a reply to this note to share it.
+            """
         let tags: [[String]] = [[]]
-        
-        let expectedContent = "People are using Coracle's custom feeds! Here are some interesting ones:\n\n🔗 Link to note\n🔗 Link to note\n🔗 Link to note\n🔗 Link to note\n\nI encourage you to try it out — create your own and paste its address into a reply to this note to share it."
+
+        let expectedContent =
+            "People are using Coracle's custom feeds! Here are some interesting ones:\n\n🔗 Link to note\n🔗 Link to note\n🔗 Link to note\n🔗 Link to note\n\nI encourage you to try it out — create your own and paste its address into a reply to this note to share it."
         // swiftlint:enable line_length
-        
+
         let components = sut.components(
             from: content,
             tags: tags,
             context: testContext
         )
         let attributedContent = components.attributedContent
-        
+
         let parsedContent = String(attributedContent.characters)
         XCTAssertEqual(parsedContent, expectedContent)
-        
+
         let links = attributedContent.links
         XCTAssertEqual(links.count, 4)
         XCTAssertEqual(links[safe: 0]?.key, "🔗 Link to note")
         XCTAssertEqual(links[safe: 0]?.value, URL(string: naddrLink))
     }
-    
+
     @MainActor func testContentWithYakihonneNeventLink() {
         // swiftlint:disable line_length
         let content = """
-        "https://yakihonne.com/notes/nevent1qgszpxr0hql8whvk6xyv5hya7yxwd4snur4hu4mg5rctz2ehekkzrvcqyrej80hs0k7ydd60p4zpdddqlx4zr66fwns5frwn2zf2gg3u8vr3w725fc0"
-        """
-        
+            "https://yakihonne.com/notes/nevent1qgszpxr0hql8whvk6xyv5hya7yxwd4snur4hu4mg5rctz2ehekkzrvcqyrej80hs0k7ydd60p4zpdddqlx4zr66fwns5frwn2zf2gg3u8vr3w725fc0"
+            """
+
         let expectedContent = "\"yakihonne.com...\""
         // swiftlint:enable line_length
-        
+
         let components = sut.components(
             from: content,
             tags: [[]],
             context: testContext
         )
         let attributedContent = components.attributedContent
-        
+
         let parsedContent = String(attributedContent.characters)
         XCTAssertEqual(parsedContent, expectedContent)
-        
+
         let links = attributedContent.links
         XCTAssertEqual(links.count, 1)
         XCTAssertEqual(links[safe: 0]?.key, "yakihonne.com...")
-        
+
         XCTAssertNil(components.quotedNoteID)
     }
 }

--- a/NosTests/Models/NotificationViewModelTests.swift
+++ b/NosTests/Models/NotificationViewModelTests.swift
@@ -3,42 +3,42 @@ import Foundation
 import XCTest
 
 final class NotificationViewModelTests: CoreDataTestCase {
-    
+
     @MainActor
     func testZapProfileNotification() throws {
         let zapRequest = try zapRequestEvent(filename: "zap_request")
         let recipient = try XCTUnwrap(Author.findOrCreate(by: "alice", context: testContext))
         let viewModel = NotificationViewModel(note: zapRequest, user: recipient)
-        
+
         let notification = viewModel.notificationCenterRequest
         XCTAssertEqual(notification.content.title, "npub1vnz0m... ⚡️ zapped you 3,500 sats!")
         XCTAssertEqual(notification.content.body, "Zapped you!")
     }
-    
+
     @MainActor
     func testZapProfileNotification_noAmount() throws {
         let zapRequest = try zapRequestEvent(filename: "zap_request_no_amount")
         let recipient = try XCTUnwrap(Author.findOrCreate(by: "alice", context: testContext))
         let viewModel = NotificationViewModel(note: zapRequest, user: recipient)
-        
+
         let notification = viewModel.notificationCenterRequest
         XCTAssertEqual(notification.content.title, "npub1vnz0m... ⚡️ zapped you!")
         XCTAssertEqual(notification.content.body, "Zap!")
     }
-    
+
     @MainActor
     func testZapProfileNotification_oneSat() throws {
         let zapRequest = try zapRequestEvent(filename: "zap_request_one_sat")
         let recipient = try XCTUnwrap(Author.findOrCreate(by: "alice", context: testContext))
         let viewModel = NotificationViewModel(note: zapRequest, user: recipient)
-        
+
         let notification = viewModel.notificationCenterRequest
         XCTAssertEqual(notification.content.title, "npub1vnz0m... ⚡️ zapped you 1 sat!")
         XCTAssertEqual(notification.content.body, "Only one sat")
     }
-    
+
     // MARK: Helpers
-    
+
     @MainActor
     private func zapRequestEvent(filename: String) throws -> Event {
         let jsonData = try jsonData(filename: filename)

--- a/NosTests/Models/OpenGraph/MockOpenGraphParser.swift
+++ b/NosTests/Models/OpenGraph/MockOpenGraphParser.swift
@@ -3,7 +3,7 @@ import Foundation
 /// A mock Open Graph parser that can be used for testing.
 final class MockOpenGraphParser: OpenGraphParser {
     var metadataCallCount = 0
-    
+
     func metadata(html: Data) -> OpenGraphMetadata? {
         metadataCallCount += 1
         return nil

--- a/NosTests/Models/OpenGraph/SoupOpenGraphParserTests.swift
+++ b/NosTests/Models/OpenGraph/SoupOpenGraphParserTests.swift
@@ -19,7 +19,7 @@ class SoupOpenGraphParserTests: XCTestCase {
 
         // Assert
         XCTAssertEqual(metadata.type, .video)
-        
+
         XCTAssertEqual(metadata.video?.url?.absoluteString, "https://example.com/movie.swf")
         XCTAssertEqual(metadata.video?.width, 2560)
         XCTAssertEqual(metadata.video?.height, 1440)
@@ -39,7 +39,7 @@ class SoupOpenGraphParserTests: XCTestCase {
 
         // Assert
         XCTAssertEqual(metadata.type, .unknown)
-        
+
         XCTAssertEqual(metadata.video?.url?.absoluteString, "https://example.com/rock.mp4")
         XCTAssertEqual(metadata.image?.url?.absoluteString, "https://example.com/rock.jpg")
     }
@@ -107,7 +107,7 @@ class SoupOpenGraphParserTests: XCTestCase {
         XCTAssertEqual(metadata.video?.url?.absoluteString, "https://www.youtube.com/embed/ZILsHowUjpQ")
         XCTAssertEqual(metadata.video?.width, 1280)
         XCTAssertEqual(metadata.video?.height, 720)
-        
+
         XCTAssertEqual(metadata.image?.width, 1280)
         XCTAssertEqual(metadata.image?.height, 720)
     }
@@ -122,7 +122,7 @@ class SoupOpenGraphParserTests: XCTestCase {
 
         // Assert
         XCTAssertEqual(
-            metadata.title, 
+            metadata.title,
             "A fortnight since TTPD 🤍 brought to you by YouTube Shorts #ForAFortnightChallenge"
         )
 

--- a/NosTests/Models/RawNostrIDTests.swift
+++ b/NosTests/Models/RawNostrIDTests.swift
@@ -6,12 +6,12 @@ final class RawNostrIDTests: XCTestCase {
         let validKey = RawNostrID("76c71aae3a491f1d9eec47cba17e229cda4113a0bbb6e6ae1776d7643e29cafa")
         XCTAssertEqual(validKey.isValid, true)
     }
-    
+
     func testHexadecimalKeyWithInvalidCharactersIsNotValid() throws {
         let invalidCharacterKey = RawNostrID("!6c71aae3a491f1d9eec47cba17e229cda4113a0bbb6e6ae1776d7643e29cafa")
         XCTAssertEqual(invalidCharacterKey.isValid, false)
     }
-    
+
     func testHexadecimalKeyTooShortIsNotValid() throws {
         let invalidShortKey = RawNostrID("6c71aae3a491f1d9eec47cba17e229cda4113a0bbb6e6ae1776d7643e29cafa")
         XCTAssertEqual(invalidShortKey.isValid, false)

--- a/NosTests/Models/URLParserTests.swift
+++ b/NosTests/Models/URLParserTests.swift
@@ -12,7 +12,8 @@ class URLParserTests: XCTestCase {
 
     func testExtractURLs() throws {
         // swiftlint:disable line_length
-        let string = "Classifieds incoming... 👀\n\nhttps://nostr.build/i/2170fa01a69bca5ad0334430ccb993e41bb47eb15a4b4dbdfbee45585f63d503.jpg"
+        let string =
+            "Classifieds incoming... 👀\n\nhttps://nostr.build/i/2170fa01a69bca5ad0334430ccb993e41bb47eb15a4b4dbdfbee45585f63d503.jpg"
         let expectedString = "Classifieds incoming... 👀"
         // swiftlint:enable line_length
         let expectedURLs = [
@@ -53,22 +54,22 @@ class URLParserTests: XCTestCase {
 
     func testExtractURLsWithMultipleURLs() throws {
         let string = """
-        A few links...
+            A few links...
 
-        https://nostr.build/i/2170fa01a69bca5ad0334430ccb993e41bb47eb15a4b4dbdfbee45585f63d503.jpg
-        nos.social
-        www.nostr.com/get-started
-        """
+            https://nostr.build/i/2170fa01a69bca5ad0334430ccb993e41bb47eb15a4b4dbdfbee45585f63d503.jpg
+            nos.social
+            www.nostr.com/get-started
+            """
         let expectedString = """
-        A few links...
-        [nos.social](https://nos.social)
-        [nostr.com...](https://www.nostr.com/get-started)
-        """
+            A few links...
+            [nos.social](https://nos.social)
+            [nostr.com...](https://www.nostr.com/get-started)
+            """
 
         let expectedURLs = [
             URL(string: "https://nostr.build/i/2170fa01a69bca5ad0334430ccb993e41bb47eb15a4b4dbdfbee45585f63d503.jpg")!,
             URL(string: "https://nos.social")!,
-            URL(string: "https://www.nostr.com/get-started")
+            URL(string: "https://www.nostr.com/get-started"),
         ]
 
         // Act
@@ -104,7 +105,7 @@ class URLParserTests: XCTestCase {
         XCTAssertEqual(actualString, expectedString)
         XCTAssertEqual(actualURLs, expectedURLs)
     }
-    
+
     func testExtractURLsDoesNotIncludePeriodsInURLs() throws {
         // Arrange
         let string = "Welcome to nos.social. It's a place for humans"

--- a/NosTests/Service/Bech32Tests.swift
+++ b/NosTests/Service/Bech32Tests.swift
@@ -17,7 +17,8 @@ final class Bech32Tests: XCTestCase {
     func testShareableIdentifier() throws {
         let prefix = "nprofile"
         // swiftlint:disable:next line_length
-        let nprofile = "nprofile1qqsrhuxx8l9ex335q7he0f09aej04zpazpl0ne2cgukyawd24mayt8gpp4mhxue69uhhytnc9e3k7mgpz4mhxue69uhkg6nzv9ejuumpv34kytnrdaksjlyr9p"
+        let nprofile =
+            "nprofile1qqsrhuxx8l9ex335q7he0f09aej04zpazpl0ne2cgukyawd24mayt8gpp4mhxue69uhhytnc9e3k7mgpz4mhxue69uhkg6nzv9ejuumpv34kytnrdaksjlyr9p"
 
         let hex = "3bf0c63fcb93463407af97a5e5ee64fa883d107ef9e558472c4eb9aaaefa459d"
         let decoded = try Bech32.decode(nprofile)
@@ -25,7 +26,7 @@ final class Bech32Tests: XCTestCase {
         let base8data = try XCTUnwrap(try decoded.checksum.base8FromBase5())
         let offset = 0
         let length = base8data[offset + 1]
-        let value = base8data.subdata(in: offset + 2 ..< offset + 2 + Int(length))
+        let value = base8data.subdata(in: offset + 2..<offset + 2 + Int(length))
         XCTAssertEqual(value.hexString, hex)
     }
 }

--- a/NosTests/Service/DatabaseCleanerTests.swift
+++ b/NosTests/Service/DatabaseCleanerTests.swift
@@ -1,88 +1,88 @@
-import XCTest
 import CoreData
+import XCTest
 
 final class DatabaseCleanerTests: CoreDataTestCase {
-    
+
     @MainActor func test_emptyDatabase() async throws {
         // Act
         try await DatabaseCleaner.cleanupEntities(for: KeyFixture.alice.publicKeyHex, in: testContext)
-        
+
         // Assert that the database is still empty
         let managedObjectModel = try XCTUnwrap(testContext.persistentStoreCoordinator?.managedObjectModel)
         let entitiesByName = managedObjectModel.entitiesByName
-        XCTAssertGreaterThan(entitiesByName.count, 0) // sanity check
-            
+        XCTAssertGreaterThan(entitiesByName.count, 0)  // sanity check
+
         for entityName in entitiesByName.keys {
             let fetchRequest = NSFetchRequest<NSFetchRequestResult>(entityName: entityName)
             XCTAssertEqual(try testContext.count(for: fetchRequest), 0)
         }
     }
-    
+
     // MARK: - EventReferences
-    
+
     @MainActor func test_cleanup_deletesCorrectEventReferences() async throws {
         // Arrange
-        // Create the signed in user or the DatabaseCleaner will exit early. 
+        // Create the signed in user or the DatabaseCleaner will exit early.
         _ = try Author.findOrCreate(by: KeyFixture.alice.publicKeyHex, context: testContext)
         let oldEventOne = try EventFixture.build(in: testContext, receivedAt: Date(timeIntervalSince1970: 9))
         let oldEventTwo = try EventFixture.build(in: testContext, receivedAt: Date(timeIntervalSince1970: 8))
         let newEvent = try EventFixture.build(in: testContext, receivedAt: Date(timeIntervalSince1970: 11))
-        
+
         // Create a reference with two old events that should be deleted
         let eventReferenceToBeDeleted = EventReference(context: testContext)
         eventReferenceToBeDeleted.referencedEvent = oldEventOne
         eventReferenceToBeDeleted.referencingEvent = oldEventTwo
-        
+
         // Create references with a new event that should not be deleted
         let eventReferenceToBeKept = EventReference(context: testContext)
         eventReferenceToBeKept.referencingEvent = newEvent
         eventReferenceToBeKept.referencedEvent = oldEventTwo
-        
+
         try testContext.save()
-        
-        // Act 
+
+        // Act
         try await DatabaseCleaner.cleanupEntities(
-            for: KeyFixture.alice.publicKeyHex, 
+            for: KeyFixture.alice.publicKeyHex,
             in: testContext,
             keeping: 1
         )
-        
+
         // Assert
         let eventReferences = try testContext.fetch(EventReference.all())
         XCTAssertEqual(eventReferences.count, 1)
         XCTAssertEqual(eventReferences.first?.referencingEvent, newEvent)
         XCTAssertEqual(eventReferences.first?.referencedEvent, oldEventTwo)
     }
-    
+
     @MainActor func test_cleanup_savesReferencedEvents() async throws {
         // Arrange
-        // Create the signed in user or the DatabaseCleaner will exit early. 
+        // Create the signed in user or the DatabaseCleaner will exit early.
         _ = try Author.findOrCreate(by: KeyFixture.alice.publicKeyHex, context: testContext)
         // Create an old event that is referenced by a newer event
         let oldEvent = try EventFixture.build(in: testContext, receivedAt: Date(timeIntervalSince1970: 9))
         let newEvent = try EventFixture.build(in: testContext, receivedAt: Date(timeIntervalSince1970: 11))
-        
+
         let eventReferenceToBeDeleted = EventReference(context: testContext)
         eventReferenceToBeDeleted.referencedEvent = oldEvent
         eventReferenceToBeDeleted.referencingEvent = newEvent
-        
+
         try testContext.save()
-        
-        // Act 
+
+        // Act
         try await DatabaseCleaner.cleanupEntities(
-            for: KeyFixture.alice.publicKeyHex, 
+            for: KeyFixture.alice.publicKeyHex,
             in: testContext,
             keeping: 1
         )
-        
+
         // Assert
         let events = try testContext.fetch(Event.allEventsRequest())
         XCTAssertEqual(events.count, 2)
     }
-    
+
     @MainActor func test_cleanup_givenEventReferenceChain_thenOldEventsStubbed() async throws {
         // Arrange
-        // Create the signed in user or the DatabaseCleaner will exit early. 
+        // Create the signed in user or the DatabaseCleaner will exit early.
         _ = try Author.findOrCreate(by: KeyFixture.alice.publicKeyHex, context: testContext)
         // Create a chain of events that reference one another. Two of them are old enough to be deleted.
         try testContext.save()
@@ -90,24 +90,24 @@ final class DatabaseCleanerTests: CoreDataTestCase {
         let oldEvent = try EventFixture.build(in: testContext, receivedAt: Date(timeIntervalSince1970: 9))
         let reallyOldEvent = try EventFixture.build(in: testContext, receivedAt: Date(timeIntervalSince1970: 0))
         try testContext.save()
-        
+
         let eventReferenceToBeKept = EventReference(context: testContext)
         eventReferenceToBeKept.referencingEvent = newEvent
         eventReferenceToBeKept.referencedEvent = oldEvent
-        
+
         let eventReferenceToBeDeleted = EventReference(context: testContext)
         eventReferenceToBeDeleted.referencingEvent = oldEvent
         eventReferenceToBeDeleted.referencedEvent = reallyOldEvent
-        
+
         try testContext.save()
-        
-        // Act 
+
+        // Act
         try await DatabaseCleaner.cleanupEntities(
-            for: KeyFixture.alice.publicKeyHex, 
+            for: KeyFixture.alice.publicKeyHex,
             in: testContext,
             keeping: 1
         )
-        
+
         // Assert
         // We expect the really old event to be deleted entirely and the old event should be changed to a stub.
         let events = try testContext.fetch(Event.allEventsRequest())
@@ -117,115 +117,115 @@ final class DatabaseCleanerTests: CoreDataTestCase {
         XCTAssertEqual(events.last?.identifier, newEvent.identifier)
         XCTAssertEqual(events.last?.isStub, false)
     }
-    
+
     // MARK: - Events
-    
+
     @MainActor func test_cleanup_keepsNEvents() async throws {
-        // Create the signed in user or the DatabaseCleaner will exit early. 
+        // Create the signed in user or the DatabaseCleaner will exit early.
         _ = try Author.findOrCreate(by: KeyFixture.alice.publicKeyHex, context: testContext)
-        
+
         var events = [Event]()
         for i in 0..<10 {
             let date = Date(timeIntervalSince1970: TimeInterval(i))
             events.append(
                 try EventFixture.build(
-                    in: testContext, 
+                    in: testContext,
                     createdAt: date,
                     receivedAt: date
-                ) 
+                )
             )
         }
-        
+
         try testContext.save()
-        
-        // Act 
+
+        // Act
         try await DatabaseCleaner.cleanupEntities(
-            for: KeyFixture.alice.publicKeyHex, 
+            for: KeyFixture.alice.publicKeyHex,
             in: testContext,
             keeping: 5
         )
-        
+
         // Assert
         let fetchedEvents = try testContext.fetch(Event.allEventsRequest())
         XCTAssertEqual(fetchedEvents.map { $0.identifier }, events.suffix(5).map { $0.identifier })
     }
-    
+
     @MainActor func test_cleanup_deletesOldEvents() async throws {
-        // Create the signed in user or the DatabaseCleaner will exit early. 
+        // Create the signed in user or the DatabaseCleaner will exit early.
         let user = KeyFixture.alice
         _ = try Author.findOrCreate(by: user.publicKeyHex, context: testContext)
-        
-        _ = try EventFixture.build(in: testContext, receivedAt: Date(timeIntervalSince1970: 9)) // old event
+
+        _ = try EventFixture.build(in: testContext, receivedAt: Date(timeIntervalSince1970: 9))  // old event
         let newEvent = try EventFixture.build(in: testContext, receivedAt: Date(timeIntervalSince1970: 11))
-        
+
         try testContext.save()
-        
-        // Act 
+
+        // Act
         try await DatabaseCleaner.cleanupEntities(
-            for: KeyFixture.alice.publicKeyHex, 
+            for: KeyFixture.alice.publicKeyHex,
             in: testContext,
             keeping: 1
         )
-        
+
         // Assert
         let events = try testContext.fetch(Event.allEventsRequest())
         XCTAssertEqual(events, [newEvent])
     }
-    
+
     // MARK: - Authors
-    
+
     @MainActor func test_cleanup_keepsInNetworkAuthors() async throws {
         // Arrange
         let alice = try Author.findOrCreate(by: KeyFixture.alice.publicKeyHex, context: testContext)
-        let bob   = try Author.findOrCreate(by: "bob", context: testContext)
-        let carl  = try Author.findOrCreate(by: "carl", context: testContext)
-        let eve   = try Author.findOrCreate(by: "eve", context: testContext)
-        
+        let bob = try Author.findOrCreate(by: "bob", context: testContext)
+        let carl = try Author.findOrCreate(by: "carl", context: testContext)
+        let eve = try Author.findOrCreate(by: "eve", context: testContext)
+
         // Act
         // Create a circle of follows alice -> bob -> carl -> eve -> alice
         _ = try Follow.findOrCreate(source: alice, destination: bob, context: testContext)
         _ = try Follow.findOrCreate(source: bob, destination: carl, context: testContext)
         _ = try Follow.findOrCreate(source: carl, destination: eve, context: testContext)
         _ = try Follow.findOrCreate(source: eve, destination: alice, context: testContext)
-        
+
         try testContext.saveIfNeeded()
-        
-        // Act 
+
+        // Act
         try await DatabaseCleaner.cleanupEntities(
-            for: KeyFixture.alice.publicKeyHex, 
+            for: KeyFixture.alice.publicKeyHex,
             in: testContext
         )
-        
+
         // Assert
         let authors = try testContext.fetch(Author.allAuthorsRequest())
         // Eve is out of network and should be deleted. The others should be kept.
         XCTAssertEqual(authors, [carl, bob, alice])
     }
-    
+
     // MARK: - Follows
-    
+
     @MainActor func test_cleanup_keepsInNetworkFollows() async throws {
         // Arrange
         let alice = try Author.findOrCreate(by: KeyFixture.alice.publicKeyHex, context: testContext)
-        let bob   = try Author.findOrCreate(by: "bob", context: testContext)
-        let carl  = try Author.findOrCreate(by: "carl", context: testContext)
-        let eve   = try Author.findOrCreate(by: "eve", context: testContext)
-        
+        let bob = try Author.findOrCreate(by: "bob", context: testContext)
+        let carl = try Author.findOrCreate(by: "carl", context: testContext)
+        let eve = try Author.findOrCreate(by: "eve", context: testContext)
+
         // Act
         // Create a circle of follows alice -> bob -> carl -> eve -> alice
         let followOne = try Follow.findOrCreate(source: alice, destination: bob, context: testContext)
         let followTwo = try Follow.findOrCreate(source: bob, destination: carl, context: testContext)
         let followThree = try Follow.findOrCreate(source: carl, destination: eve, context: testContext)
         _ = try Follow.findOrCreate(source: eve, destination: alice, context: testContext)
-        
+
         try testContext.saveIfNeeded()
-        
-        // Act 
+
+        // Act
         try await DatabaseCleaner.cleanupEntities(
-            for: KeyFixture.alice.publicKeyHex, 
+            for: KeyFixture.alice.publicKeyHex,
             in: testContext
         )
-        
+
         // Assert
         let follows = try testContext.fetch(Follow.allFollowsRequest())
         XCTAssertEqual(follows, [followThree, followTwo, followOne])
@@ -257,16 +257,16 @@ final class DatabaseCleanerTests: CoreDataTestCase {
         let events = try testContext.fetch(Event.allEventsRequest())
         XCTAssertEqual(events.count, 0)
     }
-    
+
     @MainActor func test_deleteAllEntities() async throws {
         _ = try EventFixture.build(in: testContext, identifier: "1", publicKey: "1", content: "test 1")
         _ = try EventFixture.build(in: testContext, identifier: "2", publicKey: "2", content: "test 2")
         _ = try EventFixture.build(in: testContext, identifier: "3", publicKey: "3", content: "test 3")
-        
+
         _ = try Relay.findOrCreate(by: "wss://cool-relay.io", context: testContext)
-        
+
         try testContext.save()
-        
+
         var events = try testContext.fetch(Event.allEventsRequest())
         XCTAssertEqual(events.count, 3)
         events.removeAll()
@@ -274,20 +274,20 @@ final class DatabaseCleanerTests: CoreDataTestCase {
         var authors = try testContext.fetch(Author.allAuthorsRequest())
         XCTAssertEqual(authors.count, 3)
         authors.removeAll()
-        
+
         let allRelaysRequest = NSFetchRequest<Event>(entityName: "Relay")
         var relays = try testContext.fetch(allRelaysRequest)
         XCTAssertEqual(relays.count, 1)
         relays.removeAll()
-        
+
         await persistenceController.container.deleteAllEntities()
-        
+
         events = try testContext.fetch(Event.allEventsRequest())
         XCTAssertTrue(events.isEmpty)
-        
+
         authors = try testContext.fetch(Author.allAuthorsRequest())
         XCTAssertTrue(authors.isEmpty)
-        
+
         relays = try testContext.fetch(allRelaysRequest)
         XCTAssertTrue(relays.isEmpty)
     }

--- a/NosTests/Service/DirectMessageWrapperTests.swift
+++ b/NosTests/Service/DirectMessageWrapperTests.swift
@@ -4,13 +4,13 @@ final class DirectMessageWrapperTests: XCTestCase {
     func testDirectMessageWrapper() throws {
         let senderKeyPair = KeyFixture.alice
         let receiverKeyPair = KeyFixture.bob
-        
+
         let wrappedDM = try DirectMessageWrapper.wrap(
             message: "Are you going to the party tonight? 🎉",
             senderKeyPair: senderKeyPair,
             receiverPubkey: receiverKeyPair.publicKeyHex
         )
-        
+
         XCTAssertEqual(wrappedDM.kind, EventKind.giftWrap.rawValue)
         XCTAssertEqual(wrappedDM.tags, [["p", receiverKeyPair.publicKeyHex]])
         XCTAssertGreaterThan(

--- a/NosTests/Service/FileStorage/NostrBuildAPIClientTests.swift
+++ b/NosTests/Service/FileStorage/NostrBuildAPIClientTests.swift
@@ -32,7 +32,7 @@ class NostrBuildAPIClientTests: XCTestCase {
             XCTFail("Expected an error to be thrown")
         } catch {
             switch error {
-            case FileStorageAPIClientError.decodingError: 
+            case FileStorageAPIClientError.decodingError:
                 break
             default:
                 XCTFail("Expected a decodingError but got \(error)")

--- a/NosTests/Service/GiftWrapperTests.swift
+++ b/NosTests/Service/GiftWrapperTests.swift
@@ -4,7 +4,7 @@ final class GiftWrapperTests: XCTestCase {
     func testGiftWrappedRumor() throws {
         let senderKeyPair = KeyFixture.alice
         let receiverKeyPair = KeyFixture.bob
-        
+
         let rumor = JSONEvent(
             pubKey: senderKeyPair.publicKeyHex,
             createdAt: Date(),
@@ -12,13 +12,13 @@ final class GiftWrapperTests: XCTestCase {
             tags: [["p", receiverKeyPair.publicKeyHex]],
             content: "Are you going to the party tonight? 🎉"
         )
-        
+
         let wrappedDM = try GiftWrapper.wrap(
             rumor: rumor,
             senderKeyPair: senderKeyPair,
             receiverPubkey: receiverKeyPair.publicKeyHex
         )
-        
+
         XCTAssertEqual(wrappedDM.kind, EventKind.giftWrap.rawValue)
         XCTAssertEqual(wrappedDM.tags, [["p", receiverKeyPair.publicKeyHex]])
         XCTAssertGreaterThan(
@@ -45,7 +45,7 @@ final class GiftWrapperTests: XCTestCase {
             giftWrap: wrappedDM,
             receiverKeyPair: receiverKeyPair
         )
-        
+
         XCTAssertEqual(unwrappedDM.kind, EventKind.directMessageRumor.rawValue)
         XCTAssertEqual(unwrappedDM.pubKey, senderKeyPair.publicKeyHex)
         XCTAssertEqual(unwrappedDM.content, "Are you going to the party tonight? 🎉")

--- a/NosTests/Service/Media/DefaultOpenGraphServiceTests.swift
+++ b/NosTests/Service/Media/DefaultOpenGraphServiceTests.swift
@@ -37,7 +37,7 @@ class DefaultOpenGraphServiceTests: XCTestCase {
         // Assert
         XCTAssertEqual(mockParser.metadataCallCount, 0)
     }
-    
+
     /// Make sure we have the right User-Agent since some websites only provide Open Graph metadata for specific values.
     func test_fetchMetadata_request_has_correct_user_agent() async throws {
         // Arrange

--- a/NosTests/Service/MockFeatureFlags.swift
+++ b/NosTests/Service/MockFeatureFlags.swift
@@ -2,13 +2,13 @@
 class MockFeatureFlags: FeatureFlags {
     /// Mock feature flags and their values.
     private var featureFlags: [FeatureFlag: Bool] = [
-        .newModerationFlow: false,
+        .newModerationFlow: false
     ]
 
     func isEnabled(_ feature: FeatureFlag) -> Bool {
         featureFlags[feature] ?? false
     }
-    
+
     func setFeature(_ feature: FeatureFlag, enabled: Bool) {
         featureFlags[feature] = enabled
     }

--- a/NosTests/Service/NostrIdentifier/NostrIdentifierTests.swift
+++ b/NosTests/Service/NostrIdentifier/NostrIdentifierTests.swift
@@ -42,7 +42,8 @@ class NostrIdentifierTests: XCTestCase {
     /// Example taken from [NIP-19](https://github.com/nostr-protocol/nips/blob/master/19.md)
     func test_nprofile() throws {
         // swiftlint:disable:next line_length
-        let nprofile = "nprofile1qqsrhuxx8l9ex335q7he0f09aej04zpazpl0ne2cgukyawd24mayt8gpp4mhxue69uhhytnc9e3k7mgpz4mhxue69uhkg6nzv9ejuumpv34kytnrdaksjlyr9p"
+        let nprofile =
+            "nprofile1qqsrhuxx8l9ex335q7he0f09aej04zpazpl0ne2cgukyawd24mayt8gpp4mhxue69uhhytnc9e3k7mgpz4mhxue69uhkg6nzv9ejuumpv34kytnrdaksjlyr9p"
 
         let identifier = try NostrIdentifier.decode(bech32String: nprofile)
         switch identifier {
@@ -62,7 +63,8 @@ class NostrIdentifierTests: XCTestCase {
     /// note1ar8gnwj6ugxyq6w9aqur74s2sn4dttk6zx0d25p34fsg476kqrksmkqqnr
     func test_nprofile_with_9_relays() throws {
         // swiftlint:disable:next line_length
-        let nprofile = "nprofile1qyvhwumn8ghj7un9d3shjtnndehhyapwwdhkx6tpdshszrnhwden5te0dehhxtnvdakz7qghwaehxw309aex2mrp0yhxummnw3ezucnpdejz7qg4waehxw309aex2mrp0yhxgctdw4eju6t09uq3xamnwvaz7tm0venxx6rpd9hzuur4vghszxnhwden5te0wfjkccte9eeks6t5vehhycm99ehkuef0qy08wumn8ghj7mn0wd68yttsw43zuam9d3kx7unyv4ezumn9wshszxrhwden5te0wfjkccte9e3h2unjv4h8gtnx095j7qgawaehxw309ahx7um5wghx6at5d9h8jampd3kx2apwvdhk6tcqyqe4dhnpkwty0ycuazepgzet4wphuzqscrh4zka7jt0qyjqypw9a60jrgzx"
+        let nprofile =
+            "nprofile1qyvhwumn8ghj7un9d3shjtnndehhyapwwdhkx6tpdshszrnhwden5te0dehhxtnvdakz7qghwaehxw309aex2mrp0yhxummnw3ezucnpdejz7qg4waehxw309aex2mrp0yhxgctdw4eju6t09uq3xamnwvaz7tm0venxx6rpd9hzuur4vghszxnhwden5te0wfjkccte9eeks6t5vehhycm99ehkuef0qy08wumn8ghj7mn0wd68yttsw43zuam9d3kx7unyv4ezumn9wshszxrhwden5te0wfjkccte9e3h2unjv4h8gtnx095j7qgawaehxw309ahx7um5wghx6at5d9h8jampd3kx2apwvdhk6tcqyqe4dhnpkwty0ycuazepgzet4wphuzqscrh4zka7jt0qyjqypw9a60jrgzx"
 
         let identifier = try NostrIdentifier.decode(bech32String: nprofile)
         switch identifier {
@@ -80,7 +82,8 @@ class NostrIdentifierTests: XCTestCase {
     /// note1qq7am022xm40yrj9k4agcfqwre4lflsq6mytky0suxunrk7ldf5sjwth8x
     func test_nevent() throws {
         // swiftlint:disable:next line_length
-        let nevent = "nevent1qyt8wumn8ghj7un9d3shjtnddaehgu3wwp6kytcpz9mhxue69uhkummnw3ezumrpdejz7qg4waehxw309aex2mrp0yhxgctdw4eju6t09uq3wamnwvaz7tmjv4kxz7fwwpexjmtpdshxuet59uq32amnwvaz7tmwdaehgu3wdau8gu3wv3jhvtcpr4mhxue69uhkummnw3ezucnfw33k76twv4ezuum0vd5kzmp0qyv8wumn8ghj7mn0wd68ytnxd46zuamf0ghxy6t69uq3jamnwvaz7tmjv4kxz7fwwdhx7un59eek7cmfv9kz7qghwaehxw309aex2mrp0yhxummnw3ezucnpdejz7qg3waehxw309ahx7um5wgh8w6twv5hsqg9p8569xea0fgnv0zuqnt3wsk5mu9j6xal7ten6332pg9r5h8g32gl7wn5w"
+        let nevent =
+            "nevent1qyt8wumn8ghj7un9d3shjtnddaehgu3wwp6kytcpz9mhxue69uhkummnw3ezumrpdejz7qg4waehxw309aex2mrp0yhxgctdw4eju6t09uq3wamnwvaz7tmjv4kxz7fwwpexjmtpdshxuet59uq32amnwvaz7tmwdaehgu3wdau8gu3wv3jhvtcpr4mhxue69uhkummnw3ezucnfw33k76twv4ezuum0vd5kzmp0qyv8wumn8ghj7mn0wd68ytnxd46zuamf0ghxy6t69uq3jamnwvaz7tmjv4kxz7fwwdhx7un59eek7cmfv9kz7qghwaehxw309aex2mrp0yhxummnw3ezucnpdejz7qg3waehxw309ahx7um5wgh8w6twv5hsqg9p8569xea0fgnv0zuqnt3wsk5mu9j6xal7ten6332pg9r5h8g32gl7wn5w"
 
         let identifier = try NostrIdentifier.decode(bech32String: nevent)
         switch identifier {
@@ -103,7 +106,8 @@ class NostrIdentifierTests: XCTestCase {
     /// Example taken from note1ypppzcue3svj2p0l80vp4lf52j3xmykn8yzjdv3gnq2sm4ljp5qqrqp9hd
     func test_nevent_with_7_relays() throws {
         // swiftlint:disable:next line_length
-        let nevent = "nevent1qydhwumn8ghj7emvv4shxmmwv96x7u3wv3jhvtmjv4kxz7gprpmhxue69uhkummnv3exjan99eshqup0wfjkccteqyt8wumn8ghj7un9d3shjtnddaehgu3wwp6kytcpzamhxue69uhhyetvv9ujuurjd9kkzmpwdejhgtcpr9mhxue69uhhyetvv9ujuumwdae8gtnnda3kjctv9uq32amnwvaz7tmjv4kxz7fwv3sk6atn9e5k7tcprdmhxue69uhkummnw3e8gctvdvhxummnw3erztnrdakj7qpq38c7tac2uhqvqvxnv5d9mrq4km46pf232v9at473watm6597vucq4rru2q"
+        let nevent =
+            "nevent1qydhwumn8ghj7emvv4shxmmwv96x7u3wv3jhvtmjv4kxz7gprpmhxue69uhkummnv3exjan99eshqup0wfjkccteqyt8wumn8ghj7un9d3shjtnddaehgu3wwp6kytcpzamhxue69uhhyetvv9ujuurjd9kkzmpwdejhgtcpr9mhxue69uhhyetvv9ujuumwdae8gtnnda3kjctv9uq32amnwvaz7tmjv4kxz7fwv3sk6atn9e5k7tcprdmhxue69uhkummnw3e8gctvdvhxummnw3erztnrdakj7qpq38c7tac2uhqvqvxnv5d9mrq4km46pf232v9at473watm6597vucq4rru2q"
 
         let identifier = try NostrIdentifier.decode(bech32String: nevent)
         switch identifier {
@@ -126,7 +130,8 @@ class NostrIdentifierTests: XCTestCase {
     /// Example taken from note16fddcyxfldwre2zywr96fnkmk7n3rtf4ehntdwy8ltyqgfntwfnq0dm347
     func test_nevent_with_10_relays() throws {
         // swiftlint:disable:next line_length
-        let nevent = "nevent1qy2hwumn8ghj7un9d3shjtnyv9kh2uewd9hj7qgewaehxw309aex2mrp0yh8xmn0wf6zuum0vd5kzmp0qyd8wumn8ghj7urewfsk66ty9enxjct5dfskvtnrdakj7qgwwaehxw309ahx7uewd3hkctcprdmhxue69uhkummnw3e8gctvdvhxummnw3erztnrdakj7qgkwaehxw309ajkgetw9ehx7um5wghxcctwvshszymhwden5te0wp6hyurvv4cxzeewv4ej7qghwaehxw309aex2mrp0yhxummnw3ezucnpdejz7qghwaehxw309aex2mrp0yh8qunfd4skctnwv46z7qgnwaehxw309aex2mrp0yhxvdm69e5k7tcqypr4d8t87evy6gka9xce8asxfr2kztrplttejhxzzamhkptceghxzxkjapf"
+        let nevent =
+            "nevent1qy2hwumn8ghj7un9d3shjtnyv9kh2uewd9hj7qgewaehxw309aex2mrp0yh8xmn0wf6zuum0vd5kzmp0qyd8wumn8ghj7urewfsk66ty9enxjct5dfskvtnrdakj7qgwwaehxw309ahx7uewd3hkctcprdmhxue69uhkummnw3e8gctvdvhxummnw3erztnrdakj7qgkwaehxw309ajkgetw9ehx7um5wghxcctwvshszymhwden5te0wp6hyurvv4cxzeewv4ej7qghwaehxw309aex2mrp0yhxummnw3ezucnpdejz7qghwaehxw309aex2mrp0yh8qunfd4skctnwv46z7qgnwaehxw309aex2mrp0yhxvdm69e5k7tcqypr4d8t87evy6gka9xce8asxfr2kztrplttejhxzzamhkptceghxzxkjapf"
 
         let identifier = try NostrIdentifier.decode(bech32String: nevent)
         switch identifier {
@@ -147,7 +152,8 @@ class NostrIdentifierTests: XCTestCase {
     /// Example taken from note12h0l6emckxgdfjnl3pfvyss4gp03yta7k0n9uwghywksksyfr9ws8q6war
     func test_naddr_with_one_relay() throws {
         // swiftlint:disable:next line_length
-        let naddr = "naddr1qqjrsdf4xs6nvdrz95unsery956rswrx95unxvee94skvvp5xymkgwfcx9snyqg3waehxw309ahx7um5wgh8w6twv5hsygx0gknt5ymr44ldyyaq0rn3p5jpzkh8y8ymg773a06ytr4wldxz55psgqqqwense4rlem"
+        let naddr =
+            "naddr1qqjrsdf4xs6nvdrz95unsery956rswrx95unxvee94skvvp5xymkgwfcx9snyqg3waehxw309ahx7um5wgh8w6twv5hsygx0gknt5ymr44ldyyaq0rn3p5jpzkh8y8ymg773a06ytr4wldxz55psgqqqwense4rlem"
 
         let identifier = try NostrIdentifier.decode(bech32String: naddr)
         switch identifier {
@@ -166,7 +172,8 @@ class NostrIdentifierTests: XCTestCase {
     /// Example taken from note1xsems9u6xqfxl3hd3z4u4yr67vvf3g6w5l5vxwl8vqwcp0kgm2hsg3zf2w
     func test_naddr_with_9_relays() throws {
         // swiftlint:disable:next line_length
-        let naddr = "naddr1qvzqqqrujgpzp75cf0tahv5z7plpdeaws7ex52nmnwgtwfr2g3m37r844evqrr6jqyghwumn8ghj7vf5xqhxvdm69e5k7tcpzdmhxue69uhhqatjwpkx2urpvuhx2ue0qythwumn8ghj7un9d3shjtnswf5k6ctv9ehx2ap0qy2hwumn8ghj7un9d3shjtnyv9kh2uewd9hj7qg6waehxw309ac8junpd45kgtnxd9shg6npvchxxmmd9uq3xamnwvaz7tmjv4kxz7fwvcmh5tnfduhsz9thwden5te0wfjkccte9ejhs6t59ec82c30qyf8wumn8ghj7un9d3shjtn5dahkcue0qy88wumn8ghj7mn0wvhxcmmv9uqpqvenx56njvpnxqcrsdf4xqcrwdqufrevn"
+        let naddr =
+            "naddr1qvzqqqrujgpzp75cf0tahv5z7plpdeaws7ex52nmnwgtwfr2g3m37r844evqrr6jqyghwumn8ghj7vf5xqhxvdm69e5k7tcpzdmhxue69uhhqatjwpkx2urpvuhx2ue0qythwumn8ghj7un9d3shjtnswf5k6ctv9ehx2ap0qy2hwumn8ghj7un9d3shjtnyv9kh2uewd9hj7qg6waehxw309ac8junpd45kgtnxd9shg6npvchxxmmd9uq3xamnwvaz7tmjv4kxz7fwvcmh5tnfduhsz9thwden5te0wfjkccte9ejhs6t59ec82c30qyf8wumn8ghj7un9d3shjtn5dahkcue0qy88wumn8ghj7mn0wvhxcmmv9uqpqvenx56njvpnxqcrsdf4xqcrwdqufrevn"
 
         let identifier = try NostrIdentifier.decode(bech32String: naddr)
         switch identifier {
@@ -185,7 +192,8 @@ class NostrIdentifierTests: XCTestCase {
     /// Example taken from note1tq4d6t3ekq2r52z2t2hqkusjcecv4qmaqjyddhzrzn3whphp69wqm833es
     func test_naddr_with_kind_30023() throws {
         // swiftlint:disable:next line_length
-        let naddr = "naddr1qqyrsctxxpjnqdpnqyghwumn8ghj7enfv96x5ctx9e3k7mgzyqalp33lewf5vdq847t6te0wvnags0gs0mu72kz8938tn24wlfze6qcyqqq823c4p5dms"
+        let naddr =
+            "naddr1qqyrsctxxpjnqdpnqyghwumn8ghj7enfv96x5ctx9e3k7mgzyqalp33lewf5vdq847t6te0wvnags0gs0mu72kz8938tn24wlfze6qcyqqq823c4p5dms"
 
         let identifier = try NostrIdentifier.decode(bech32String: naddr)
         switch identifier {
@@ -204,7 +212,8 @@ class NostrIdentifierTests: XCTestCase {
     /// Example taken from note1tyt3a7tqxhgvvve87jzxpsndguw6vq29qfuenau40kartujlrppq5zmncg
     func test_naddr_with_no_relays() throws {
         // swiftlint:disable:next line_length
-        let naddr = "naddr1qvzqqqr4gupzqqn84g7e954y0xkkhnxudlnk2uphm645kaagh08axe3mpmh3j66cqq24g3mwgffxswfdvgck5un32d9z6sne2aghskj3r5v"
+        let naddr =
+            "naddr1qvzqqqr4gupzqqn84g7e954y0xkkhnxudlnk2uphm645kaagh08axe3mpmh3j66cqq24g3mwgffxswfdvgck5un32d9z6sne2aghskj3r5v"
 
         let identifier = try NostrIdentifier.decode(bech32String: naddr)
         switch identifier {

--- a/NosTests/Service/NostrIdentifier/TLVElementTests.swift
+++ b/NosTests/Service/NostrIdentifier/TLVElementTests.swift
@@ -6,7 +6,8 @@ final class TLVElementTests: XCTestCase {
     /// Verify that we can decode the elements of a nprofile.
     func test_decodeElements_nprofile() throws {
         // swiftlint:disable:next line_length
-        let nprofile = "nprofile1qqsrhuxx8l9ex335q7he0f09aej04zpazpl0ne2cgukyawd24mayt8gpp4mhxue69uhhytnc9e3k7mgpz4mhxue69uhkg6nzv9ejuumpv34kytnrdaksjlyr9p"
+        let nprofile =
+            "nprofile1qqsrhuxx8l9ex335q7he0f09aej04zpazpl0ne2cgukyawd24mayt8gpp4mhxue69uhhytnc9e3k7mgpz4mhxue69uhkg6nzv9ejuumpv34kytnrdaksjlyr9p"
 
         let expectedSpecial = "3bf0c63fcb93463407af97a5e5ee64fa883d107ef9e558472c4eb9aaaefa459d"
         let (_, checksum) = try Bech32.decode(nprofile)
@@ -16,14 +17,15 @@ final class TLVElementTests: XCTestCase {
         let special = try XCTUnwrap(elements.first { $0.type == .special })
         XCTAssertEqual(special.value.hexString, expectedSpecial)
 
-        let relays = elements
+        let relays =
+            elements
             .filter { $0.type == .relay }
             .map { String(data: $0.value, encoding: .ascii) }
         XCTAssertEqual(
             relays,
             [
                 "wss://r.x.com",
-                "wss://djbas.sadkb.com"
+                "wss://djbas.sadkb.com",
             ]
         )
     }

--- a/NosTests/Service/Relay/RelaySubscriptionManagerTests.swift
+++ b/NosTests/Service/Relay/RelaySubscriptionManagerTests.swift
@@ -1,35 +1,35 @@
-import XCTest
 import Starscream
+import XCTest
 
 final class RelaySubscriptionManagerTests: XCTestCase {
 
     let relayOneURL = URL(string: "wss://relay.one")!
     let relayTwoURL = URL(string: "wss://relay.two")!
     let relayThreeURL = URL(string: "wss://relay.three")!
-    
+
     // swiftlint:disable:next implicitly_unwrapped_optional
     var subject: RelaySubscriptionManagerActor!
-    
+
     override func setUp() async throws {
         try await super.setUp()
         subject = RelaySubscriptionManagerActor()
     }
-    
+
     func test_openSockets_givenDisconnectedSockets_startsConnectingAll() async throws {
         // Arrange
         _ = await subject.queueSubscription(with: Filter(), to: relayOneURL)
         _ = await subject.queueSubscription(with: Filter(), to: relayTwoURL)
         _ = await subject.queueSubscription(with: Filter(), to: relayThreeURL)
-        
+
         // Act
         await subject.openSockets()
-        
+
         // Assert
         let connections = await subject.socketConnections
         XCTAssertEqual(connections.count, 3)
         connections.values.forEach { XCTAssertEqual($0.state, .connecting) }
     }
-    
+
     func test_openSockets_givenErroredSocket_startsConnectingAll() async throws {
         // Arrange
         _ = await subject.queueSubscription(with: Filter(), to: relayOneURL)
@@ -39,32 +39,32 @@ final class RelaySubscriptionManagerTests: XCTestCase {
         var request = URLRequest(url: relayTwoURL)
         request.timeoutInterval = 10
         let socket = WebSocket(request: request, useCustomEngine: false)
-        
+
         // Act
         await subject.trackError(socket: socket)
         try await Task.sleep(for: .seconds(1))
         await subject.openSockets()
-        
+
         // Assert
         let connections = await subject.socketConnections
         XCTAssertEqual(connections.count, 3)
         connections.values.forEach { XCTAssertEqual($0.state, .connecting) }
     }
-    
+
     func test_openSockets_givenOneDisconnectedSocket_startsConnectingAll() async throws {
         // Arrange
         _ = await subject.queueSubscription(with: Filter(), to: relayOneURL)
         _ = await subject.queueSubscription(with: Filter(), to: relayTwoURL)
         _ = await subject.queueSubscription(with: Filter(), to: relayThreeURL)
         await subject.openSockets()
-        
+
         let connections = await subject.socketConnections
         let connection = connections[relayThreeURL]
         connection?.state = .disconnected
-        
+
         // Act
         await subject.openSockets()
-        
+
         // Assert
         XCTAssertEqual(connections.count, 3)
         connections.values.forEach { XCTAssertEqual($0.state, .connecting) }

--- a/NosTests/Service/ReportPublisherTests.swift
+++ b/NosTests/Service/ReportPublisherTests.swift
@@ -1,5 +1,5 @@
-import XCTest
 import CoreData
+import XCTest
 
 final class ReportPublisherTests: CoreDataTestCase {
     @MainActor func testCreatePublicReport() throws {
@@ -13,13 +13,15 @@ final class ReportPublisherTests: CoreDataTestCase {
             category: ReportCategory.findCategory(from: "CL")!,
             pubKey: aliceKeyPair.publicKeyHex
         )
-        
+
         XCTAssertEqual(publicReport.kind, EventKind.report.rawValue)
         XCTAssertEqual(publicReport.pubKey, aliceKeyPair.publicKeyHex)
-        XCTAssertEqual(publicReport.tags, [
-            ["e", note.identifier!, "profanity"],
-            ["p", bobKeyPair.publicKeyHex]
-        ])
+        XCTAssertEqual(
+            publicReport.tags,
+            [
+                ["e", note.identifier!, "profanity"],
+                ["p", bobKeyPair.publicKeyHex],
+            ])
     }
 
     @MainActor func testCreateNoteReportRequestDM() throws {
@@ -33,14 +35,16 @@ final class ReportPublisherTests: CoreDataTestCase {
             category: ReportCategory.findCategory(from: "CL")!,
             keyPair: aliceKeyPair
         )!
-        
+
         XCTAssertEqual(reportRequestDM.kind, EventKind.giftWrap.rawValue)
         XCTAssertNotEqual(reportRequestDM.pubKey, aliceKeyPair.publicKeyHex)
-        XCTAssertEqual(reportRequestDM.tags, [
-            ["p", Tagr.publicKey.hex]
-        ])
+        XCTAssertEqual(
+            reportRequestDM.tags,
+            [
+                ["p", Tagr.publicKey.hex]
+            ])
     }
-    
+
     @MainActor func testCreateAuthorReportRequestDM() throws {
         let aliceKeyPair = KeyFixture.alice
         let bobKeyPair = KeyFixture.bob
@@ -56,16 +60,18 @@ final class ReportPublisherTests: CoreDataTestCase {
             category: ReportCategory.findCategory(from: "CL")!,
             keyPair: aliceKeyPair
         )!
-        
+
         XCTAssertEqual(reportRequestDM.kind, EventKind.giftWrap.rawValue)
         XCTAssertNotEqual(reportRequestDM.pubKey, aliceKeyPair.publicKeyHex)
-        XCTAssertEqual(reportRequestDM.tags, [
-            ["p", Tagr.publicKey.hex]
-        ])
+        XCTAssertEqual(
+            reportRequestDM.tags,
+            [
+                ["p", Tagr.publicKey.hex]
+            ])
     }
 
     // MARK: Helpers
-    
+
     func createTestEvent(
         in context: NSManagedObjectContext,
         keyPair: KeyPair
@@ -74,13 +80,13 @@ final class ReportPublisherTests: CoreDataTestCase {
         event.createdAt = Date(timeIntervalSince1970: TimeInterval(1_675_264_762))
         event.content = "Testing nos #[0]"
         event.kind = 1
-        
+
         let author = Author(context: context)
         author.hexadecimalPublicKey = keyPair.publicKeyHex
         event.author = author
-        
+
         try event.sign(withKey: keyPair)
-        
+
         return event
     }
 }

--- a/NosTests/Service/SocialGraphCacheTests.swift
+++ b/NosTests/Service/SocialGraphCacheTests.swift
@@ -1,21 +1,21 @@
-import XCTest
 import CoreData
 import Dependencies
+import XCTest
 
 final class SocialGraphCacheTests: CoreDataTestCase {
-    
+
     @MainActor func testEmpty() async throws {
         // Arrange
         _ = try Author.findOrCreate(by: KeyFixture.alice.publicKeyHex, context: testContext)
-        
+
         // Act
         let sut = SocialGraphCache(userKey: KeyFixture.alice.publicKeyHex, context: testContext)
         try testContext.save()
-        
+
         // Assert
         try await eventually { await sut.followedKeys == Set([KeyFixture.alice.publicKeyHex]) }
     }
-    
+
     /// The `XCTExpectFailure` below does _not_ work in CI. That is, when the test fails, CI still fails.
     @MainActor func testOneFollower() async throws {
         XCTExpectFailure("This test is failing intermittently, see #671", options: .nonStrict())
@@ -28,19 +28,19 @@ final class SocialGraphCacheTests: CoreDataTestCase {
             destination: bob,
             context: testContext
         )
-        
+
         // Add to the current user's follows
         alice.follows.insert(follow)
         try testContext.save()
-        
+
         // Act
         let sut = SocialGraphCache(userKey: KeyFixture.alice.publicKeyHex, context: testContext)
-        
+
         // Assert
         let expectedKeys = Set([KeyFixture.alice.publicKeyHex, KeyFixture.bob.publicKeyHex])
         try await eventually { await sut.followedKeys == expectedKeys }
     }
-    
+
     /// The `XCTExpectFailure` below does _not_ work in CI. That is, when the test fails, CI still fails.
     @MainActor func testFollow() async throws {
         XCTExpectFailure("This test is failing intermittently, see #671", options: .nonStrict())
@@ -48,26 +48,26 @@ final class SocialGraphCacheTests: CoreDataTestCase {
         // Arrange
         let alice = try Author.findOrCreate(by: KeyFixture.alice.publicKeyHex, context: testContext)
         let bob = try Author.findOrCreate(by: KeyFixture.bob.publicKeyHex, context: testContext)
-        
+
         // Act
         let sut = SocialGraphCache(userKey: KeyFixture.alice.publicKeyHex, context: testContext)
         try testContext.save()
-        
+
         // Assert
         let followedKeys = await sut.followedKeys
         XCTAssertEqual(followedKeys, [KeyFixture.alice.publicKeyHex])
-        
+
         // Rearrange
         // alice follows bob
         let follow = try Follow.findOrCreate(source: alice, destination: bob, context: testContext)
         alice.addToFollows(follow)
         try testContext.save()
-        
+
         // Reassert
         let expectedKeys = Set([KeyFixture.alice.publicKeyHex, KeyFixture.bob.publicKeyHex])
         try await eventually { await sut.followedKeys == expectedKeys }
     }
-    
+
     /// The `XCTExpectFailure` below does _not_ work in CI. That is, when the test fails, CI still fails.
     @MainActor func testTwoFollows() async throws {
         XCTExpectFailure("This test is failing intermittently, see #671", options: .nonStrict())
@@ -76,90 +76,90 @@ final class SocialGraphCacheTests: CoreDataTestCase {
         let alice = try Author.findOrCreate(by: KeyFixture.alice.publicKeyHex, context: testContext)
         let bob = try Author.findOrCreate(by: KeyFixture.bob.publicKeyHex, context: testContext)
         let eve = try Author.findOrCreate(by: KeyFixture.eve.publicKeyHex, context: testContext)
-        
+
         // Act
         let sut = SocialGraphCache(userKey: KeyFixture.alice.publicKeyHex, context: testContext)
         try testContext.save()
-        
+
         // Assert
         let followedKeys = await sut.followedKeys
         XCTAssertEqual(followedKeys, [KeyFixture.alice.publicKeyHex])
-        
+
         // Rearrange
         // alice follows bob
         let follow1 = try Follow.findOrCreate(source: alice, destination: bob, context: testContext)
         alice.addToFollows(follow1)
         try testContext.save()
-        
+
         // alice follows carol
         let follow2 = try Follow.findOrCreate(source: alice, destination: eve, context: testContext)
         alice.addToFollows(follow2)
         try testContext.save()
-        
+
         // Reassert
-        
+
         let expectedKeys = Set([
             KeyFixture.alice.publicKeyHex,
             KeyFixture.eve.publicKeyHex,
-            KeyFixture.bob.publicKeyHex
+            KeyFixture.bob.publicKeyHex,
         ])
         try await eventually { await sut.followedKeys == expectedKeys }
     }
-    
+
     @MainActor func testTwoHops() async throws {
         // Arrange
         let alice = try Author.findOrCreate(by: KeyFixture.alice.publicKeyHex, context: testContext)
         let bob = try Author.findOrCreate(by: KeyFixture.bob.publicKeyHex, context: testContext)
         let eve = try Author.findOrCreate(by: KeyFixture.eve.publicKeyHex, context: testContext)
-        
+
         // Act
         let sut = SocialGraphCache(userKey: KeyFixture.alice.publicKeyHex, context: testContext)
         try testContext.save()
-        
+
         // Rearrange
         // alice follows bob
         let follow1 = try Follow.findOrCreate(source: alice, destination: bob, context: testContext)
         alice.addToFollows(follow1)
         try testContext.save()
-        
+
         var expectedKeys = Set([
             KeyFixture.alice.publicKeyHex,
-            KeyFixture.bob.publicKeyHex
+            KeyFixture.bob.publicKeyHex,
         ])
         try await eventually { await sut.followedKeys == expectedKeys }
         try await eventually { await !sut.isInNetwork(KeyFixture.eve.publicKeyHex) }
-        
+
         // bob follows eve
         let follow2 = try Follow.findOrCreate(source: bob, destination: eve, context: testContext)
         bob.addToFollows(follow2)
         try testContext.save()
-        
+
         // Reassert
         expectedKeys = Set([
             KeyFixture.alice.publicKeyHex,
-            KeyFixture.bob.publicKeyHex
+            KeyFixture.bob.publicKeyHex,
         ])
         try await eventually { await sut.followedKeys == expectedKeys }
         try await eventually { await sut.isInNetwork(KeyFixture.eve.publicKeyHex) }
     }
-    
+
     @MainActor func testOutOfNetwork() async throws {
         // Arrange
         _ = try Author.findOrCreate(by: KeyFixture.alice.publicKeyHex, context: testContext)
         _ = try Author.findOrCreate(by: KeyFixture.bob.publicKeyHex, context: testContext)
         _ = try Author.findOrCreate(by: KeyFixture.eve.publicKeyHex, context: testContext)
-        
+
         // Act
         let sut = SocialGraphCache(userKey: KeyFixture.alice.publicKeyHex, context: testContext)
         try testContext.save()
-        
+
         // Assert
         // assert twice for each key - first time hits db, second time hits cache
         var isInNetwwork = await sut.isInNetwork(KeyFixture.eve.publicKeyHex)
         XCTAssertFalse(isInNetwwork)
         isInNetwwork = await sut.isInNetwork(KeyFixture.eve.publicKeyHex)
         XCTAssertFalse(isInNetwwork)
-        
+
         isInNetwwork = await sut.isInNetwork(KeyFixture.bob.publicKeyHex)
         XCTAssertFalse(isInNetwwork)
         isInNetwwork = await sut.isInNetwork(KeyFixture.bob.publicKeyHex)

--- a/NosTests/TestHelpers/CoreDataTestCase.swift
+++ b/NosTests/TestHelpers/CoreDataTestCase.swift
@@ -1,16 +1,16 @@
-import XCTest
 import CoreData
-import Foundation
 import Dependencies
+import Foundation
+import XCTest
 
 /// An `XCTestCase` that sets up an in-memory Core Data stack and resets it between test runs.
 class CoreDataTestCase: XCTestCase {
-    
+
     @Dependency(\.persistenceController) var persistenceController
-    
+
     // swiftlint:disable:next implicitly_unwrapped_optional
     @MainActor var testContext: NSManagedObjectContext!
-    
+
     @MainActor override func setUp() async throws {
         try await super.setUp()
         persistenceController.resetForTesting()

--- a/NosTests/TestHelpers/RawNostrID+Random.swift
+++ b/NosTests/TestHelpers/RawNostrID+Random.swift
@@ -4,7 +4,7 @@ extension RawNostrID {
     static var random: RawNostrID {
         var randomBytes = [UInt8](repeating: 0, count: 32)
         _ = SecRandomCopyBytes(kSecRandomDefault, randomBytes.count, &randomBytes)
-        
+
         let hexString = randomBytes.map { String(format: "%02x", $0) }.joined()
         return hexString
     }

--- a/NosTests/TestHelpers/SQLiteStoreTestCase.swift
+++ b/NosTests/TestHelpers/SQLiteStoreTestCase.swift
@@ -1,19 +1,19 @@
-import XCTest
 import CoreData
 import Dependencies
+import XCTest
 
 // swiftlint:disable implicitly_unwrapped_optional
 
 /// A test case that uses a full core data stack including a SQLite backing store.
 class SQLiteStoreTestCase: XCTestCase {
-        
+
     var persistenceController: PersistenceController!
-    
+
     override func setUp() {
         super.setUp()
         persistenceController = PersistenceController(containerName: "NosTests", inMemory: true, erase: true)
     }
-    
+
     override func tearDownWithError() throws {
         try persistenceController.tearDown()
         persistenceController = nil
@@ -28,7 +28,7 @@ extension PersistenceController {
         for store in container.persistentStoreCoordinator.persistentStores {
             try container.persistentStoreCoordinator.remove(store)
         }
-        
+
         try container.persistentStoreDescriptions.forEach { storeDescription in
             try container.persistentStoreCoordinator.destroyPersistentStore(
                 at: storeDescription.url!,
@@ -36,7 +36,7 @@ extension PersistenceController {
                 options: nil
             )
         }
-        
+
         viewContext.reset()
         backgroundViewContext.reset()
         parseContext.reset()

--- a/NosTests/TestHelpers/XCTest+Eventually.swift
+++ b/NosTests/TestHelpers/XCTest+Eventually.swift
@@ -3,7 +3,7 @@ import Foundation
 /// A function that polls for a given condition to be true. Useful for waiting on async properties to change in XCTests
 /// since XCTestExpectations do not play nice with `async/await`.
 func eventually(condition: @escaping () async throws -> Bool) async throws {
-    try await Task.init(timeout: 10) { 
+    try await Task.init(timeout: 10) {
         while true {
             if try await condition() {
                 break

--- a/NosTests/Views/Components/Media/ImageAnimatedTests.swift
+++ b/NosTests/Views/Components/Media/ImageAnimatedTests.swift
@@ -1,6 +1,6 @@
-import XCTest
 import SDWebImage
 import SDWebImageWebPCoder
+import XCTest
 
 final class ImageAnimatedTests: XCTestCase {
     func test_gif_isAnimated() throws {
@@ -9,8 +9,8 @@ final class ImageAnimatedTests: XCTestCase {
         let data = try Data(contentsOf: url)
 
         let image = try XCTUnwrap(UIImage(data: data))
-        XCTAssertFalse(image.sd_isAnimated) // ideally this would return true
-        XCTAssertNil(image.images) // ideally this would be non-nil
+        XCTAssertFalse(image.sd_isAnimated)  // ideally this would return true
+        XCTAssertNil(image.images)  // ideally this would be non-nil
 
         let sdImage = try XCTUnwrap(SDAnimatedImage(data: data))
         XCTAssertTrue(sdImage.sd_isAnimated)
@@ -32,8 +32,8 @@ final class ImageAnimatedTests: XCTestCase {
         let data = try Data(contentsOf: url)
 
         let image = try XCTUnwrap(UIImage(data: data))
-        XCTAssertFalse(image.sd_isAnimated) // ideally this would return true
-        XCTAssertNil(image.images) // ideally this would be non-nil
+        XCTAssertFalse(image.sd_isAnimated)  // ideally this would return true
+        XCTAssertNil(image.images)  // ideally this would be non-nil
 
         let sdImage = try XCTUnwrap(SDAnimatedImage(data: data))
         XCTAssertTrue(sdImage.sd_isAnimated)

--- a/NosTests/Views/EventObservationTests.swift
+++ b/NosTests/Views/EventObservationTests.swift
@@ -1,17 +1,17 @@
-import XCTest
+import Combine
+import CoreData
 import Dependencies
 import SwiftUI
 import ViewInspector
-import Combine
-import CoreData
-        
+import XCTest
+
 // This is a bit of instrumentation recommended by the ViewInspector package to set up views for asynchronous inspection
 // see https://github.com/nalexn/ViewInspector/blob/0.9.10/guide.md#approach-2
 internal final class Inspection<V> {
-    
+
     let notice = PassthroughSubject<UInt, Never>()
     var callbacks = [UInt: (V) -> Void]()
-    
+
     func visit(_ view: V, _ line: UInt) {
         if let callback = callbacks.removeValue(forKey: line) {
             callback(view)
@@ -19,42 +19,42 @@ internal final class Inspection<V> {
     }
 }
 
-extension Inspection: InspectionEmissary { }
+extension Inspection: InspectionEmissary {}
 
 struct EventObservationTestView: View {
     @FetchRequest<Event>(
-        entity: Event.entity(), 
+        entity: Event.entity(),
         sortDescriptors: [NSSortDescriptor(keyPath: \Event.createdAt, ascending: true)]
     ) var events
-        
-    internal let inspection = Inspection<Self>() 
+
+    internal let inspection = Inspection<Self>()
     var body: some View {
-        List(events) { event in 
+        List(events) { event in
             Text(event.content ?? "null")
         }
-        .onReceive(inspection.notice) { self.inspection.visit(self, $0) } 
+        .onReceive(inspection.notice) { self.inspection.visit(self, $0) }
     }
 }
 
 /// Testing that our SwiftUI Views can successfully observe Event changes from Core Data
 final class EventObservationTests: CoreDataTestCase {
-    
+
     /// This tests that the same event created in two separate contexts will update correctly in the view when both
-    /// contexts are saved. This test exhibits bug https://github.com/planetary-social/nos/issues/697.  
+    /// contexts are saved. This test exhibits bug https://github.com/planetary-social/nos/issues/697.
     @MainActor func testDuplicateEventMergingGivenParseContextSavesFirst() throws {
         XCTExpectFailure("This test is failing intermittently, see #703", options: .nonStrict())
         // Arrange
         let viewContext = persistenceController.viewContext
         let parseContext = persistenceController.parseContext
-        
+
         let eventID = "123456"
         let eventContent = "foo bar"
-        
+
         // Act
         _ = try Event.findOrCreateStubBy(id: eventID, context: viewContext)
         let fullEvent = try Event.findOrCreateStubBy(id: eventID, context: parseContext)
         fullEvent.content = eventContent
-        
+
         let view = EventObservationTestView()
         ViewHosting.host(view: view.environment(\.managedObjectContext, persistenceController.viewContext))
         // sanity check
@@ -63,11 +63,11 @@ final class EventObservationTests: CoreDataTestCase {
             XCTAssertEqual(eventContentInView, "null")
         }
         wait(for: [expectNullContent], timeout: 0.1)
-        
+
         // If you reverse the two lines below this test fails. Not sure why :( but I'm not seeing #703 anymore when
-        // running the full app. 
+        // running the full app.
         try parseContext.save()
-        
+
         let expectContent = view.inspection.inspect { view in
             let eventContentInView = try view.find(ViewType.Text.self).string()
             XCTAssertEqual(eventContentInView, eventContent)

--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,8 @@
 // this file is here because it helps SourceKit-LSP parse your project i.e. when used with VSCode.
 // see https://medium.com/swlh/ios-development-on-vscode-27be37293fe1
 import PackageDescription
-let packageName = "Nos" 
+
+let packageName = "Nos"
 let package = Package(
     name: "",
     products: [


### PR DESCRIPTION
This is a 10 minute experiment I did after seeing this over the weekend and chatting about it with Itunu. I ran Apple's `swift-format` tool which has been around for a while but is now shipped with Xcode 16. It mostly made whitespace changes, but there are a few conventions it changed.

The exact command I ran was `swift format -ri .` after making a few tweaks in `.swift-format`.

I think we should probably start using this at some point because it will catch some small issues that we spend time on in code reviews. I'm not sure if now is the right time though. Probably after launch. But I'm curious to get everyone's quick thoughts if you want to spend 5 or 10 minutes looking over this. 

