### PR TITLE
Enable new onboarding feature flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a tip to Discover to prompt first-time users to go to their Feed. [#1601](https://github.com/planetary-social/nos/issues/1601)
 - Added a tip to the Feed to welcome first-time users and explain how the Feed works. [#1602](https://github.com/planetary-social/nos/issues/1602)
 - Added a tag to published contact lists to help us detect the source of lost contact lists. [cleanstr#51](https://github.com/planetary-social/cleanstr/issues/51)
+- Updated the onboarding screens with a new design.
 - Removed integration with Universal Name Space [#1636](https://github.com/planetary-social/nos/issues/1636)
 - Remove most usage of xcstringstool-generated strings to improve performance. [#1458](https://github.com/planetary-social/nos/issues/1458)
 

--- a/Nos/Service/FeatureFlags.swift
+++ b/Nos/Service/FeatureFlags.swift
@@ -31,7 +31,7 @@ protocol FeatureFlags {
 
     /// Feature flags and their values.
     private var featureFlags: [FeatureFlag: Bool] = [
-        .newOnboardingFlow: false
+        .newOnboardingFlow: true
     ]
 
     /// Returns true if the feature is enabled.


### PR DESCRIPTION
## Issues covered
None, or all the onboarding ones. (I opened #1673 -Matt)

## Description
Enables the new onboarding feature flag by default. This means it'll be always enabled for production, and enabled by default (and still toggleable) for staging and dev. This seemed safer to me than deleting the flag entirely since I rushed through implementing the screens and not all of them have made it through UAT yet.

## How to test
1. Log out
2. Delete the app
3. Reinstall
4. Start onboarding
5. Ensure you get the new screens, like the new age verification, the Create Account screen with 4 steps, etc.
