### PR TITLE
Fix blank author cards on the Discover tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added new authors and categories to the Discover tab. [#1592](https://github.com/planetary-social/nos/issues/1592)
 
 ### Internal Changes
+- Added code to hide users on the Discover tab with no profile metadata. [#1592](https://github.com/planetary-social/nos/issues/1592)
 - Migrate ObservableObject to @Observable where possible [#1458](https://github.com/planetary-social/nos/issues/1458)
 - Added the Create Account onboarding screen. Currently behind the “New Onboarding Flow” feature flag. [#1594](https://github.com/planetary-social/nos/issues/1594)
 - Increase build settings timeout in fastlane. [#1662](https://github.com/planetary-social/nos/pull/1662)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Release Notes
+- Added relay.mostr.pub to the default relay list. [#1592](https://github.com/planetary-social/nos/issues/1592)
 - Fix two bugs that could result in muted users being unmuted. [#1674](https://github.com/planetary-social/nos/pull/1674)
 - Added a tip to Discover to prompt first-time users to go to their Feed. [#1601](https://github.com/planetary-social/nos/issues/1601)
 - Added a tip to the Feed to welcome first-time users and explain how the Feed works. [#1602](https://github.com/planetary-social/nos/issues/1602)

--- a/Nos/Models/CoreData/Relay+CoreDataClass.swift
+++ b/Nos/Models/CoreData/Relay+CoreDataClass.swift
@@ -16,6 +16,7 @@ public class Relay: NosManagedObject {
         "wss://relay.damus.io",
         "wss://purplepag.es",
         "wss://nos.lol",
+        "wss://relay.mostr.pub",
         ]
     }
     

--- a/Nos/Views/Discover/DiscoverContentsView.swift
+++ b/Nos/Views/Discover/DiscoverContentsView.swift
@@ -84,12 +84,16 @@ struct DiscoverContentsView: View {
                     
                     ForEach(featuredAuthorIDs) { authorID in
                         AuthorObservationView(authorID: authorID) { author in
-                            AuthorCard(author: author) {
-                                router.push(author)
+                            VStack {
+                                if author.lastUpdatedMetadata != nil {
+                                    AuthorCard(author: author) {
+                                        router.push(author)
+                                    }
+                                    .padding(.horizontal, 13)
+                                    .padding(.top, 5)
+                                    .readabilityPadding()
+                                }
                             }
-                            .padding(.horizontal, 13)
-                            .padding(.top, 5)
-                            .readabilityPadding()
                             .task {
                                 subscriptions[author.id] =
                                 await relayService.requestMetadata(


### PR DESCRIPTION
## Issues covered
Part of #1592

## Description
We have added some authors to the Discover tab whose profile metadata doesn't exist on any of the relays in our default list. To work around this for launch this PR does two things:
- Adds relay.mostr.pub to the default relay list, so we can load profile metadata for some of the ActivityPub users.
- Hides AuthorCards on the Discover screen until we have metadata for them.

## How to test
1. Do a fresh install of Nos
2. Go through onboarding
3. Look through the Discover tab for users with no display name. You shouldn't find any.

## Screenshots/Video

| Before | After |
|--------|--------|
|![simulator_screenshot_73CA6F6D-4903-4D27-9B0F-FDA2A139A1AC](https://github.com/user-attachments/assets/b4b24ce6-253c-4003-9aff-7fe34cc91656) |![Simulator Screenshot - iPhone 16 for real - 2024-10-21 at 15 39 48](https://github.com/user-attachments/assets/4ce11d6a-6c5e-46de-a8a7-6cafd9b34ea0)|

