### PR TITLE
fix crash when tapping Post button on macOS #1687

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Release Notes
+- Fix crash when tapping Post button on macOS. [#1687](https://github.com/planetary-social/nos/issues/1687)
+
+### Internal Changes
+
 ## [1.0.1] - 2024-10-28Z
 
 ### Release Notes

--- a/Nos/Views/AppView.swift
+++ b/Nos/Views/AppView.swift
@@ -13,6 +13,7 @@ struct AppView: View {
     @Dependency(\.crashReporting) private var crashReporting
     @Dependency(\.userDefaults) private var userDefaults
     @Environment(CurrentUser.self) var currentUser
+    @Environment(RelayService.self) private var relayService
 
     @State private var lastSelectedTab = AppDestination.home
     @State private var showNIP05Wizard = false
@@ -163,6 +164,7 @@ struct AppView: View {
         .sheet(isPresented: $showNewPost) {
             NoteComposer(initialContents: newPostContents, isPresented: $showNewPost)
                 .environment(currentUser)
+                .environment(relayService)
                 .interactiveDismissDisabled()
         }
     }


### PR DESCRIPTION
## Issues covered
$1687

## Description
The app crashed on macOS when tapping the Post button.

## How to test
1. Launch app on macOS
2. Tap Post button.
App crashes here.

## Screenshots/Video
No crash now:
![no-mac-crash](https://github.com/user-attachments/assets/a4ed8728-7639-4caa-ba10-7e72e431d2cb)

