### PR TITLE
#1597: Display Name screen in onboarding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added the Create Account onboarding screen. Currently behind the “New Onboarding Flow” feature flag. [#1594](https://github.com/planetary-social/nos/issues/1594)
 - Added the Private Key onboarding screen. Currently behind the “New Onboarding Flow” feature flag. [#1595](https://github.com/planetary-social/nos/issues/1595)
 - Added the Public Key onboarding screen. Currently behind the “New Onboarding Flow” feature flag. [#1596](https://github.com/planetary-social/nos/issues/1596)
+- Added the Display Name onboarding screen. Currently behind the “New Onboarding Flow” feature flag. [#1597](https://github.com/planetary-social/nos/issues/1597)
 
 ## [0.2.2] - 2024-10-11Z
 

--- a/Nos.xcodeproj/project.pbxproj
+++ b/Nos.xcodeproj/project.pbxproj
@@ -19,6 +19,8 @@
 		030E56CA2CC1BC6200A4A51E /* PublicKeyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 030E56C92CC1BC6200A4A51E /* PublicKeyView.swift */; };
 		030E56E42CC1BF2900A4A51E /* CopyButtonState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 030E56E32CC1BF2900A4A51E /* CopyButtonState.swift */; };
 		030E56F32CC2836D00A4A51E /* CopyKeyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 030E56F22CC2836D00A4A51E /* CopyKeyView.swift */; };
+		030E570D2CC2A05B00A4A51E /* DisplayNameView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 030E570C2CC2A05B00A4A51E /* DisplayNameView.swift */; };
+		030E571B2CC2ADDB00A4A51E /* SaveProfileError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 030E571A2CC2ADDB00A4A51E /* SaveProfileError.swift */; };
 		030FECAB2CB5E0B900820014 /* BuildYourNetworkView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 030FECAA2CB5E0B900820014 /* BuildYourNetworkView.swift */; };
 		0314CF742C9C7DD00001A53B /* youTube_fortnight_short.html in Resources */ = {isa = PBXBuildFile; fileRef = 0314CF732C9C7DD00001A53B /* youTube_fortnight_short.html */; };
 		0314D5AC2C7D31060002E7F4 /* MediaService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0314D5AB2C7D31060002E7F4 /* MediaService.swift */; };
@@ -595,6 +597,8 @@
 		030E56C92CC1BC6200A4A51E /* PublicKeyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublicKeyView.swift; sourceTree = "<group>"; };
 		030E56E32CC1BF2900A4A51E /* CopyButtonState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CopyButtonState.swift; sourceTree = "<group>"; };
 		030E56F22CC2836D00A4A51E /* CopyKeyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CopyKeyView.swift; sourceTree = "<group>"; };
+		030E570C2CC2A05B00A4A51E /* DisplayNameView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisplayNameView.swift; sourceTree = "<group>"; };
+		030E571A2CC2ADDB00A4A51E /* SaveProfileError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SaveProfileError.swift; sourceTree = "<group>"; };
 		030FECAA2CB5E0B900820014 /* BuildYourNetworkView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildYourNetworkView.swift; sourceTree = "<group>"; };
 		0314CF732C9C7DD00001A53B /* youTube_fortnight_short.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = youTube_fortnight_short.html; sourceTree = "<group>"; };
 		0314D5AB2C7D31060002E7F4 /* MediaService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaService.swift; sourceTree = "<group>"; };
@@ -1478,6 +1482,7 @@
 			children = (
 				030FECAA2CB5E0B900820014 /* BuildYourNetworkView.swift */,
 				039F09582CC051EE00FEEC81 /* CreateAccountView.swift */,
+				030E570C2CC2A05B00A4A51E /* DisplayNameView.swift */,
 				3F30020629C237AB003D4F8B /* OnboardingAgeVerificationView.swift */,
 				3F30020C29C382EB003D4F8B /* OnboardingLoginView.swift */,
 				3F30020829C23895003D4F8B /* OnboardingNotOldEnoughView.swift */,
@@ -1658,6 +1663,7 @@
 				502B6C3C2C9462A400446316 /* PushNotificationRegistrar.swift */,
 				C936B4612A4CB01C00DF1EB9 /* PushNotificationService.swift */,
 				C9A8015D2BD0177D006E29B2 /* ReportPublisher.swift */,
+				030E571A2CC2ADDB00A4A51E /* SaveProfileError.swift */,
 				5B8805192A21027C00E21F06 /* SHA256Key.swift */,
 				C9B678E029EEC41000303F33 /* SocialGraphCache.swift */,
 				C9F64D8B29ED840700563F2B /* Zipper.swift */,
@@ -2351,6 +2357,7 @@
 				C92E7F6D2C4EFF9B00B80638 /* WebSocketState.swift in Sources */,
 				C95D68AB299E710F00429F86 /* Color+Hex.swift in Sources */,
 				037975EA2C0E695A00ADDF37 /* MockFeatureFlags.swift in Sources */,
+				030E571B2CC2ADDB00A4A51E /* SaveProfileError.swift in Sources */,
 				C94A5E182A72C84200B6EC5D /* ReportCategory.swift in Sources */,
 				C9A8015E2BD0177D006E29B2 /* ReportPublisher.swift in Sources */,
 				C9F0BB6B29A503D6000547FC /* PublicKey.swift in Sources */,
@@ -2549,6 +2556,7 @@
 				C905B0772A619E99009B8A78 /* LPLinkViewRepresentable.swift in Sources */,
 				C95D68A7299E6FF000429F86 /* KeyFixture.swift in Sources */,
 				0304D0B22C9B731F001D16C7 /* MockOpenGraphService.swift in Sources */,
+				030E570D2CC2A05B00A4A51E /* DisplayNameView.swift in Sources */,
 				C94437E629B0DB83004D8C86 /* NotificationsView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Nos/Assets/Colors.xcassets/text-field-placeholder.colorset/Contents.json
+++ b/Nos/Assets/Colors.xcassets/text-field-placeholder.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "0.500",
+          "blue" : "0xD8",
+          "green" : "0x88",
+          "red" : "0xA5"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Nos/Assets/Localization/Localizable.xcstrings
+++ b/Nos/Assets/Localization/Localizable.xcstrings
@@ -5236,6 +5236,18 @@
         }
       }
     },
+    "displayNameError" : {
+      "comment" : "error message for when we can't set the display name in onboarding",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "There is a problem connecting to the servers. You can skip for now and visit your Profile to update later."
+          }
+        }
+      }
+    },
     "displayNameHeadline" : {
       "comment" : "headline for the display name screen in onboarding",
       "extractionState" : "manual",
@@ -17512,6 +17524,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "將我的朋友的朋友圈之外的用戶的筆記隱藏在內容警告後面。"
+          }
+        }
+      }
+    },
+    "skipForNow" : {
+      "comment" : "button title that allows the user to skip this for now",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Skip for now"
           }
         }
       }

--- a/Nos/Assets/Localization/Localizable.xcstrings
+++ b/Nos/Assets/Localization/Localizable.xcstrings
@@ -5224,6 +5224,18 @@
         }
       }
     },
+    "displayNameDescription" : {
+      "comment" : "a description for the display name screen in onboarding",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This is how others will see you when they view your notes. You can always change it."
+          }
+        }
+      }
+    },
     "displayNameHeadline" : {
       "comment" : "headline for the display name screen in onboarding",
       "extractionState" : "manual",
@@ -5232,6 +5244,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Display Name"
+          }
+        }
+      }
+    },
+    "displayNamePlaceholder" : {
+      "comment" : "placeholder text for the display name field in onboarding",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your display name"
           }
         }
       }

--- a/Nos/Service/SaveProfileError.swift
+++ b/Nos/Service/SaveProfileError.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+/// An error that may occur while saving a profile.
+enum SaveProfileError: LocalizedError {
+    case unexpectedError
+    case unableToPublishChanges
+
+    var errorDescription: String? {
+        switch self {
+        case .unexpectedError:
+            return "Something unexpected happened"
+        case .unableToPublishChanges:
+            return "We were unable to publish your changes to the network."
+        }
+    }
+}

--- a/Nos/Views/Onboarding/DisplayNameView.swift
+++ b/Nos/Views/Onboarding/DisplayNameView.swift
@@ -1,0 +1,108 @@
+import Dependencies
+import SwiftUI
+
+/// The Display Name view in the onboarding.
+struct DisplayNameView: View {
+    @Environment(OnboardingState.self) private var state
+    @Environment(CurrentUser.self) private var currentUser
+    @Environment(\.managedObjectContext) private var viewContext
+
+    @Dependency(\.crashReporting) private var crashReporting
+
+    @State private var displayName = ""
+    @State private var saveError: SaveProfileError?
+
+    private var showAlert: Binding<Bool> {
+        Binding {
+            saveError != nil
+        } set: { _ in
+            saveError = nil
+        }
+    }
+
+    var body: some View {
+        ZStack {
+            Color.appBg
+                .ignoresSafeArea()
+            ViewThatFits(in: .vertical) {
+                displayNameStack
+
+                ScrollView {
+                    displayNameStack
+                }
+            }
+        }
+        .navigationBarHidden(true)
+        .alert(isPresented: showAlert, error: saveError) {
+            Button {
+                saveError = nil
+                Task {
+                    await save()
+                }
+            } label: {
+                Text("retry")
+            }
+            Button {
+                saveError = nil
+            } label: {
+                Text("cancel")
+            }
+        }
+    }
+
+    var displayNameStack: some View {
+        VStack(alignment: .leading, spacing: 20) {
+            LargeNumberView(3)
+            Text("displayNameHeadline")
+                .font(.clarityBold(.title))
+                .foregroundStyle(Color.primaryTxt)
+            Text("displayNameDescription")
+                .font(.body)
+                .foregroundStyle(Color.secondaryTxt)
+            TextField(
+                "",
+                text: $displayName,
+                prompt: Text("displayNamePlaceholder")
+                    .foregroundStyle(Color.textFieldPlaceholder)
+            )
+                .textInputAutocapitalization(.none)
+                .foregroundStyle(Color.primaryTxt)
+                .fontWeight(.bold)
+                .autocorrectionDisabled()
+                .padding()
+                .withStyledBorder()
+            Spacer()
+            BigActionButton("next") {
+                await save()
+            }
+        }
+        .padding(40)
+        .readabilityPadding()
+    }
+    
+    /// Saves the display name locally and publishes the event to relays. Sets `saveError` if it fails.
+    func save() async {
+        guard let author = await currentUser.author else {
+            saveError = SaveProfileError.unexpectedError
+            return
+        }
+
+        author.displayName = displayName
+        do {
+            try viewContext.save()
+            try await currentUser.publishMetadata()
+            state.step = .buildYourNetwork
+        } catch CurrentUserError.errorWhilePublishingToRelays {
+            saveError = SaveProfileError.unableToPublishChanges
+        } catch {
+            crashReporting.report(error)
+            saveError = SaveProfileError.unexpectedError
+        }
+    }
+}
+
+#Preview {
+    DisplayNameView()
+        .environment(OnboardingState())
+        .inject(previewData: PreviewData())
+}

--- a/Nos/Views/Onboarding/DisplayNameView.swift
+++ b/Nos/Views/Onboarding/DisplayNameView.swift
@@ -68,7 +68,7 @@ struct DisplayNameView: View {
         state.step = .buildYourNetwork
     }
 
-    /// Saves the display name locally and publishes the event to relays. Sets `saveError` if it fails.
+    /// Saves the display name locally and publishes the event to relays. Sets `showError` if it fails.
     func save() async {
         guard let author = await currentUser.author else {
             showError = true

--- a/Nos/Views/Onboarding/DisplayNameView.swift
+++ b/Nos/Views/Onboarding/DisplayNameView.swift
@@ -10,15 +10,7 @@ struct DisplayNameView: View {
     @Dependency(\.crashReporting) private var crashReporting
 
     @State private var displayName = ""
-    @State private var saveError: SaveProfileError?
-
-    private var showAlert: Binding<Bool> {
-        Binding {
-            saveError != nil
-        } set: { _ in
-            saveError = nil
-        }
-    }
+    @State private var showError: Bool = false
 
     var body: some View {
         ZStack {
@@ -33,19 +25,11 @@ struct DisplayNameView: View {
             }
         }
         .navigationBarHidden(true)
-        .alert(isPresented: showAlert, error: saveError) {
+        .alert("displayNameError", isPresented: $showError) {
             Button {
-                saveError = nil
-                Task {
-                    await save()
-                }
+                nextStep()
             } label: {
-                Text("retry")
-            }
-            Button {
-                saveError = nil
-            } label: {
-                Text("cancel")
+                Text("skipForNow")
             }
         }
     }
@@ -79,11 +63,15 @@ struct DisplayNameView: View {
         .padding(40)
         .readabilityPadding()
     }
-    
+
+    func nextStep() {
+        state.step = .buildYourNetwork
+    }
+
     /// Saves the display name locally and publishes the event to relays. Sets `saveError` if it fails.
     func save() async {
         guard let author = await currentUser.author else {
-            saveError = SaveProfileError.unexpectedError
+            showError = true
             return
         }
 
@@ -91,12 +79,10 @@ struct DisplayNameView: View {
         do {
             try viewContext.save()
             try await currentUser.publishMetadata()
-            state.step = .buildYourNetwork
-        } catch CurrentUserError.errorWhilePublishingToRelays {
-            saveError = SaveProfileError.unableToPublishChanges
+            nextStep()
         } catch {
             crashReporting.report(error)
-            saveError = SaveProfileError.unexpectedError
+            showError = true
         }
     }
 }

--- a/Nos/Views/Onboarding/OnboardingView.swift
+++ b/Nos/Views/Onboarding/OnboardingView.swift
@@ -22,6 +22,7 @@ enum OnboardingStep {
     case createAccount
     case privateKey
     case publicKey
+    case displayName
     case buildYourNetwork
     case login
 }
@@ -56,6 +57,9 @@ struct OnboardingView: View {
                             .environment(state)
                     case .publicKey:
                         PublicKeyView()
+                            .environment(state)
+                    case .displayName:
+                        DisplayNameView()
                             .environment(state)
                     case .login:
                         OnboardingLoginView(completion: completion)

--- a/Nos/Views/Onboarding/PublicKeyView.swift
+++ b/Nos/Views/Onboarding/PublicKeyView.swift
@@ -44,7 +44,7 @@ struct PublicKeyView: View {
             CopyKeyView("copyPublicKey", keyString: $publicKeyString, copyButtonState: $copyButtonState)
             Spacer()
             BigActionButton("next") {
-                state.step = .buildYourNetwork
+                state.step = .displayName
             }
         }
         .padding(40)

--- a/Nos/Views/Profile/Edit/ProfileEditView.swift
+++ b/Nos/Views/Profile/Edit/ProfileEditView.swift
@@ -24,7 +24,7 @@ struct ProfileEditView: View {
     @State private var website: String = ""
     @State private var showNIP05Wizard = false
     @State private var showConfirmationDialog = false
-    @State private var saveError: SaveError?
+    @State private var saveError: SaveProfileError?
     
     @State private var isUploadingPhoto = false
 
@@ -144,24 +144,10 @@ struct ProfileEditView: View {
             // Go back to profile page
             router.pop()
         } catch CurrentUserError.errorWhilePublishingToRelays {
-            saveError = SaveError.unableToPublishChanges
+            saveError = SaveProfileError.unableToPublishChanges
         } catch {
             crashReporting.report(error)
-            saveError = SaveError.unexpectedError
-        }
-    }
-
-    enum SaveError: LocalizedError {
-        case unexpectedError
-        case unableToPublishChanges
-
-        var errorDescription: String? {
-            switch self {
-            case .unexpectedError:
-                return "Something unexpected happened"
-            case .unableToPublishChanges:
-                return "We were unable to publish your changes in the network"
-            }
+            saveError = SaveProfileError.unexpectedError
         }
     }
 }


### PR DESCRIPTION
## Issues covered
#1597 

## Description
Adds the Display Name screen to onboarding.

I [asked in Figma](https://www.figma.com/design/6MeujQUXzC1AuviHEHCs0J?node-id=9321-17713#992122438) about handling errors, so that logic is included here as well.

## How to test
1. Navigate to Settings
2. Enable New Onboarding Flow
3. Log out
4. Try the new onboarding flow
5. Observe the display name screen

I'm not sure how to test the errors that can be thrown when saving the display name. Maybe you know?

I did hard-code the `showError: Bool` to `true` to test that when the alert is displayed, tapping the "Skip for now" button moves to the next screen.

## Screenshots/Video
### Happy path
https://github.com/user-attachments/assets/2d4c6377-57e5-4c22-8746-4ce8b36c3c58

### Error state
![Simulator Screenshot - iPhone 15 Pro - 2024-10-18 at 15 12 14](https://github.com/user-attachments/assets/b6e88d5e-9692-431f-99bb-a3fe5ab38eec)
