### PR TITLE
Update relays that are added on signup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed display of mastodon usernames so it shows @username@server.instance rather than username@instance-name.mostr.pub
 - Nos now publishes the hashtags it finds in your note when you post. This means it works the way you’ve always expected it to work. [#44](https://github.com/verse-pbc/issues/issues/44)
 - Fixed crash related to tracking delete events. [#96](https://github.com/verse-pbc/issues/issues/96)
+- Updated the default relays that are added when you create an account. [#17](https://github.com/verse-pbc/issues/issues/17)
 
 ### Internal Changes
 - Upgraded to Xcode 16. [#1570](https://github.com/planetary-social/nos/issues/1570)

--- a/Nos/Models/CoreData/Relay+CoreDataClass.swift
+++ b/Nos/Models/CoreData/Relay+CoreDataClass.swift
@@ -13,9 +13,7 @@ public class Relay: NosManagedObject {
     static var recommended: [String] {
         [
         nosAddress.absoluteString,
-        "wss://relay.damus.io",
-        "wss://purplepag.es",
-        "wss://nos.lol",
+        "wss://news.nos.social",
         "wss://relay.mostr.pub",
         ]
     }


### PR DESCRIPTION
## Issues covered
https://github.com/verse-pbc/issues/issues/17

## Description
Adds just three relays on signup instead of the five we used to have.

## How to test
1. Log out
2. Create a new account
3. Get through onboarding
4. Tap the menu button to show the side menu
5. Tap Relays
6. Observe your relays

## Screenshots/Video

| Before | After |
|--------|--------|
| ![Simulator Screenshot - iPhone 16 Pro - 2024-12-23 at 17 12 17](https://github.com/user-attachments/assets/b9299b0f-b441-4ded-9abf-7984d514be67) | ![Simulator Screenshot - iPhone 16 Pro - 2024-12-23 at 17 11 13](https://github.com/user-attachments/assets/d290087e-8f86-43c2-8877-516e6b7d9421) |
