### PR TITLE
ObservableObject to @Observable migrations #1458

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Internal Changes
 - Migrate ObservableObject to @Observable where possible [#1458](https://github.com/planetary-social/nos/issues/1458)
 - Added the Create Account onboarding screen. Currently behind the “New Onboarding Flow” feature flag. [#1594](https://github.com/planetary-social/nos/issues/1594)
+- More ObservableObject to @Observable migrations [#1458](https://github.com/planetary-social/nos/issues/1458)
 
 ## [0.2.2] - 2024-10-11Z
 

--- a/Nos.xcodeproj/project.pbxproj
+++ b/Nos.xcodeproj/project.pbxproj
@@ -175,6 +175,7 @@
 		504454712C90728E00251A7E /* Event+Fetching.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5044546D2C90726A00251A7E /* Event+Fetching.swift */; };
 		504454722C90729100251A7E /* Event+Hydration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5044546F2C90728500251A7E /* Event+Hydration.swift */; };
 		5045540D2C81E10C0044ECAE /* EditableAvatarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5045540C2C81E10C0044ECAE /* EditableAvatarView.swift */; };
+		506102882CC3D29B003DC0E3 /* TextDebouncer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 506102872CC3D29B003DC0E3 /* TextDebouncer.swift */; };
 		508133CB2C79F78500DFBF75 /* AttributedString+Quotation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 508133CA2C79F78500DFBF75 /* AttributedString+Quotation.swift */; };
 		508133DB2C7A003600DFBF75 /* AttributedString+QuotationsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 508133DA2C7A003600DFBF75 /* AttributedString+QuotationsTests.swift */; };
 		508133DC2C7A007700DFBF75 /* AttributedString+Quotation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 508133CA2C79F78500DFBF75 /* AttributedString+Quotation.swift */; };
@@ -703,6 +704,7 @@
 		5044546D2C90726A00251A7E /* Event+Fetching.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Event+Fetching.swift"; sourceTree = "<group>"; };
 		5044546F2C90728500251A7E /* Event+Hydration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Event+Hydration.swift"; sourceTree = "<group>"; };
 		5045540C2C81E10C0044ECAE /* EditableAvatarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditableAvatarView.swift; sourceTree = "<group>"; };
+		506102872CC3D29B003DC0E3 /* TextDebouncer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextDebouncer.swift; sourceTree = "<group>"; };
 		508133CA2C79F78500DFBF75 /* AttributedString+Quotation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AttributedString+Quotation.swift"; sourceTree = "<group>"; };
 		508133DA2C7A003600DFBF75 /* AttributedString+QuotationsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AttributedString+QuotationsTests.swift"; sourceTree = "<group>"; };
 		508B2B602C9EF65300C14034 /* NSPersistentContainer+Nos.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSPersistentContainer+Nos.swift"; sourceTree = "<group>"; };
@@ -1858,6 +1860,7 @@
 				C94A5E172A72C84200B6EC5D /* ReportCategory.swift */,
 				C9E37E142A1E8143003D4B0A /* ReportTarget.swift */,
 				C992B3292B3613CC00704A9C /* SubscriptionCancellable.swift */,
+				506102872CC3D29B003DC0E3 /* TextDebouncer.swift */,
 				5BFBB28A2BD9D79F002E909F /* URLParser.swift */,
 				659B27232BD9CB4500BEA6CC /* VerifiableEvent.swift */,
 				030742C32B4769F90073839D /* CoreData */,
@@ -2421,6 +2424,7 @@
 				C95D68A1299E6D3E00429F86 /* BioView.swift in Sources */,
 				5BE281CA2AE2CCEB00880466 /* HomeTab.swift in Sources */,
 				03C49AC22C938DE100502321 /* SoupOpenGraphParser.swift in Sources */,
+				506102882CC3D29B003DC0E3 /* TextDebouncer.swift in Sources */,
 				C94D14812A12B3F70014C906 /* SearchBar.swift in Sources */,
 				C92E7F672C4EFF3D00B80638 /* WebSocketErrorEvent.swift in Sources */,
 				0317263C2C7935220030EDCA /* AspectRatioContainer.swift in Sources */,

--- a/Nos/Models/TextDebouncer.swift
+++ b/Nos/Models/TextDebouncer.swift
@@ -1,0 +1,27 @@
+import Combine
+import SwiftUI
+
+@Observable final class TextDebouncer {
+
+    private(set) var debouncedText = ""
+
+    var text = "" {
+        didSet {
+            textPublisher.send(text)
+        }
+    }
+    @ObservationIgnored private lazy var textPublisher = CurrentValueSubject<String, Never>(text)
+
+    private var subscriptions = Set<AnyCancellable>()
+
+    init() {
+        textPublisher
+            .removeDuplicates()
+            .filter { $0.count >= 3 }
+            .debounce(for: .milliseconds(200), scheduler: RunLoop.main)
+            .sink { [weak self] value in
+                self?.debouncedText = value
+            }
+            .store(in: &subscriptions)
+    }
+}

--- a/Nos/NosApp.swift
+++ b/Nos/NosApp.swift
@@ -34,7 +34,7 @@ struct NosApp: App {
                 .environmentObject(router)
                 .environment(appController)
                 .environment(currentUser)
-                .environmentObject(pushNotificationService)
+                .environment(pushNotificationService)
                 .onOpenURL { DeepLinkService.handle($0, router: router) }
                 .onChange(of: scenePhase) { _, newPhase in
                     switch newPhase {

--- a/Nos/NosApp.swift
+++ b/Nos/NosApp.swift
@@ -30,7 +30,7 @@ struct NosApp: App {
         WindowGroup {
             AppView()
                 .environment(\.managedObjectContext, persistenceController.viewContext)
-                .environmentObject(relayService)
+                .environment(relayService)
                 .environmentObject(router)
                 .environment(appController)
                 .environment(currentUser)

--- a/Nos/Service/PushNotificationService.swift
+++ b/Nos/Service/PushNotificationService.swift
@@ -8,13 +8,13 @@ import Combine
 /// A class that abstracts our interactions with push notification infrastructure and iOS permissions. It can handle
 /// UNUserNotificationCenterDelegate callbacks for receiving and displaying notifications, and it watches the db for
 /// all new events and creates `NosNotification`s and displays them when appropriate.
-@MainActor class PushNotificationService: 
-    NSObject, ObservableObject, NSFetchedResultsControllerDelegate, UNUserNotificationCenterDelegate {
+@MainActor @Observable class PushNotificationService:
+    NSObject, NSFetchedResultsControllerDelegate, UNUserNotificationCenterDelegate {
     
     // MARK: - Public Properties
     
     /// The number of unread notifications that should be displayed as a badge
-    @Published var badgeCount = 0
+    private(set) var badgeCount = 0
 
     private let showPushNotificationsAfterKey = "PushNotificationService.notificationCutoff"
 
@@ -40,22 +40,20 @@ import Combine
     
     // MARK: - Private Properties
     
-    @Dependency(\.relayService) private var relayService
-    @Dependency(\.persistenceController) private var persistenceController
-    @Dependency(\.router) private var router
-    @Dependency(\.analytics) private var analytics
-    @Dependency(\.crashReporting) private var crashReporting
-    @Dependency(\.userDefaults) private var userDefaults
-    @Dependency(\.currentUser) private var currentUser
+    @ObservationIgnored @Dependency(\.relayService) private var relayService
+    @ObservationIgnored @Dependency(\.persistenceController) private var persistenceController
+    @ObservationIgnored @Dependency(\.router) private var router
+    @ObservationIgnored @Dependency(\.analytics) private var analytics
+    @ObservationIgnored @Dependency(\.crashReporting) private var crashReporting
+    @ObservationIgnored @Dependency(\.userDefaults) private var userDefaults
+    @ObservationIgnored @Dependency(\.currentUser) private var currentUser
     
     private var notificationWatcher: NSFetchedResultsController<Event>?
     private var relaySubscription: SubscriptionCancellable?
     private var currentAuthor: Author? 
-    private lazy var modelContext: NSManagedObjectContext = {
-        persistenceController.newBackgroundContext()
-    }()
+    @ObservationIgnored private lazy var modelContext = persistenceController.newBackgroundContext()
     
-    private lazy var registrar = PushNotificationRegistrar()
+    @ObservationIgnored private lazy var registrar = PushNotificationRegistrar()
     
     // MARK: - Setup
     

--- a/Nos/Service/Relay/RelayService.swift
+++ b/Nos/Service/Relay/RelayService.swift
@@ -9,7 +9,7 @@ import UIKit
 
 /// A service that maintains connections to Nostr Relay servers and executes requests for data from those relays
 /// in the form of `Filters` and `RelaySubscription`s.
-class RelayService: ObservableObject {
+@Observable class RelayService {
     
     private var subscriptionManager: RelaySubscriptionManager
     private var processSubscriptionQueueTimer: AsyncTimer?
@@ -19,11 +19,10 @@ class RelayService: ObservableObject {
     private var processingQueue = DispatchQueue(label: "RelayService-processing", qos: .userInitiated)
     private var parseQueue = ParseQueue()
     
-    @Dependency(\.persistenceController) var persistenceController
-    @Dependency(\.analytics) private var analytics
-    @Dependency(\.crashReporting) private var crashReporting
-    @MainActor @Dependency(\.currentUser) private var currentUser
-    @Published var numberOfConnectedRelays: Int = 0
+    @ObservationIgnored @Dependency(\.persistenceController) var persistenceController
+    @ObservationIgnored @Dependency(\.analytics) private var analytics
+    @ObservationIgnored @Dependency(\.crashReporting) private var crashReporting
+    @MainActor @ObservationIgnored @Dependency(\.currentUser) private var currentUser
     
     init(subscriptionManager: RelaySubscriptionManager = RelaySubscriptionManagerActor()) {
         self.subscriptionManager = subscriptionManager
@@ -312,13 +311,6 @@ extension RelayService {
         await clearStaleSubscriptions()
         
         await subscriptionManager.processSubscriptionQueue()
-        
-        let socketsCount = await subscriptionManager.sockets().count
-        Task { @MainActor in
-            if numberOfConnectedRelays != socketsCount {
-                numberOfConnectedRelays = socketsCount
-            }
-        }
     }
     
     private func clearStaleSubscriptions() async {

--- a/Nos/Views/AppView.swift
+++ b/Nos/Views/AppView.swift
@@ -8,7 +8,7 @@ struct AppView: View {
 
     @Environment(AppController.self) var appController
     @EnvironmentObject private var router: Router
-    @EnvironmentObject var pushNotificationService: PushNotificationService
+    @Environment(PushNotificationService.self) private var pushNotificationService
     @Dependency(\.analytics) private var analytics
     @Dependency(\.crashReporting) private var crashReporting
     @Dependency(\.userDefaults) private var userDefaults
@@ -230,7 +230,7 @@ struct AppView_Previews: PreviewProvider {
             .environmentObject(router)
             .environment(loggedInAppController)
             .environment(currentUser)
-            .environmentObject(pushNotificationService)
+            .environment(pushNotificationService)
 
         AppView()
             .environment(\.managedObjectContext, previewContext)
@@ -238,7 +238,7 @@ struct AppView_Previews: PreviewProvider {
             .environmentObject(router)
             .environment(AppController())
             .environment(currentUser)
-            .environmentObject(pushNotificationService)
+            .environment(pushNotificationService)
 
         AppView()
             .environment(\.managedObjectContext, previewContext)
@@ -246,6 +246,6 @@ struct AppView_Previews: PreviewProvider {
             .environmentObject(routerWithSideMenuOpened)
             .environment(AppController())
             .environment(currentUser)
-            .environmentObject(pushNotificationService)
+            .environment(pushNotificationService)
     }
 }

--- a/Nos/Views/AppView.swift
+++ b/Nos/Views/AppView.swift
@@ -226,7 +226,7 @@ struct AppView_Previews: PreviewProvider {
     static var previews: some View {
         AppView()
             .environment(\.managedObjectContext, previewContext)
-            .environmentObject(relayService)
+            .environment(relayService)
             .environmentObject(router)
             .environment(loggedInAppController)
             .environment(currentUser)
@@ -234,7 +234,7 @@ struct AppView_Previews: PreviewProvider {
 
         AppView()
             .environment(\.managedObjectContext, previewContext)
-            .environmentObject(relayService)
+            .environment(relayService)
             .environmentObject(router)
             .environment(AppController())
             .environment(currentUser)
@@ -242,7 +242,7 @@ struct AppView_Previews: PreviewProvider {
 
         AppView()
             .environment(\.managedObjectContext, previewContext)
-            .environmentObject(relayService)
+            .environment(relayService)
             .environmentObject(routerWithSideMenuOpened)
             .environment(AppController())
             .environment(currentUser)

--- a/Nos/Views/Components/Author/AuthorListView.swift
+++ b/Nos/Views/Components/Author/AuthorListView.swift
@@ -7,7 +7,7 @@ struct AuthorListView: View {
     
     @Environment(\.managedObjectContext) private var viewContext
 
-    @StateObject private var searchController = SearchController(searchOrigin: .mentions)
+    @State private var searchController = SearchController(searchOrigin: .mentions)
 
     @FocusState private var isSearching: Bool
 

--- a/Nos/Views/Components/Author/CompactAuthorCard.swift
+++ b/Nos/Views/Components/Author/CompactAuthorCard.swift
@@ -7,7 +7,7 @@ struct CompactAuthorCard: View {
     let author: Author
 
     @EnvironmentObject private var router: Router
-    @EnvironmentObject private var relayService: RelayService
+    @Environment(RelayService.self) private var relayService
     
     @State private var relaySubscriptions = SubscriptionCancellables()
 

--- a/Nos/Views/Components/Button/LikeButton.swift
+++ b/Nos/Views/Components/Button/LikeButton.swift
@@ -17,7 +17,7 @@ struct LikeButton: View {
     /// Whether a "like" or "delete like" event is currently being published.
     @State private var isPublishing = false
 
-    @EnvironmentObject private var relayService: RelayService
+    @Environment(RelayService.self) private var relayService
     @Environment(CurrentUser.self) private var currentUser
     @Environment(\.managedObjectContext) private var viewContext
     @ObservationIgnored @Dependency(\.analytics) private var analytics

--- a/Nos/Views/Components/Button/NoteButton.swift
+++ b/Nos/Views/Components/Button/NoteButton.swift
@@ -31,7 +31,7 @@ struct NoteButton: View {
     private let tapAction: ((Event) -> Void)?
     @State private var relaySubscriptions = SubscriptionCancellables()
 
-    @EnvironmentObject private var relayService: RelayService
+    @Environment(RelayService.self) private var relayService
     @EnvironmentObject private var router: Router
     
     /// Initializes a NoteButton object.

--- a/Nos/Views/Components/Button/RepostButton.swift
+++ b/Nos/Views/Components/Button/RepostButton.swift
@@ -10,7 +10,7 @@ struct RepostButton: View {
     let showsCount: Bool
 
     @FetchRequest private var reposts: FetchedResults<Event>
-    @EnvironmentObject private var relayService: RelayService
+    @Environment(RelayService.self) private var relayService
     @Environment(CurrentUser.self) private var currentUser
     @Environment(\.managedObjectContext) private var viewContext
     

--- a/Nos/Views/Components/ThreadView.swift
+++ b/Nos/Views/Components/ThreadView.swift
@@ -151,7 +151,7 @@ struct ThreadView_Previews: PreviewProvider {
     static var previews: some View {
         ThreadView(root: rootNote, allReplies: [replyNote, secondReply])
             .environment(\.managedObjectContext, emptyPreviewContext)
-            .environmentObject(emptyRelayService)
+            .environment(emptyRelayService)
             .environmentObject(router)
             .environment(currentUser)
     }

--- a/Nos/Views/Discover/DiscoverContentsView.swift
+++ b/Nos/Views/Discover/DiscoverContentsView.swift
@@ -3,7 +3,7 @@ import SwiftUI
 import Dependencies
 
 struct DiscoverContentsView: View {
-    @ObservedObject var searchController: SearchController
+    @State private var searchController: SearchController
 
     @EnvironmentObject private var router: Router
 

--- a/Nos/Views/Discover/DiscoverContentsView.swift
+++ b/Nos/Views/Discover/DiscoverContentsView.swift
@@ -3,7 +3,7 @@ import SwiftUI
 import Dependencies
 
 struct DiscoverContentsView: View {
-    @State private var searchController: SearchController
+    private var searchController: SearchController
 
     @EnvironmentObject private var router: Router
 

--- a/Nos/Views/Discover/DiscoverTab.swift
+++ b/Nos/Views/Discover/DiscoverTab.swift
@@ -17,7 +17,7 @@ struct DiscoverTab: View {
     
     @State private var isVisible = false
 
-    @StateObject private var searchController = SearchController()
+    @State private var searchController = SearchController()
 
     @State var predicate: NSPredicate = .false
 

--- a/Nos/Views/Fixtures/PreviewData.swift
+++ b/Nos/Views/Fixtures/PreviewData.swift
@@ -341,7 +341,7 @@ struct InjectPreviewData: ViewModifier {
         content
             .environment(\.managedObjectContext, previewData.persistenceController.viewContext)
             .environmentObject(previewData.router)
-            .environmentObject(previewData.relayService)
+            .environment(previewData.relayService)
             .environment(previewData.currentUser)
     }
 }

--- a/Nos/Views/Note/NoteCard.swift
+++ b/Nos/Views/Note/NoteCard.swift
@@ -223,7 +223,7 @@ struct NoteCard_Previews: PreviewProvider {
             }
         }
         .environment(\.managedObjectContext, previewData.previewContext)
-        .environmentObject(previewData.relayService)
+        .environment(previewData.relayService)
         .environmentObject(previewData.router)
         .environment(previewData.currentUser)
         .padding()

--- a/Nos/Views/Note/NoteView.swift
+++ b/Nos/Views/Note/NoteView.swift
@@ -4,7 +4,7 @@ import SwiftUINavigation
 import Dependencies
 
 struct NoteView: View {
-    @EnvironmentObject private var relayService: RelayService
+    @Environment(RelayService.self) private var relayService
     @EnvironmentObject private var router: Router
     @Environment(CurrentUser.self) private var currentUser
     @Dependency(\.analytics) private var analytics
@@ -210,7 +210,7 @@ struct RepliesView_Previews: PreviewProvider {
             }
         }
         .environment(\.managedObjectContext, previewContext)
-        .environmentObject(emptyRelayService)
+        .environment(emptyRelayService)
         .environmentObject(router)
         .environment(currentUser)
         .padding()

--- a/Nos/Views/NoteComposer/NoteComposer.swift
+++ b/Nos/Views/NoteComposer/NoteComposer.swift
@@ -7,8 +7,8 @@ import SwiftUINavigation
 struct NoteComposer: View {
     
     @Environment(\.managedObjectContext) private var viewContext
-    @EnvironmentObject private var relayService: RelayService
-    @Environment(CurrentUser.self) var currentUser
+    @Environment(RelayService.self) private var relayService
+    @Dependency(\.currentUser) private var currentUser
     @Dependency(\.analytics) private var analytics
     @Dependency(\.noteParser) private var noteParser
     @Dependency(\.persistenceController) private var persistenceController
@@ -262,7 +262,7 @@ struct NoteComposer: View {
         .zIndex(1)
     }
 
-    private func postAction() async {
+    @MainActor private func postAction() async {
         guard currentUser.keyPair != nil, let author = currentUser.author else {
             alert = AlertState(title: {
                 TextState(String(localized: .localizable.error))
@@ -345,7 +345,7 @@ struct NoteComposer: View {
         )
     }
 
-    private func publishPost() async {
+    @MainActor private func publishPost() async {
         guard let keyPair = currentUser.keyPair, let author = currentUser.author else {
             Log.error("Cannot post without a keypair")
             return

--- a/Nos/Views/Notifications/NotificationCard.swift
+++ b/Nos/Views/Notifications/NotificationCard.swift
@@ -6,7 +6,7 @@ struct NotificationCard: View {
     
     @Environment(\.managedObjectContext) private var viewContext
     @EnvironmentObject private var router: Router
-    @EnvironmentObject private var relayService: RelayService
+    @Environment(RelayService.self) private var relayService
     @Dependency(\.persistenceController) private var persistenceController
     
     let viewModel: NotificationViewModel

--- a/Nos/Views/Notifications/NotificationsView.swift
+++ b/Nos/Views/Notifications/NotificationsView.swift
@@ -7,7 +7,7 @@ import Logger
 /// Displays a list of cells that let the user know when other users interact with their notes.
 struct NotificationsView: View {
     
-    @EnvironmentObject private var relayService: RelayService
+    @Environment(RelayService.self) private var relayService
     @EnvironmentObject private var router: Router
     @Dependency(\.analytics) private var analytics
     @Dependency(\.pushNotificationService) private var pushNotificationService

--- a/Nos/Views/Profile/Edit/CreateUsernameWizard/AlreadyHaveANIP05View.swift
+++ b/Nos/Views/Profile/Edit/CreateUsernameWizard/AlreadyHaveANIP05View.swift
@@ -5,7 +5,7 @@ import SwiftUI
 
 struct AlreadyHaveANIP05View: View {
     @Binding var isPresented: Bool
-    @State private var usernameObserver = TextDebouncer()
+    @State var usernameObserver = TextDebouncer()
     @State private var verified: Bool?
     @State private var isVerifying = false
     @State private var verifyTask: Task<Void, Never>?
@@ -126,7 +126,7 @@ struct AlreadyHaveANIP05View: View {
 
 fileprivate struct UsernameTextField: View {
 
-    @State var usernameObserver: TextDebouncer
+    @Bindable var usernameObserver: TextDebouncer
     @FocusState private var usernameFieldIsFocused: Bool
 
     var body: some View {

--- a/Nos/Views/Profile/Edit/CreateUsernameWizard/AlreadyHaveANIP05View.swift
+++ b/Nos/Views/Profile/Edit/CreateUsernameWizard/AlreadyHaveANIP05View.swift
@@ -5,7 +5,7 @@ import SwiftUI
 
 struct AlreadyHaveANIP05View: View {
     @Binding var isPresented: Bool
-    @StateObject private var usernameObserver = UsernameObserver()
+    @State private var usernameObserver = TextDebouncer()
     @State private var verified: Bool?
     @State private var isVerifying = false
     @State private var verifyTask: Task<Void, Never>?
@@ -124,31 +124,9 @@ struct AlreadyHaveANIP05View: View {
     }
 }
 
-fileprivate class UsernameObserver: ObservableObject {
-
-    @Published
-    var debouncedText = ""
-
-    @Published
-    var text = ""
-
-    private var subscriptions = Set<AnyCancellable>()
-
-    init() {
-        $text
-            .removeDuplicates()
-            .filter { $0.count >= 3 }
-            .debounce(for: .milliseconds(200), scheduler: RunLoop.main)
-            .sink { [weak self] value in
-                self?.debouncedText = value
-            }
-            .store(in: &subscriptions)
-    }
-}
-
 fileprivate struct UsernameTextField: View {
 
-    @StateObject var usernameObserver: UsernameObserver
+    @State var usernameObserver: TextDebouncer
     @FocusState private var usernameFieldIsFocused: Bool
 
     var body: some View {

--- a/Nos/Views/Profile/Edit/CreateUsernameWizard/PickYourUsernameSheet.swift
+++ b/Nos/Views/Profile/Edit/CreateUsernameWizard/PickYourUsernameSheet.swift
@@ -6,7 +6,7 @@ import SwiftUI
 struct PickYourUsernameSheet: View {
 
     @Binding var isPresented: Bool
-    @StateObject private var usernameObserver = UsernameObserver()
+    @State private var usernameObserver = TextDebouncer()
     @State private var verified: Bool?
     @State private var isVerifying = false
     @Dependency(\.namesAPI) private var namesAPI
@@ -114,31 +114,9 @@ struct PickYourUsernameSheet: View {
     }
 }
 
-fileprivate class UsernameObserver: ObservableObject {
-
-    @Published
-    var debouncedText = ""
-
-    @Published
-    var text = ""
-
-    private var subscriptions = Set<AnyCancellable>()
-
-    init() {
-        $text
-            .removeDuplicates()
-            .filter { $0.count >= 3 }
-            .debounce(for: .milliseconds(200), scheduler: RunLoop.main)
-            .sink { [weak self] value in
-                self?.debouncedText = value
-            }
-            .store(in: &subscriptions)
-    }
-}
-
 fileprivate struct UsernameTextField: View {
 
-    @StateObject var usernameObserver: UsernameObserver
+    @State var usernameObserver: TextDebouncer
     @FocusState private var usernameFieldIsFocused: Bool
 
     var body: some View {

--- a/Nos/Views/Profile/Edit/CreateUsernameWizard/PickYourUsernameSheet.swift
+++ b/Nos/Views/Profile/Edit/CreateUsernameWizard/PickYourUsernameSheet.swift
@@ -6,7 +6,7 @@ import SwiftUI
 struct PickYourUsernameSheet: View {
 
     @Binding var isPresented: Bool
-    @State private var usernameObserver = TextDebouncer()
+    @State var usernameObserver = TextDebouncer()
     @State private var verified: Bool?
     @State private var isVerifying = false
     @Dependency(\.namesAPI) private var namesAPI
@@ -116,7 +116,7 @@ struct PickYourUsernameSheet: View {
 
 fileprivate struct UsernameTextField: View {
 
-    @State var usernameObserver: TextDebouncer
+    @Bindable var usernameObserver: TextDebouncer
     @FocusState private var usernameFieldIsFocused: Bool
 
     var body: some View {

--- a/Nos/Views/Relay/RelayView.swift
+++ b/Nos/Views/Relay/RelayView.swift
@@ -10,7 +10,7 @@ struct RelaysDestination: Hashable {
 
 struct RelayView: View {
     @Environment(\.managedObjectContext) private var viewContext
-    @EnvironmentObject private var relayService: RelayService
+    @Environment(RelayService.self) private var relayService
     @Environment(CurrentUser.self) private var currentUser
     @ObservedObject var author: Author
     


### PR DESCRIPTION
## Issues covered
#1458 

## Description
Migrates several more classes to use `@Observable` macro rather than the `ObservableObject` protocol for the performance gains and general modernization of patterns.

## How to test
1. Navigate to the Note Composer view.
2. Tap "@" to bring up the user search view.
Observe that the search fires on key taps.

1. Navigate to the Note Composer.
2. Type a note.
3. Send it.
Observe that the note was sent.

1. Navigate to the Discover tab.
2. Search for something.
Observe that results appear as you type.

1. Navigate to your profile view.
2. Tap the Claim your username button.
3. Select either set up or already have.
4. Type in the box.
Observe that the UI responds as you type.

## Screenshots/Video
No intended UI changes, but here are some videos of affected areas of code to show that they still work as expected:

Adding a mention to a note...(shows that the refactored `TextDebouncer` works)
![mention](https://github.com/user-attachments/assets/da25bdd8-935f-4bf3-8a21-350ed7d8c847)

Posting a note...(shows that `RelayService` as `@Observable` works)
![posting](https://github.com/user-attachments/assets/d4121750-3df2-4ffa-a8ce-275966ffdee7)

Search in Discover...(shows that `SearchController` as `@Observable` works)
![search](https://github.com/user-attachments/assets/0417e0b2-dcfc-4463-9c37-3a6bd5d57d97)

Username search...(shows that `SearchController` and `TextDebouncer` work)
![username](https://github.com/user-attachments/assets/ca76b198-6148-491e-89ef-f78f9762dfb4)
