### PR TITLE
migrate ObservableObject to @Observable where possible #1458

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed integration with Universal Name Space [#1636](https://github.com/planetary-social/nos/issues/1636)
 
 ### Internal Changes
+- migrate ObservableObject to @Observable where possible [#1458](https://github.com/planetary-social/nos/issues/1458)
 
 ## [0.2.2] - 2024-10-11Z
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed integration with Universal Name Space [#1636](https://github.com/planetary-social/nos/issues/1636)
 
 ### Internal Changes
-- migrate ObservableObject to @Observable where possible [#1458](https://github.com/planetary-social/nos/issues/1458)
+- Migrate ObservableObject to @Observable where possible [#1458](https://github.com/planetary-social/nos/issues/1458)
 
 ## [0.2.2] - 2024-10-11Z
 

--- a/Nos.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Nos.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -244,5 +244,5 @@
       }
     }
   ],
-  "version" : 2
+  "version" : 3
 }

--- a/Nos.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Nos.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -244,5 +244,5 @@
       }
     }
   ],
-  "version" : 3
+  "version" : 2
 }

--- a/Nos/Controller/RawEventController.swift
+++ b/Nos/Controller/RawEventController.swift
@@ -2,7 +2,7 @@ import Foundation
 import Logger
 
 /// A view model for the RawEventView
-@MainActor protocol RawEventViewModel: ObservableObject {
+protocol RawEventViewModel {
     
     /// The raw message to display in screen
     var rawMessage: String? { get }
@@ -21,17 +21,14 @@ import Logger
 }
 
 /// A controller for the `RawEventView`
-@MainActor class RawEventController: RawEventViewModel {
+@Observable final class RawEventController: RawEventViewModel {
 
-    private var note: Event
+    private let note: Event
+    private let dismissHandler: () -> Void
 
-    @Published var rawMessage: String?
-    
-    @Published var loadingMessage: String?
-
-    @Published var errorMessage: String?
-    
-    private var dismissHandler: () -> Void
+    private(set) var rawMessage: String?
+    private(set) var loadingMessage: String?
+    private(set) var errorMessage: String?
 
     init(note: Event, dismissHandler: @escaping () -> Void) {
         self.note = note
@@ -52,22 +49,20 @@ import Logger
         self.rawMessage = rawMessage
         self.loadingMessage = nil
     }
-
+    
     private func loadRawMessage() {
         loadingMessage = String(localized: .localizable.loading)
-        Task { [note, weak self] in
-            var rawMessage: String
-            let errorMessage = note.content ?? "error"
-            do {
-                let data = try JSONSerialization.data(
-                    withJSONObject: note.jsonRepresentation ?? [:],
-                    options: [.prettyPrinted]
-                )
-                rawMessage = String(decoding: data, as: UTF8.self) 
-            } catch {
-                rawMessage = errorMessage
-            }
-            self?.updateRawMessage(rawMessage)
+        
+        let rawMessage: String
+        do {
+            let data = try JSONSerialization.data(
+                withJSONObject: note.jsonRepresentation ?? [:],
+                options: [.prettyPrinted]
+            )
+            rawMessage = String(decoding: data, as: UTF8.self)
+        } catch {
+            rawMessage = note.content ?? "error"
         }
+        updateRawMessage(rawMessage)
     }
 }

--- a/Nos/Models/NotificationViewModel.swift
+++ b/Nos/Models/NotificationViewModel.swift
@@ -8,11 +8,11 @@ import UIKit
 /// in the .init method of a View. Because of this you must call the async function
 /// `loadContent()` to populate the `content` variable because it relies on some
 ///  database queries.
-class NotificationViewModel: ObservableObject, Identifiable {
+@Observable final class NotificationViewModel: Identifiable {
     let noteID: RawEventID
     let authorProfilePhotoURL: URL?
     let actionText: AttributedString
-    @Published var content: AttributedString?
+    private(set) var content: AttributedString?
     let date: Date
     
     var id: RawEventID {

--- a/Nos/Views/Components/Event/RawEventView.swift
+++ b/Nos/Views/Components/Event/RawEventView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct RawEventView<ViewModel>: View where ViewModel: RawEventViewModel {
-    @ObservedObject var viewModel: ViewModel
+    let viewModel: ViewModel
 
     /// A loading overlay that displays the `loadingMessage` from the view model.
     private var loadingIndicator: some View {
@@ -84,11 +84,11 @@ struct RawEventView<ViewModel>: View where ViewModel: RawEventViewModel {
 
 fileprivate class PreviewViewModel: RawEventViewModel {
 
-    @Published var rawMessage: String?
+    var rawMessage: String?
 
-    @Published var loadingMessage: String? = "Loading..."
+    var loadingMessage: String? = "Loading..."
 
-    @Published var errorMessage: String?
+    var errorMessage: String?
 
     init(_ rawMessage: String) {
         self.rawMessage = rawMessage

--- a/Nos/Views/Notifications/NotificationCard.swift
+++ b/Nos/Views/Notifications/NotificationCard.swift
@@ -9,13 +9,9 @@ struct NotificationCard: View {
     @EnvironmentObject private var relayService: RelayService
     @Dependency(\.persistenceController) private var persistenceController
     
-    @ObservedObject private var viewModel: NotificationViewModel
+    let viewModel: NotificationViewModel
     @State private var relaySubscriptions = SubscriptionCancellables()
     @State private var content: AttributedString?
-    
-    init(viewModel: NotificationViewModel) {
-        self.viewModel = viewModel
-    }
     
     func showNote() {
         guard let note = Event.find(by: viewModel.noteID, context: viewContext) else {

--- a/Nos/Views/Onboarding/OnboardingAgeVerificationView.swift
+++ b/Nos/Views/Onboarding/OnboardingAgeVerificationView.swift
@@ -3,7 +3,7 @@ import SwiftUI
 
 /// The Age Verification view in the onboarding.
 struct OnboardingAgeVerificationView: View {
-    @EnvironmentObject var state: OnboardingState
+    @Environment(OnboardingState.self) private var state
 
     @Dependency(\.crashReporting) private var crashReporting
     @Dependency(\.currentUser) private var currentUser

--- a/Nos/Views/Onboarding/OnboardingNotOldEnoughView.swift
+++ b/Nos/Views/Onboarding/OnboardingNotOldEnoughView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct OnboardingNotOldEnoughView: View {
-    @EnvironmentObject var state: OnboardingState
+    @Environment(OnboardingState.self) private var state
     
     var body: some View {
         VStack {

--- a/Nos/Views/Onboarding/OnboardingStartView.swift
+++ b/Nos/Views/Onboarding/OnboardingStartView.swift
@@ -3,7 +3,7 @@ import SwiftUI
 
 /// The beginning of the Onboarding views which contains buttons to start creating a new account or log in.
 struct OnboardingStartView: View {
-    @EnvironmentObject var state: OnboardingState
+    @Environment(OnboardingState.self) private var state
 
     @Dependency(\.analytics) private var analytics
 
@@ -54,6 +54,6 @@ struct OnboardingStartView: View {
 
 #Preview {
     OnboardingStartView()
-        .environmentObject(OnboardingState())
+        .environment(OnboardingState())
         .inject(previewData: PreviewData())
 }

--- a/Nos/Views/Onboarding/OnboardingView.swift
+++ b/Nos/Views/Onboarding/OnboardingView.swift
@@ -1,13 +1,13 @@
 import SwiftUI
 
-class OnboardingState: ObservableObject {
-    @Published var flow: OnboardingFlow = .createAccount
-    @Published var step: OnboardingStep = .onboardingStart {
+@Observable final class OnboardingState {
+    var flow: OnboardingFlow = .createAccount
+    var step: OnboardingStep = .onboardingStart {
         didSet {
             path.append(step)
         }
     }
-    @Published var path = NavigationPath()
+    var path = NavigationPath()
 }
 
 enum OnboardingFlow {
@@ -25,7 +25,7 @@ enum OnboardingStep {
 
 /// The view that initializes the onboarding navigation stack and shows the first view.
 struct OnboardingView: View {
-    @StateObject var state = OnboardingState()
+    @State var state = OnboardingState()
     
     /// Completion to be called when all onboarding steps are complete
     let completion: @MainActor () -> Void
@@ -33,18 +33,18 @@ struct OnboardingView: View {
     var body: some View {
         NavigationStack(path: $state.path) {
             OnboardingStartView()
-                .environmentObject(state)
+                .environment(state)
                 .navigationDestination(for: OnboardingStep.self) { step in
                     switch step {
                     case .onboardingStart:
                         OnboardingStartView()
-                            .environmentObject(state)
+                            .environment(state)
                     case .ageVerification:
                         OnboardingAgeVerificationView()
-                            .environmentObject(state)
+                            .environment(state)
                     case .notOldEnough:
                         OnboardingNotOldEnoughView()
-                            .environmentObject(state)
+                            .environment(state)
                     case .login:
                         OnboardingLoginView(completion: completion)
                     case .buildYourNetwork:


### PR DESCRIPTION
## Issues covered
#1458 

## Description
Migrates usage of the `ObservableObject` property to the `@Observable` macro in a few places. This is done both for performance improvement and for modernizing our patterns.

Unfortunately, there are some occurrences of `ObservableObject` which cannot be migrated at this time. One is where we use an `@Published` property in a Combine publisher. Other occurrences are where the class we want to migrate also contains `@Dependency` properties. These appear to be incompatible.
<img width="800" alt="Nos_—_SearchController_swift" src="https://github.com/user-attachments/assets/deea327d-68ff-4978-92aa-2ad0bf729da9">

## How to test
This PR updates three occurrences of `ObservableObject`.
1. Onboarding:
  * Launch the app while not signed in and click through the Onboarding flow. Verify that it still works as expected.
2. Notifications:
  * Navigate to the Notifications tab and scroll through notifications.
3. Raw Events:
  * View the source of some events to make sure that flow works as expected.



## Screenshots/Video
Onboarding
![Screen Recording 2024-10-17 at 7 43 43 AM 2024-10-17 07_44_45](https://github.com/user-attachments/assets/504a6352-f4e5-4425-9a90-666e7d0603c5)

Notifications
![Screen Recording 2024-10-17 at 7 45 08 AM 2024-10-17 07_46_18](https://github.com/user-attachments/assets/4bcae96c-ac88-4cf1-85bd-8bc0c5a822e0)

Raw Events
![Screen Recording 2024-10-17 at 7 40 53 AM 2024-10-17 07_42_19](https://github.com/user-attachments/assets/bea34c60-6176-4594-be24-8ffdf42f92b1)


