### PR TITLE
Fix follower notification tap should open Follower's profile.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Release Notes
 - Fix typo in minimum age warning
 - Fix crash when tapping Post button on macOS. [#1687](https://github.com/planetary-social/nos/issues/1687)
+- Fix tapping follower notification not opening follower profile. [#11](https://github.com/verse-pbc/issues/issues/11)
 
 ### Internal Changes
 

--- a/Nos/Service/PushNotificationService.swift
+++ b/Nos/Service/PushNotificationService.swift
@@ -211,7 +211,6 @@ import Combine
                     let firstPubkey = followPubkeys.first,
                     let publicKey = PublicKey.build(npubOrHex: firstPubkey) {
                     Task { @MainActor in
-                        self.router.selectedTab = .notifications
                         self.router.pushAuthor(id: publicKey.hex)
                     }
                 }


### PR DESCRIPTION
## Issues covered
[#11](https://github.com/verse-pbc/issues/issues/11)

## Description
Since we do not show the follower's notification on the notification's tab, I removed the router selecting tab and just routed to the follower's profile directly.

## How to test
1. Please follow these [steps](https://www.notion.so/nossocial/How-to-Test-Push-Notifications-in-Nos-884955ce3fc74e548505c783e9102c7c) to send a push notification.
2. Send a new follower push notification. [This](https://icloud.developer.apple.com/dashboard/notifications/teams/GZCZBKH7MY/app/com.verse.Nos-dev/notifications/f5484d45-fc9f-4c19-ae5b-7bf8dca610e2/environment/DEVELOPMENT/tracking/500ae1d0-5b38-d3c2-bdda-07c10087c9e0) can be used, please don't forget to change the device token.
3. Please confirm that tapping the notification alert opens the user's profile page.

## Screenshots/Video
Before:

https://github.com/user-attachments/assets/dcac76b7-9bf1-4969-aded-56300da05eda


After:

https://github.com/user-attachments/assets/c20ddea8-2cab-45a3-9983-50c4b0e53333


