### PR TITLE
Allow Github actions to update provisioning profiles

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -50,7 +50,7 @@ platform :ios do
       )
       match(
           type: "appstore",  
-          readonly: true,
+          readonly: false,
           app_identifier: options[:appidentifier],
           keychain_name: "keychain",
           keychain_password: keychain_pass


### PR DESCRIPTION
## Issues covered
#97

## Description
This gets the automatic deployment to TestFlight working again. I targeted feature/lists-ui, which means that only that branch will get deployed to TestFlight until it is merged to `main`. That sounds kind of conventient to me, but feel free to change the destination branch if you want @bryanmontz. And feel free to merge whenever.

## How to test
[Here's my test of the workflow](https://github.com/planetary-social/nos/actions/runs/12473446885)