### PR TITLE
Fix quoted note composer does not expand to fit mention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix typo in minimum age warning
 - Fix crash when tapping Post button on macOS. [#1687](https://github.com/planetary-social/nos/issues/1687)
 - Fix tapping follower notification not opening follower profile. [#11](https://github.com/verse-pbc/issues/issues/11)
+- Fix quoted note composer does not expand to fit mention. [#25](https://github.com/verse-pbc/issues/issues/25)
 
 ### Internal Changes
 

--- a/Nos/Controller/NoteEditorController.swift
+++ b/Nos/Controller/NoteEditorController.swift
@@ -198,6 +198,9 @@ import UIKit
         textView.attributedText = attributedString
         textView.selectedRange.location = range.location + link.length
         isEmpty = false
+
+        // Update the textview height after inserting text
+        updateIntrinsicHeight(view: textView)
     }
     
     /// Takes the same arguments as `textView(_:shouldChangeTextIn:replacementText:)` and detects the case where the 


### PR DESCRIPTION
## Issues covered
[#25](https://github.com/verse-pbc/issues/issues/25)

## Description
The `textview` height was not being updated when we insert a text in the `textview` (which is what we do when we include a mention in the note composer) instead of actually typing in the `textview`. I just called the `updateIntrinsicHeight` function in the insert text function.

## How to test
1. Find a note on the feed.
2. Click the repost button in the note action bar.
3. Select the quote option from the list of options.
4. Try to type something long and then mention someone towards the end of the note composer.
5. Please check that the mentioned name is visible as the note composer updates its new height.

## Screenshots/Video
Before:

https://planetary-app.slack.com/archives/CM4EPK324/p1728253623123829

After:


https://github.com/user-attachments/assets/574b90a6-3416-4d22-9be0-76e837a9a2e0


