### PR TITLE
minor strings simplifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Release Notes
+
+### Internal Changes
+- minor strings simplifications
+
 ## [1.0.1] - 2024-10-28Z
 
 ### Release Notes

--- a/Nos/Views/Home/HomeFeedView.swift
+++ b/Nos/Views/Home/HomeFeedView.swift
@@ -145,7 +145,7 @@ struct HomeFeedView: View {
                 } label: {
                     Image(systemName: "line.3.horizontal.decrease.circle")
                         .foregroundStyle(Color.secondaryTxt)
-                        .accessibilityLabel(Text("filter"))
+                        .accessibilityLabel("filter")
                 }
                 .frame(minWidth: 40, minHeight: 40)
             }

--- a/Nos/Views/NoteComposer/ComposerActionBar.swift
+++ b/Nos/Views/NoteComposer/ComposerActionBar.swift
@@ -119,7 +119,7 @@ struct ComposerActionBar: View {
                 .frame(minWidth: 44, minHeight: 44)
         }
         .padding(.leading, 8)
-        .accessibilityLabel(Text("attachMedia"))
+        .accessibilityLabel("attachMedia")
     }
 
     /// Expiration Time
@@ -135,7 +135,7 @@ struct ComposerActionBar: View {
                         self.expirationTime = $0 ? option.timeInterval : nil
                     })
                 )
-                .accessibilityLabel(Text("expirationDate"))
+                .accessibilityLabel("expirationDate")
                 .padding(12)
             } else {
                 Button {

--- a/Nos/Views/NoteComposer/NoteComposer.swift
+++ b/Nos/Views/NoteComposer/NoteComposer.swift
@@ -191,7 +191,7 @@ struct NoteComposer: View {
                 }
             }
             .background(Color.appBg)
-            .navigationBarTitle(String(localized: "newNote"), displayMode: .inline)
+            .navigationBarTitle("newNote", displayMode: .inline)
             .toolbarBackground(.visible, for: .navigationBar)
             .toolbarBackground(Color.cardBgBottom, for: .navigationBar)
             .toolbar {

--- a/Nos/Views/Onboarding/OnboardingLoginView.swift
+++ b/Nos/Views/Onboarding/OnboardingLoginView.swift
@@ -34,7 +34,7 @@ struct OnboardingLoginView: View {
         VStack {
             Form {
                 Section {
-                    SecureField(String(localized: "privateKeyPlaceholder"), text: $privateKeyString)
+                    SecureField("privateKeyPlaceholder", text: $privateKeyString)
                         .foregroundColor(.primaryTxt)
                 } header: {
                     Text("pasteYourSecretKey")

--- a/Nos/Views/Settings/DeleteConfirmationView.swift
+++ b/Nos/Views/Settings/DeleteConfirmationView.swift
@@ -50,13 +50,13 @@ struct DeleteConfirmationView: View {
     /// Creates the title and message view for the delete confirmation.
     private func titleMessageView() -> some View {
         VStack(spacing: 0) {
-            Text(String(localized: "deleteAccount"))
+            Text("deleteAccount")
                 .font(.headline)
                 .fontWeight(.bold)
                 .padding(.bottom, 10)
                 .padding(.top, 18)
 
-            Text(String(localized: "deleteAccountMessage"))
+            Text("deleteAccountMessage")
                 .font(.footnote)
                 .fixedSize(horizontal: false, vertical: true)
                 .multilineTextAlignment(.center)
@@ -101,7 +101,7 @@ struct DeleteConfirmationView: View {
         onCancel: @escaping () -> Void
     ) -> some View {
         HStack {
-            Button(String(localized: "cancel")) {
+            Button("cancel") {
                 onCancel()
             }
             .frame(maxWidth: .infinity)
@@ -111,7 +111,7 @@ struct DeleteConfirmationView: View {
                 .frame(width: 1, height: 50)
                 .background(Color.actionSheetDivider)
 
-            Button(String(localized: "delete")) {
+            Button("delete") {
                 onDelete()
             }
             .frame(maxWidth: .infinity)

--- a/Nos/Views/Settings/SettingsView.swift
+++ b/Nos/Views/Settings/SettingsView.swift
@@ -44,7 +44,7 @@ struct SettingsView: View {
                         .foregroundColor(.primaryTxt)
                         .font(.clarity(.regular, textStyle: .body))
                         .lineLimit(1)
-                        .accessibilityLabel(Text("privateKey"))
+                        .accessibilityLabel("privateKey")
 
                     Spacer()
 


### PR DESCRIPTION
## Issues covered
No GitHub issue.

## Description
Simplifies our localized string usage in a few places.

`.accessibilityLabel(Text("stringKeyHere"))` -> `.accessibilityLabel("stringKeyHere")`

Similar changes for `SecureField`, `Button`, `.navigationBarTitle`.

No visible changes to the user, but here is a screenshot showing that the accessibility label is still the localized string and not the key itself:
<img width="800" alt="Cursor" src="https://github.com/user-attachments/assets/e37884bc-1169-433c-9e4b-91f682e3a92f">

