### PR TITLE
Track mentions autocomplete opened

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Internal Changes
 - Migrate ObservableObject to @Observable where possible [#1458](https://github.com/planetary-social/nos/issues/1458)
 - Added the Create Account onboarding screen. Currently behind the “New Onboarding Flow” feature flag. [#1594](https://github.com/planetary-social/nos/issues/1594)
+- Track opening mentions with Posthog. [#1480](https://github.com/planetary-social/nos/issues/1480)
 
 ## [0.2.2] - 2024-10-11Z
 

--- a/Nos/Controller/NoteEditorController.swift
+++ b/Nos/Controller/NoteEditorController.swift
@@ -19,8 +19,14 @@ import UIKit
     
     /// A variable that controls whether the mention autocomplete window should be shown. This window is triggered
     /// by typing an '@' symbol and allows the user to search for another user to mention in their note.
-    var showMentionsAutocomplete = false
-    
+    var showMentionsAutocomplete = false {
+        didSet {
+            if showMentionsAutocomplete {
+                analytics.mentionsAutocompleteOpened()
+            }
+        }
+    }
+
     /// The view the user will use for editing. Should only be set by ``NoteTextEditor/NoteUITextViewRepresentable``.
     var textView: UITextView? {
         didSet {
@@ -78,7 +84,6 @@ import UIKit
         ///  Check if `@` was appended and show the mentionsAutoComplete list.
         guard text == "@" else { return }
         showMentionsAutocomplete = true
-        analytics.openedMentions()
     }
     
     /// Appends the given URL and adds the default link styling attributes. Will append a space before the link 
@@ -235,13 +240,11 @@ import UIKit
     private func checkForMentionsAutocomplete(in textView: UITextView, at range: NSRange) -> Bool {
         if textView.text.count == 0 {
             showMentionsAutocomplete = true
-            analytics.openedMentions()
             return true
         } else {
             let lastCharacter = (textView.text as NSString).character(at: max(range.location - 1, 0))
             if let scalar = UnicodeScalar(lastCharacter), CharacterSet.whitespacesAndNewlines.contains(scalar) {
                 showMentionsAutocomplete = true
-                analytics.openedMentions()
                 return true
             }
         }

--- a/Nos/Controller/NoteEditorController.swift
+++ b/Nos/Controller/NoteEditorController.swift
@@ -1,3 +1,4 @@
+import Dependencies
 import Foundation
 import SwiftUI
 import UIKit
@@ -8,6 +9,8 @@ import UIKit
 /// To use: instantiate and pass into a `NoteTextEditor` view. You can retrieve the typed text via the `text` property
 /// when the user indicates they are ready to post it.  
 @Observable class NoteEditorController: NSObject, UITextViewDelegate {
+
+    @ObservationIgnored @Dependency(\.analytics) private var analytics
 
     /// The height that fits all entered text. This value will be updated by `NoteUITextViewRepresentable` 
     /// automatically, and should be used to set the frame of `NoteUITextViewRepresentable` from SwiftUI. This is done 
@@ -75,6 +78,7 @@ import UIKit
         ///  Check if `@` was appended and show the mentionsAutoComplete list.
         guard text == "@" else { return }
         showMentionsAutocomplete = true
+        analytics.openedMentions()
     }
     
     /// Appends the given URL and adds the default link styling attributes. Will append a space before the link 
@@ -231,11 +235,13 @@ import UIKit
     private func checkForMentionsAutocomplete(in textView: UITextView, at range: NSRange) -> Bool {
         if textView.text.count == 0 {
             showMentionsAutocomplete = true
+            analytics.openedMentions()
             return true
         } else {
             let lastCharacter = (textView.text as NSString).character(at: max(range.location - 1, 0))
             if let scalar = UnicodeScalar(lastCharacter), CharacterSet.whitespacesAndNewlines.contains(scalar) {
                 showMentionsAutocomplete = true
+                analytics.openedMentions()
                 return true
             }
         }

--- a/Nos/Controller/SearchController.swift
+++ b/Nos/Controller/SearchController.swift
@@ -87,7 +87,7 @@ class SearchController: ObservableObject {
                     case .discover:
                         analytics.searchedDiscover()
                     case .mentions:
-                        analytics.searchedMentions()
+                        analytics.mentionsAutocompleteCharactersEntered()
                     }
                 }
                 self.authorResults = self.authors(named: query)

--- a/Nos/Service/Analytics.swift
+++ b/Nos/Service/Analytics.swift
@@ -297,4 +297,8 @@ class Analytics {
     func cancelledUploadSourceSelection() {
         track("Cancelled Upload Source Selection")
     }
+
+    func openedMentions() {
+        track("Mentions Opened")
+    }
 }

--- a/Nos/Service/Analytics.swift
+++ b/Nos/Service/Analytics.swift
@@ -161,8 +161,8 @@ class Analytics {
     }
 
     /// Tracks when the user submits a search on the Mentions screen.
-    func searchedMentions() {
-        track("Mentions Search Started")
+    func mentionsAutocompleteCharactersEntered() {
+        track("Mentions Autocomplete Characters Entered")
     }
 
     /// Tracks when the user taps on a search result on the Discover screen.
@@ -298,7 +298,7 @@ class Analytics {
         track("Cancelled Upload Source Selection")
     }
 
-    func openedMentions() {
-        track("Mentions Opened")
+    func mentionsAutocompleteOpened() {
+        track("Mentions Autocomplete Opened")
     }
 }


### PR DESCRIPTION
## Issues covered
#1480 

## Description
This PR tracks mentions when the mentions button is clicked and the user types an "@"

## How to test
1. Build the app.
2. Click on the post button at the bottom of the screen.
3. Type an "@" or press the mentions button.
4. Please check that the following is logged: "Mentions Opened".
