### PR TITLE
Fix mute list parsing bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Release Notes
+- Fix two bugs that could result in muted users being unmuted. [#1674](https://github.com/planetary-social/nos/pull/1674)
 - Added a tip to Discover to prompt first-time users to go to their Feed. [#1601](https://github.com/planetary-social/nos/issues/1601)
 - Added a tip to the Feed to welcome first-time users and explain how the Feed works. [#1602](https://github.com/planetary-social/nos/issues/1602)
 - Added a tag to published contact lists to help us detect the source of lost contact lists. [cleanstr#51](https://github.com/planetary-social/cleanstr/issues/51)

--- a/Nos.xcodeproj/project.pbxproj
+++ b/Nos.xcodeproj/project.pbxproj
@@ -321,6 +321,9 @@
 		C94D855C2991479900749478 /* NoteComposer.swift in Sources */ = {isa = PBXBuildFile; fileRef = C94D855B2991479900749478 /* NoteComposer.swift */; };
 		C94D855F29914D2300749478 /* SwiftUINavigation in Frameworks */ = {isa = PBXBuildFile; productRef = C94D855E29914D2300749478 /* SwiftUINavigation */; };
 		C94FE9F729DB259300019CD3 /* Text+Gradient.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9A0DAE629C69FA000466635 /* Text+Gradient.swift */; };
+		C95057A72CC692360024EC9C /* mute_list.json in Resources */ = {isa = PBXBuildFile; fileRef = C95057A62CC692320024EC9C /* mute_list.json */; };
+		C95057B12CC698730024EC9C /* mute_list_2.json in Resources */ = {isa = PBXBuildFile; fileRef = C95057B02CC6986E0024EC9C /* mute_list_2.json */; };
+		C95057C52CC69A7D0024EC9C /* mute_list_self.json in Resources */ = {isa = PBXBuildFile; fileRef = C95057C42CC69A770024EC9C /* mute_list_self.json */; };
 		C959DB762BD01DF4008F3627 /* GiftWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = C959DB752BD01DF4008F3627 /* GiftWrapper.swift */; };
 		C959DB772BD01DF4008F3627 /* GiftWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = C959DB752BD01DF4008F3627 /* GiftWrapper.swift */; };
 		C959DB812BD02460008F3627 /* NostrSDK in Frameworks */ = {isa = PBXBuildFile; productRef = C959DB802BD02460008F3627 /* NostrSDK */; };
@@ -838,6 +841,9 @@
 		C94D39212ABDDDFE0019C4D5 /* Secrets.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Secrets.xcconfig; sourceTree = "<group>"; };
 		C94D39242ABDDFB60019C4D5 /* EmptySecrets.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = EmptySecrets.xcconfig; sourceTree = "<group>"; };
 		C94D855B2991479900749478 /* NoteComposer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteComposer.swift; sourceTree = "<group>"; };
+		C95057A62CC692320024EC9C /* mute_list.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = mute_list.json; sourceTree = "<group>"; };
+		C95057B02CC6986E0024EC9C /* mute_list_2.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = mute_list_2.json; sourceTree = "<group>"; };
+		C95057C42CC69A770024EC9C /* mute_list_self.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = mute_list_self.json; sourceTree = "<group>"; };
 		C959DB752BD01DF4008F3627 /* GiftWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GiftWrapper.swift; sourceTree = "<group>"; };
 		C95D689E299E6B4100429F86 /* ProfileHeader.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProfileHeader.swift; sourceTree = "<group>"; };
 		C95D68A0299E6D3E00429F86 /* BioView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BioView.swift; sourceTree = "<group>"; };
@@ -1211,6 +1217,9 @@
 		03618AF72C82583D00BCBC55 /* Fixtures */ = {
 			isa = PBXGroup;
 			children = (
+				C95057C42CC69A770024EC9C /* mute_list_self.json */,
+				C95057B02CC6986E0024EC9C /* mute_list_2.json */,
+				C95057A62CC692320024EC9C /* mute_list.json */,
 				C9BD91882B61BBEF00FDA083 /* bad_contact_list.json */,
 				0350F1162C0A47B20024CC15 /* contact_list.json */,
 				039C96282C48321E00A8EB39 /* long_form_data.json */,
@@ -2214,6 +2223,7 @@
 				038196F72CA36797002A94E3 /* elmo-animated.webp in Resources */,
 				9DB106002C650DDE00F98A30 /* Colors.xcassets in Resources */,
 				C987F84329BA951E00B44E7A /* ClarityCity-Black.otf in Resources */,
+				C95057A72CC692360024EC9C /* mute_list.json in Resources */,
 				C9BD91892B61BBEF00FDA083 /* bad_contact_list.json in Resources */,
 				50F695072C6392C4000E4C74 /* zap_receipt.json in Resources */,
 				039C96292C48321E00A8EB39 /* long_form_data.json in Resources */,
@@ -2222,6 +2232,7 @@
 				C987F84729BA951E00B44E7A /* ClarityCity-Light.otf in Resources */,
 				C987F83929BA951E00B44E7A /* ClarityCity-MediumItalic.otf in Resources */,
 				C987F85129BA951E00B44E7A /* ClarityCity-ExtraLightItalic.otf in Resources */,
+				C95057B12CC698730024EC9C /* mute_list_2.json in Resources */,
 				C987F84D29BA951E00B44E7A /* ClarityCity-ThinItalic.otf in Resources */,
 				03B4E6A22C125CA1006E5F59 /* nostr_build_nip96_upload_response.json in Resources */,
 				0314CF742C9C7DD00001A53B /* youTube_fortnight_short.html in Resources */,
@@ -2240,6 +2251,7 @@
 				0373CE802C08DBC40027C856 /* old_contact_list.json in Resources */,
 				0350F10C2C0A46760024CC15 /* new_contact_list.json in Resources */,
 				3AEABEFF2B2BF858001BC933 /* Moderation.xcstrings in Resources */,
+				C95057C52CC69A7D0024EC9C /* mute_list_self.json in Resources */,
 				C9DEC006298947900078B43A /* sample_data.json in Resources */,
 				037071362C90D3F200BEAEC4 /* youtube_video_toxic.html in Resources */,
 				C94B2D182B17F5EC002104B6 /* sample_repost.json in Resources */,

--- a/Nos.xcodeproj/project.pbxproj
+++ b/Nos.xcodeproj/project.pbxproj
@@ -844,6 +844,7 @@
 		C95057A62CC692320024EC9C /* mute_list.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = mute_list.json; sourceTree = "<group>"; };
 		C95057B02CC6986E0024EC9C /* mute_list_2.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = mute_list_2.json; sourceTree = "<group>"; };
 		C95057C42CC69A770024EC9C /* mute_list_self.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = mute_list_self.json; sourceTree = "<group>"; };
+		C95057C62CC69FD70024EC9C /* Nos 19.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Nos 19.xcdatamodel"; sourceTree = "<group>"; };
 		C959DB752BD01DF4008F3627 /* GiftWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GiftWrapper.swift; sourceTree = "<group>"; };
 		C95D689E299E6B4100429F86 /* ProfileHeader.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProfileHeader.swift; sourceTree = "<group>"; };
 		C95D68A0299E6D3E00429F86 /* BioView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BioView.swift; sourceTree = "<group>"; };
@@ -3827,6 +3828,7 @@
 		C936B4572A4C7B7C00DF1EB9 /* Nos.xcdatamodeld */ = {
 			isa = XCVersionGroup;
 			children = (
+				C95057C62CC69FD70024EC9C /* Nos 19.xcdatamodel */,
 				C9BB9FE32CBEFF560045DC5A /* Nos 18.xcdatamodel */,
 				C9D2839E2CB9B177007ADCB9 /* Nos 17.xcdatamodel */,
 				033B288D2C419E7600E325E8 /* Nos 16.xcdatamodel */,
@@ -3838,7 +3840,7 @@
 				C9C547562A4F1D1A006B0741 /* Nos 9.xcdatamodel */,
 				5BFF66AF2A4B55FC00AA79DD /* Nos 10.xcdatamodel */,
 			);
-			currentVersion = C9BB9FE32CBEFF560045DC5A /* Nos 18.xcdatamodel */;
+			currentVersion = C95057C62CC69FD70024EC9C /* Nos 19.xcdatamodel */;
 			path = Nos.xcdatamodeld;
 			sourceTree = "<group>";
 			versionGroupType = wrapper.xcdatamodel;

--- a/Nos/Models/CoreData/Event+Hydration.swift
+++ b/Nos/Models/CoreData/Event+Hydration.swift
@@ -60,7 +60,7 @@ extension Event {
             hydrateMetaData(from: jsonEvent, author: newAuthor, context: context)
             
         case .mute:
-            hydrateMuteList(from: jsonEvent, context: context)
+            try hydrateMuteList(from: jsonEvent, context: context)
         case .repost:
             
             hydrateDefault(from: jsonEvent, context: context)
@@ -179,8 +179,8 @@ extension Event {
         }
     }
     
-    private func hydrateMuteList(from jsonEvent: JSONEvent, context: NSManagedObjectContext) {
-        let mutedKeys = jsonEvent.tags.map { $0[1] }
+    private func hydrateMuteList(from jsonEvent: JSONEvent, context: NSManagedObjectContext) throws {
+        let mutedKeys = Set(jsonEvent.tags.map { $0[1] })
         
         let request = Author.allAuthorsRequest(muted: true)
         
@@ -188,21 +188,22 @@ extension Event {
         if let authors = try? context.fetch(request) {
             for author in authors where !mutedKeys.contains(author.hexadecimalPublicKey!) {
                 author.muted = false
-                print("Parse-Un-Muted \(author.hexadecimalPublicKey ?? "")")
+                Log.info("Parse-Un-Muted \(author.hexadecimalPublicKey ?? "")")
             }
         }
         
         // Mute anyone (locally only) in the mutedKeys
         for key in mutedKeys {
-            if let author = try? Author.find(by: key, context: context) {
+            if let author = try? Author.findOrCreate(by: key, context: context) {
                 author.muted = true
-                print("Parse-Muted \(author.hexadecimalPublicKey ?? "")")
+                Log.info("Parse-Muted \(author.hexadecimalPublicKey ?? "")")
             }
         }
         
         // Force ensure current user never was muted
-        Task { @MainActor in
-            currentUser.author?.muted = false
+        if let signedInUserID = currentUser.publicKeyHex {
+            let currentUser = try Author.find(by: signedInUserID, context: context)
+            currentUser?.muted = false
         }
     }
 }

--- a/Nos/Models/CoreData/Event+Hydration.swift
+++ b/Nos/Models/CoreData/Event+Hydration.swift
@@ -180,6 +180,12 @@ extension Event {
     }
     
     private func hydrateMuteList(from jsonEvent: JSONEvent, context: NSManagedObjectContext) throws {
+        guard createdAt! > author?.lastUpdatedMuteList ?? Date.distantPast else {
+            return
+        }
+        
+        author?.lastUpdatedMuteList = Date(timeIntervalSince1970: TimeInterval(jsonEvent.createdAt))
+        
         let mutedKeys = Set(jsonEvent.tags.map { $0[1] })
         
         let request = Author.allAuthorsRequest(muted: true)

--- a/Nos/Models/CoreData/Generated/Author+CoreDataProperties.swift
+++ b/Nos/Models/CoreData/Generated/Author+CoreDataProperties.swift
@@ -11,6 +11,7 @@ extension Author {
     @NSManaged public var displayName: String?
     @NSManaged public var hexadecimalPublicKey: RawAuthorID?
     @NSManaged public var lastUpdatedContactList: Date?
+    @NSManaged public var lastUpdatedMuteList: Date?
     @NSManaged public var lastUpdatedMetadata: Date?
     @NSManaged public var muted: Bool
     @NSManaged public var name: String?

--- a/Nos/Models/CoreData/Nos.xcdatamodeld/Nos 19.xcdatamodel/.xccurrentversion
+++ b/Nos/Models/CoreData/Nos.xcdatamodeld/Nos 19.xcdatamodel/.xccurrentversion
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>_XCCurrentVersionName</key>
-	<string>Nos 19.xcdatamodel</string>
+	<string>Nos.xcdatamodel</string>
 </dict>
 </plist>

--- a/Nos/Models/CoreData/Nos.xcdatamodeld/Nos 19.xcdatamodel/Nos.xcdatamodel/contents
+++ b/Nos/Models/CoreData/Nos.xcdatamodeld/Nos 19.xcdatamodel/Nos.xcdatamodel/contents
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="21513" systemVersion="22D68" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+    <entity name="Author" representedClassName=".Author" syncable="YES" codeGenerationType="category">
+        <attribute name="about" optional="YES" attributeType="String"/>
+        <attribute name="displayName" optional="YES" attributeType="String"/>
+        <attribute name="hexadecimalPublicKey" attributeType="String"/>
+        <attribute name="lastUpdatedContactList" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="lastUpdatedMetadata" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="muted" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="name" optional="YES" attributeType="String"/>
+        <attribute name="nip05" optional="YES" attributeType="String"/>
+        <attribute name="profilePhotoURL" optional="YES" attributeType="URI"/>
+        <attribute name="rawMetadata" optional="YES" attributeType="Binary"/>
+        <relationship name="events" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Event" inverseName="author" inverseEntity="Event"/>
+        <relationship name="followers" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Follow" inverseName="destination" inverseEntity="Follow"/>
+        <relationship name="follows" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="Follow" inverseName="source" inverseEntity="Follow"/>
+        <relationship name="relays" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Relay"/>
+    </entity>
+    <entity name="AuthorReference" representedClassName="AuthorReference" syncable="YES" codeGenerationType="category">
+        <attribute name="pubkey" optional="YES" attributeType="String"/>
+        <attribute name="recommendedRelayUrl" optional="YES" attributeType="String"/>
+        <relationship name="event" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Event" inverseName="authorReferences" inverseEntity="Event"/>
+    </entity>
+    <entity name="Event" representedClassName=".Event" syncable="YES" codeGenerationType="category">
+        <attribute name="allTags" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromDataTransformerName"/>
+        <attribute name="content" optional="YES" attributeType="String"/>
+        <attribute name="createdAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="identifier" attributeType="String"/>
+        <attribute name="kind" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="sendAttempts" optional="YES" attributeType="Integer 16" usesScalarValueType="YES"/>
+        <attribute name="signature" optional="YES" attributeType="String"/>
+        <relationship name="author" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Author" inverseName="events" inverseEntity="Author"/>
+        <relationship name="authorReferences" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="AuthorReference" inverseName="event" inverseEntity="AuthorReference"/>
+        <relationship name="deletedOn" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Relay"/>
+        <relationship name="eventReferences" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="EventReference" inverseName="referencingEvent" inverseEntity="EventReference"/>
+        <relationship name="publishedTo" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Relay"/>
+        <relationship name="referencingEvents" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="EventReference" inverseName="referencedEvent" inverseEntity="EventReference"/>
+    </entity>
+    <entity name="EventReference" representedClassName="EventReference" syncable="YES" codeGenerationType="category">
+        <attribute name="eventId" optional="YES" attributeType="String"/>
+        <attribute name="marker" optional="YES" attributeType="String"/>
+        <attribute name="recommendedRelayUrl" optional="YES" attributeType="String"/>
+        <relationship name="referencedEvent" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Event" inverseName="referencingEvents" inverseEntity="Event"/>
+        <relationship name="referencingEvent" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Event" inverseName="eventReferences" inverseEntity="Event"/>
+    </entity>
+    <entity name="Follow" representedClassName=".Follow" syncable="YES" codeGenerationType="category">
+        <attribute name="lastUpdated" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="petName" optional="YES" attributeType="String"/>
+        <relationship name="destination" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Author" inverseName="followers" inverseEntity="Author"/>
+        <relationship name="source" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Author" inverseName="follows" inverseEntity="Author"/>
+    </entity>
+    <entity name="Relay" representedClassName=".Relay" syncable="YES" codeGenerationType="category">
+        <attribute name="address" attributeType="String"/>
+        <attribute name="createdAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+    </entity>
+</model>

--- a/Nos/Models/CoreData/Nos.xcdatamodeld/Nos 19.xcdatamodel/contents
+++ b/Nos/Models/CoreData/Nos.xcdatamodeld/Nos 19.xcdatamodel/contents
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="23231" systemVersion="24A335" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+    <entity name="Author" representedClassName=".Author" syncable="YES">
+        <attribute name="about" optional="YES" attributeType="String"/>
+        <attribute name="displayName" optional="YES" attributeType="String"/>
+        <attribute name="hexadecimalPublicKey" attributeType="String"/>
+        <attribute name="lastUpdatedContactList" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="lastUpdatedMetadata" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="lastUpdatedMuteList" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="muted" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="name" optional="YES" attributeType="String"/>
+        <attribute name="nip05" optional="YES" attributeType="String"/>
+        <attribute name="profilePhotoURL" optional="YES" attributeType="URI"/>
+        <attribute name="rawMetadata" optional="YES" attributeType="Binary"/>
+        <attribute name="website" optional="YES" attributeType="String"/>
+        <relationship name="events" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Event" inverseName="author" inverseEntity="Event"/>
+        <relationship name="followers" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Follow" inverseName="destination" inverseEntity="Follow"/>
+        <relationship name="followNotifications" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="NosNotification" inverseName="follower" inverseEntity="NosNotification"/>
+        <relationship name="follows" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="Follow" inverseName="source" inverseEntity="Follow"/>
+        <relationship name="incomingNotifications" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="NosNotification" inverseName="user" inverseEntity="NosNotification"/>
+        <relationship name="relays" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Relay" inverseName="authors" inverseEntity="Relay"/>
+        <uniquenessConstraints>
+            <uniquenessConstraint>
+                <constraint value="hexadecimalPublicKey"/>
+            </uniquenessConstraint>
+        </uniquenessConstraints>
+    </entity>
+    <entity name="AuthorReference" representedClassName="AuthorReference" syncable="YES">
+        <attribute name="pubkey" optional="YES" attributeType="String"/>
+        <attribute name="recommendedRelayUrl" optional="YES" attributeType="String"/>
+        <relationship name="event" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Event" inverseName="authorReferences" inverseEntity="Event"/>
+    </entity>
+    <entity name="Event" representedClassName=".Event" syncable="YES">
+        <attribute name="allTags" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromDataTransformerName"/>
+        <attribute name="content" optional="YES" attributeType="String"/>
+        <attribute name="createdAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="expirationDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="identifier" optional="YES" attributeType="String"/>
+        <attribute name="isRead" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="isVerified" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="kind" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="receivedAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="replaceableIdentifier" optional="YES" attributeType="String"/>
+        <attribute name="sendAttempts" optional="YES" attributeType="Integer 16" usesScalarValueType="YES"/>
+        <attribute name="signature" optional="YES" attributeType="String"/>
+        <relationship name="author" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Author" inverseName="events" inverseEntity="Author"/>
+        <relationship name="authorReferences" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="AuthorReference" inverseName="event" inverseEntity="AuthorReference"/>
+        <relationship name="deletedOn" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Relay" inverseName="deletedEvents" inverseEntity="Relay"/>
+        <relationship name="eventReferences" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="EventReference" inverseName="referencingEvent" inverseEntity="EventReference"/>
+        <relationship name="publishedTo" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Relay" inverseName="publishedEvents" inverseEntity="Relay"/>
+        <relationship name="referencingEvents" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="EventReference" inverseName="referencedEvent" inverseEntity="EventReference"/>
+        <relationship name="seenOnRelays" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Relay" inverseName="events" inverseEntity="Relay"/>
+        <relationship name="shouldBePublishedTo" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Relay" inverseName="shouldBePublishedEvents" inverseEntity="Relay"/>
+        <uniquenessConstraints>
+            <uniquenessConstraint>
+                <constraint value="identifier"/>
+            </uniquenessConstraint>
+        </uniquenessConstraints>
+    </entity>
+    <entity name="EventReference" representedClassName="EventReference" syncable="YES">
+        <attribute name="eventId" optional="YES" attributeType="String"/>
+        <attribute name="marker" optional="YES" attributeType="String"/>
+        <attribute name="recommendedRelayUrl" optional="YES" attributeType="String"/>
+        <relationship name="referencedEvent" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Event" inverseName="referencingEvents" inverseEntity="Event"/>
+        <relationship name="referencingEvent" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Event" inverseName="eventReferences" inverseEntity="Event"/>
+    </entity>
+    <entity name="Follow" representedClassName=".Follow" syncable="YES">
+        <attribute name="petName" optional="YES" attributeType="String"/>
+        <relationship name="destination" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Author" inverseName="followers" inverseEntity="Author"/>
+        <relationship name="source" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Author" inverseName="follows" inverseEntity="Author"/>
+    </entity>
+    <entity name="NosNotification" representedClassName="NosNotification" syncable="YES">
+        <attribute name="createdAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="eventID" optional="YES" attributeType="String"/>
+        <attribute name="isRead" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <relationship name="follower" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Author" inverseName="followNotifications" inverseEntity="Author"/>
+        <relationship name="user" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Author" inverseName="incomingNotifications" inverseEntity="Author"/>
+        <uniquenessConstraints>
+            <uniquenessConstraint>
+                <constraint value="eventID"/>
+            </uniquenessConstraint>
+        </uniquenessConstraints>
+    </entity>
+    <entity name="Relay" representedClassName=".Relay" syncable="YES">
+        <attribute name="address" attributeType="String"/>
+        <attribute name="contact" optional="YES" attributeType="String"/>
+        <attribute name="createdAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="metadataFetchedAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="name" optional="YES" attributeType="String"/>
+        <attribute name="pubkey" optional="YES" attributeType="String"/>
+        <attribute name="relayDescription" optional="YES" attributeType="String"/>
+        <attribute name="software" optional="YES" attributeType="String"/>
+        <attribute name="supportedNIPs" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromDataTransformer"/>
+        <attribute name="version" optional="YES" attributeType="String"/>
+        <relationship name="authors" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Author" inverseName="relays" inverseEntity="Author"/>
+        <relationship name="deletedEvents" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Event" inverseName="deletedOn" inverseEntity="Event"/>
+        <relationship name="events" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Event" inverseName="seenOnRelays" inverseEntity="Event"/>
+        <relationship name="publishedEvents" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Event" inverseName="publishedTo" inverseEntity="Event"/>
+        <relationship name="shouldBePublishedEvents" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Event" inverseName="shouldBePublishedTo" inverseEntity="Event"/>
+    </entity>
+</model>

--- a/Nos/Service/DatabaseCleaner.swift
+++ b/Nos/Service/DatabaseCleaner.swift
@@ -62,7 +62,7 @@ enum DatabaseCleaner {
                     Event.previewRequest(),
                     EventReference.orphanedRequest(),
                     AuthorReference.orphanedRequest(),
-                    Author.outOfNetwork(for: currentUser),
+                    Author.orphaned(for: currentUser),
                     Follow.orphanedRequest(),
                     Relay.orphanedRequest(),
                     NosNotification.oldNotificationsRequest(),

--- a/NosTests/IntegrationTests/EventProcessorIntegrationTests.swift
+++ b/NosTests/IntegrationTests/EventProcessorIntegrationTests.swift
@@ -330,7 +330,7 @@ class EventProcessorIntegrationTests: CoreDataTestCase {
         // The third user should not be muted because they are not muted in the newer list.
         XCTAssertEqual(try Author.find(by: mutedUserOne, context: testContext)?.muted, true)
         XCTAssertEqual(try Author.find(by: mutedUserTwo, context: testContext)?.muted, true)
-        XCTAssertEqual(try Author.find(by: mutedUserThree, context: testContext)?.muted, false)
+        XCTAssertEqual(try Author.find(by: mutedUserThree, context: testContext)?.muted, nil)
     }
     
     @MainActor func test_parseMuteList_unMutesSelf() async throws {

--- a/NosTests/IntegrationTests/EventProcessorIntegrationTests.swift
+++ b/NosTests/IntegrationTests/EventProcessorIntegrationTests.swift
@@ -333,7 +333,7 @@ class EventProcessorIntegrationTests: CoreDataTestCase {
         XCTAssertEqual(try Author.find(by: mutedUserThree, context: testContext)?.muted, nil)
     }
     
-    @MainActor func test_parseMuteList_unMutesSelf() async throws {
+    @MainActor func test_parseMuteList_unmutesSelf() async throws {
         // Arrange
         let keyPair = KeyPair(nsec: "nsec17vdaesh5tp6u5dy74vdy7a7e5x5ww4wfdnrn6ewgnsfxav8pcurqnlmj88")
         @Dependency(\.currentUser) var currentUser

--- a/NosTests/IntegrationTests/Fixtures/mute_list.json
+++ b/NosTests/IntegrationTests/Fixtures/mute_list.json
@@ -1,0 +1,22 @@
+{
+    "kind": 10000,
+    "id": "f1171a8ef1983fb1d55089092da5e7bbcb204bf9219697a3cf08d8e53ddbcec5",
+    "pubkey": "ffd99f9e545b53e3291dab4b8cd6d25d12b9973c40f02e1938c0891d62e38e57",
+    "created_at": 1729518241,
+    "tags": [
+        [
+            "p",
+            "756bcacddd4fd7051cde3e39464cdd3557fec416ab1f496e2e91da0534b14272"
+        ],
+        [
+            "p",
+            "d0a1ffb8761b974cec4a3be8cbcb2e96a7090dcf465ffeac839aa4ca20c9a59e"
+        ],
+        [
+            "p",
+            "27cf2c68535ae1fc06510e827670053f5dcd39e6bd7e05f1ffb487ef2ac13549"
+        ]
+    ],
+    "content": "",
+    "sig": "907b4365e5aa5d54358ae7a741e7a6acc0162f91c6210fad44c9c1e87a79a9b5a3a96d97c1178e60a60b7d0ad8d60023b90e6c913b9f1d972dbe813fbe901bd6"
+}

--- a/NosTests/IntegrationTests/Fixtures/mute_list_2.json
+++ b/NosTests/IntegrationTests/Fixtures/mute_list_2.json
@@ -1,0 +1,18 @@
+{
+    "kind": 10000,
+    "id": "c54f0aef32400e566355f88af29dc9ad7c7fcad46ca4488013eec1260254bafe",
+    "pubkey": "ffd99f9e545b53e3291dab4b8cd6d25d12b9973c40f02e1938c0891d62e38e57",
+    "created_at": 1729519829,
+    "tags": [
+        [
+            "p",
+            "756bcacddd4fd7051cde3e39464cdd3557fec416ab1f496e2e91da0534b14272"
+        ],
+        [
+            "p",
+            "d0a1ffb8761b974cec4a3be8cbcb2e96a7090dcf465ffeac839aa4ca20c9a59e"
+        ]
+    ],
+    "content": "",
+    "sig": "0c55ce1abd8df9b93c0978c31170d9cc134fc89e971f76112d7686ed3134b6a80de112b90f35e75e1e5a935c0aaf1fcbb575aed7bb35ffe086858522a41c6d96"
+}

--- a/NosTests/IntegrationTests/Fixtures/mute_list_self.json
+++ b/NosTests/IntegrationTests/Fixtures/mute_list_self.json
@@ -1,0 +1,14 @@
+{
+    "kind": 10000,
+    "id": "e6c75757729b1e00e9d71a4187c3291e63f98d25972c5179a50f9f8f162cbf64",
+    "pubkey": "ffd99f9e545b53e3291dab4b8cd6d25d12b9973c40f02e1938c0891d62e38e57",
+    "created_at": 1729520332,
+    "tags": [
+        [
+            "p",
+            "ffd99f9e545b53e3291dab4b8cd6d25d12b9973c40f02e1938c0891d62e38e57"
+        ]
+    ],
+    "content": "",
+    "sig": "da7a71bb5dc9fd9e7cb6353ca43e97117a71e67b9ab94635b1a43cf5a1de83b586dd6d2e78d5b03e2e90fb032bb7c23eb9b643a9820b5e18fc5c0c5f654b09da"
+}

--- a/NosTests/Models/CoreData/AuthorTests.swift
+++ b/NosTests/Models/CoreData/AuthorTests.swift
@@ -229,7 +229,7 @@ final class AuthorTests: CoreDataTestCase {
         XCTAssertEqual(events.count, 0)
     }
     
-    @MainActor func test_outOfNetwork_givenCircleOfFollows() throws {
+    @MainActor func test_orphaned_givenCircleOfFollows() throws {
         // Arrange
         let alice = try Author.findOrCreate(by: "alice", context: testContext)
         let bob   = try Author.findOrCreate(by: "bob", context: testContext)
@@ -246,9 +246,26 @@ final class AuthorTests: CoreDataTestCase {
         try testContext.saveIfNeeded()
         
         // Act 
-        let authors = try testContext.fetch(Author.outOfNetwork(for: alice))
+        let authors = try testContext.fetch(Author.orphaned(for: alice))
         
         // Assert
         XCTAssertEqual(authors, [eve])
+    }
+    
+    @MainActor func test_orphaned_givenNoFollows() throws {
+        // Arrange
+        let alice = try Author.findOrCreate(by: "alice", context: testContext)
+        let bob   = try Author.findOrCreate(by: "bob", context: testContext)
+        let carl  = try Author.findOrCreate(by: "carl", context: testContext)
+        let eve   = try Author.findOrCreate(by: "eve", context: testContext)
+        
+        // Act
+        try testContext.saveIfNeeded()
+        
+        // Act 
+        let authors = try testContext.fetch(Author.orphaned(for: alice))
+        
+        // Assert
+        XCTAssertEqual(authors, [eve, carl, bob])
     }
 }

--- a/NosTests/Service/DatabaseCleanerTests.swift
+++ b/NosTests/Service/DatabaseCleanerTests.swift
@@ -274,7 +274,7 @@ final class DatabaseCleanerTests: CoreDataTestCase {
         
         // Assert
         let authors = try testContext.fetch(Author.allAuthorsRequest())
-        // Bob should be kept around since 
+        // Bob should be kept around because he has published events that weren't deleted.
         XCTAssertEqual(authors, [bob, alice]) 
         
         // Sanity check that Bob's event was kept

--- a/NosTests/Service/DatabaseCleanerTests.swift
+++ b/NosTests/Service/DatabaseCleanerTests.swift
@@ -202,6 +202,87 @@ final class DatabaseCleanerTests: CoreDataTestCase {
         XCTAssertEqual(authors, [carl, bob, alice])
     }
     
+    @MainActor func test_cleanup_erasesAuthorsWithoutFollows() async throws {
+        // Arrange
+        let alice = try Author.findOrCreate(by: KeyFixture.alice.publicKeyHex, context: testContext)
+        _ = try Author.findOrCreate(by: "bob", context: testContext)
+        _ = try Author.findOrCreate(by: "carl", context: testContext)
+        _ = try Author.findOrCreate(by: "eve", context: testContext)
+        
+        // Act
+        try testContext.saveIfNeeded()
+        
+        // Act 
+        try await DatabaseCleaner.cleanupEntities(
+            for: KeyFixture.alice.publicKeyHex, 
+            in: testContext
+        )
+        
+        // Assert
+        let authors = try testContext.fetch(Author.allAuthorsRequest())
+        // Eve and bob are muted and should be saved even though bob is out of network
+        XCTAssertEqual(authors, [alice])
+    }
+    
+    @MainActor func test_cleanup_keepsMutedAuthors() async throws {
+        // Arrange
+        let alice = try Author.findOrCreate(by: KeyFixture.alice.publicKeyHex, context: testContext)
+        let bob   = try Author.findOrCreate(by: "bob", context: testContext)
+        _ = try Author.findOrCreate(by: "carl", context: testContext)
+        let eve   = try Author.findOrCreate(by: "eve", context: testContext)
+        
+        // Act
+        _ = try Follow.findOrCreate(source: alice, destination: bob, context: testContext)
+        bob.muted = true
+        eve.muted = true
+        
+        try testContext.saveIfNeeded()
+        
+        // Act 
+        try await DatabaseCleaner.cleanupEntities(
+            for: KeyFixture.alice.publicKeyHex, 
+            in: testContext
+        )
+        
+        // Assert
+        let authors = try testContext.fetch(Author.allAuthorsRequest())
+        // Eve and bob are muted and should be saved even though bob is out of network
+        XCTAssertEqual(authors, [eve, bob, alice])
+    }
+    
+    @MainActor func test_cleanup_keepsAuthorsWithEvents() async throws {
+        // Arrange
+        let alice = try Author.findOrCreate(by: KeyFixture.alice.publicKeyHex, context: testContext)
+        let bob   = try Author.findOrCreate(by: KeyFixture.bob.publicKeyHex, context: testContext)
+        
+        // Act
+        // Create an event by an out of network author
+        let event = try EventFixture.build(
+            in: testContext, 
+            publicKey: KeyFixture.bob.publicKeyHex, 
+            receivedAt: Date(timeIntervalSince1970: 11)
+        )
+        
+        try testContext.saveIfNeeded()
+        
+        // Act 
+        try await DatabaseCleaner.cleanupEntities(
+            for: KeyFixture.alice.publicKeyHex, 
+            in: testContext,
+            keeping: 1
+        )
+        
+        // Assert
+        let authors = try testContext.fetch(Author.allAuthorsRequest())
+        // Bob should be kept around since 
+        XCTAssertEqual(authors, [bob, alice]) 
+        
+        // Sanity check that Bob's event was kept
+        let events = try testContext.fetch(Event.allEventsRequest())
+        XCTAssertEqual(events.count, 1)
+        XCTAssertEqual(events.first?.identifier, event.identifier)
+    }
+    
     // MARK: - Follows
     
     @MainActor func test_cleanup_keepsInNetworkFollows() async throws {


### PR DESCRIPTION
## Issues covered
https://github.com/planetary-social/nos/issues/1154

## Description
To start off this ticket I decided to write some unit tests for mute list parsing, because we've had reports of them not working properly. Sure enough, I found two bugs. One was that if we received an old mute list (like from a relay that the user stopped using at some point) then we would process it and overwrite the newer one. The other bug I will describe in a comment below.

## How to test
There aren't really any functional changes to test and we never had steps to reproduce these bugs with the mute list being overwritten. So I think the best way to test is to read through the unit tests and verify that they are correct and complete.