### PR TITLE
fixed crash related to tracking delete events #96

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Release Notes
 - Fixed display of mastodon usernames so it shows @username@server.instance rather than username@instance-name.mostr.pub
 - Nos now publishes the hashtags it finds in your note when you post. This means it works the way you’ve always expected it to work. [#44](https://github.com/verse-pbc/issues/issues/44)
+- Fixed crash related to tracking delete events. [#96](https://github.com/verse-pbc/issues/issues/96)
 
 ### Internal Changes
 - Upgraded to Xcode 16. [#1570](https://github.com/planetary-social/nos/issues/1570)

--- a/Nos/Models/CoreData/Event+CoreDataClass.swift
+++ b/Nos/Models/CoreData/Event+CoreDataClass.swift
@@ -492,13 +492,18 @@ public class Event: NosManagedObject, VerifiableEvent {
 
     /// This tracks which relays this event is deleted on. Hide posts with deletedOn.count > 0
     func trackDelete(on relay: Relay, context: NSManagedObjectContext) throws {
-        if EventKind(rawValue: kind) == .delete, let eTags = allTags as? [[String]] {
-            for deletedEventId in eTags.map({ $0[1] }) {
-                if let deletedEvent = Event.find(by: deletedEventId, context: context),
-                    deletedEvent.author?.hexadecimalPublicKey == author?.hexadecimalPublicKey {
-                    print("\(deletedEvent.identifier ?? "n/a") was deleted on \(relay.address ?? "unknown")")
-                    deletedEvent.deletedOn.insert(relay)
-                }
+        guard EventKind(rawValue: kind) == .delete,
+            let tags = allTags as? [[String]] else {
+            return
+        }
+        
+        let eTags = tags.filter { $0.first == "e" && $0.count >= 2 }
+        
+        for deletedEventId in eTags.map({ $0[1] }) {
+            if let deletedEvent = Event.find(by: deletedEventId, context: context),
+                deletedEvent.author?.hexadecimalPublicKey == author?.hexadecimalPublicKey {
+                print("\(deletedEvent.identifier ?? "n/a") was deleted on \(relay.address ?? "unknown")")
+                deletedEvent.deletedOn.insert(relay)
             }
         }
     }


### PR DESCRIPTION
## Issues covered
https://github.com/verse-pbc/issues/issues/96

## Description
The issue was an unprotected direct array access and unexpected tags in an event. Direct array access must _always_ be preceded by a count check on the array or by using a "safe" function that does that internally.

## How to test
1. Navigate to main feed
2. Scroll around for a while until receiving a delete event with tags other than "e" tags in it
