### PR TITLE
Make Slack notification a little louder for failed builds

### DIFF
--- a/.github/workflows/notify-slack-on-failure.yml
+++ b/.github/workflows/notify-slack-on-failure.yml
@@ -15,7 +15,7 @@ jobs:
         uses: slackapi/slack-github-action@v1.23.0
         with:
           channel-id: ${{ secrets.SLACK_CHANNEL_ID }}
-          slack-message: "GitHub Action *${{ github.event.workflow_run.name }}* has failed in the *${{ github.repository }}* repository.\n<${{ github.event.workflow_run.html_url }}|View the workflow run>"
+          slack-message: "💥 GitHub Action *${{ github.event.workflow_run.name }}* has failed in the *${{ github.repository }}* repository. 💥\n<${{ github.event.workflow_run.html_url }}|View the workflow run>"
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 


### PR DESCRIPTION
## Issues covered
None

## The Problem
Currently our build failure notifications look like this in Slack:

<img width="688" alt="Screenshot 2024-10-15 at 3 56 48 PM" src="https://github.com/user-attachments/assets/d7e56d66-1abb-4717-82b6-f96c4018f3fc">

This is easy to miss in a somewhat busy channel, or even a non-busy one. It doesn't look very important or visually indicate that there's a problem.

## Description
Make the Slack notification a little louder for failed deployments by adding two of the following emoji: 💥

I considered other emoji, such as:

- ⚠️ 
- 💣 
- 🚨 
- ⚡ 
- ☢️ 
- ☣️ 

but this one seemed the most appropriate.

## How to test
Merge and pray 🙏