### PR TITLE
Increase build settings timeout during fastlane deployments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Internal Changes
 - Migrate ObservableObject to @Observable where possible [#1458](https://github.com/planetary-social/nos/issues/1458)
 - Added the Create Account onboarding screen. Currently behind the “New Onboarding Flow” feature flag. [#1594](https://github.com/planetary-social/nos/issues/1594)
+- Increase build settings timeout in fastlane. [#1662](https://github.com/planetary-social/nos/pull/1662)
 
 ## [0.2.2] - 2024-10-11Z
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -15,6 +15,10 @@
 
 default_platform(:ios)
 
+# Work around
+# https://github.com/fastlane/fastlane/issues/20919
+ENV["FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT"] = "60" 
+
 platform :ios do
   asc_key_content = ENV["APP_STORE_CONNECT_API_KEY_CONTENT"]
   asc_issuer_id = ENV["APP_STORE_CONNECT_ISSUER_ID"]


### PR DESCRIPTION
## Description
Trying to fix this intermittent deployment failure:

```
xcodebuild -showBuildSettings timed out after 4 retries with a base timeout of 3. You can override the base timeout value with the environment variable FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT, and the number of retries with the environment variable FASTLANE_XCODEBUILD_SETTINGS_RETRIES 
```

[example](https://github.com/planetary-social/nos/actions/runs/11404283834/job/31733112904)

I got this idea from https://github.com/fastlane/fastlane/issues/20919#issuecomment-1344976529

## How to test
Merge and hope this intermittent failure stops.