### PR TITLE
Remove inactive authors from Discover tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Upgraded to Xcode 16. [#1570](https://github.com/planetary-social/nos/issues/1570)
 - Download and parse an author’s lists when viewing their profile. [#49](https://github.com/verse-pbc/issues/issues/49)
 - Updated fastlane scripts to fix the TestFlight deployment pipeline. [#97](https://github.com/verse-pbc/issues/issues/97)
+- Removed inactive accounts from Discover tab. [#94](https://github.com/verse-pbc/issues/issues/94)
 
 ## [1.0.3] - 2024-12-04Z
 

--- a/Nos/Views/Discover/DiscoverTab.swift
+++ b/Nos/Views/Discover/DiscoverTab.swift
@@ -19,7 +19,6 @@ struct DiscoverTab: View {
 
     @State private var searchController = SearchController()
 
-    @State var predicate: NSPredicate = .false
     @FocusState private var isSearching: Bool
 
     let goToFeedTip = GoToFeedTip()

--- a/Nos/Views/Discover/FeaturedAuthor+Cohort1.swift
+++ b/Nos/Views/Discover/FeaturedAuthor+Cohort1.swift
@@ -28,11 +28,6 @@ extension FeaturedAuthor {
             categories: [.music]
         ),
         FeaturedAuthor(
-            name: "Judson McKinney and the Wanderers",
-            npub: "npub1jvt2hacqqzvwjkum30mlvmy52jer4p4crfh0veqstpk58rr9e7ms2fwh74",
-            categories: [.music]
-        ),
-        FeaturedAuthor(
             name: "Black in Aquatics",
             npub: "npub1ee852umhw26afdfwgf90cky9ufaythwyarttqu59lazcrx56z0tsmx3mkz",
             categories: [.sports]

--- a/Nos/Views/Discover/FeaturedAuthor+Cohort4.swift
+++ b/Nos/Views/Discover/FeaturedAuthor+Cohort4.swift
@@ -13,11 +13,6 @@ extension FeaturedAuthor {
             categories: [.art]
         ),
         FeaturedAuthor(
-            name: "Neigsendoig Cocules",
-            npub: "npub1372csjhjv35sxcqm90ca2d0cfxsl6xku7j6hhswynwdy9m7zl98scn950w",
-            categories: [.music]
-        ),
-        FeaturedAuthor(
             name: "Lexie Bean",
             npub: "npub1s8c5mk68qn0erxrx5waqz7xxk39x5xx2367879eqcv270tqs4tvsf5ewgf",
             categories: [.activists]

--- a/Nos/Views/Discover/FeaturedAuthor+Cohort5.swift
+++ b/Nos/Views/Discover/FeaturedAuthor+Cohort5.swift
@@ -118,11 +118,6 @@ extension FeaturedAuthor {
             categories: [.tech, .activists]
         ),
         FeaturedAuthor(
-            name: "Strypey",
-            npub: "npub1pwwm8s9zxssfm3aqv3g4fvqfh9kglr76m5z434cymju9gp9jhwwqdqtc65",
-            categories: [.tech, .activists]
-        ),
-        FeaturedAuthor(
             name: "Cecilia",
             npub: "npub1paftqx5zvj0gjtu3whudejxdgv4vdn27paw4lzaauc43kgfxxaqs75c5a7",
             categories: [.art]
@@ -218,11 +213,6 @@ extension FeaturedAuthor {
             categories: [.news, .nzAustralia]
         ),
         FeaturedAuthor(
-            name: "Ian Griffin",
-            npub: "npub19p6edn6lvz9dmegm7s8vyz9w5w0ejzgztke8rcswxgmqr35h8feszt36jc",
-            categories: [.sciFi, .nzAustralia]
-        ),
-        FeaturedAuthor(
             name: "JSM",
             npub: "npub1uqeexjx2djkfwzxdnrnrrch5h2k4xn0uapcgsxm94ftaxrlhy5lqywjckg",
             categories: [.tech]
@@ -266,11 +256,6 @@ extension FeaturedAuthor {
             name: "Nacho",
             npub: "npub1daajnadf0f0s7uz3yftur8434rtz2s949gkdpx7uyeapm9rlt0qq9q8w5z",
             categories: [.lifestyle]
-        ),
-        FeaturedAuthor(
-            name: "Morvin",
-            npub: "npub1030nmrre84tzpq2de535pd6up2x74c32n6r5xsw2kf0zf58j333sxssyu7",
-            categories: [.art]
         )
     ]
 }

--- a/Nos/Views/Discover/FeaturedAuthor.swift
+++ b/Nos/Views/Discover/FeaturedAuthor.swift
@@ -41,11 +41,6 @@ extension FeaturedAuthor {
             name: "Rabble",
             npub: "npub1wmr34t36fy03m8hvgl96zl3znndyzyaqhwmwdtshwmtkg03fetaqhjg240",
             categories: [.activists, .tech]
-        ),
-        FeaturedAuthor(
-            name: "Edward Snowden",
-            npub: "npub1sn0wdenkukak0d9dfczzeacvhkrgz92ak56egt7vdgzn8pv2wfqqhrjdv9",
-            categories: [.activists, .tech]
         )
     ]
 }
@@ -106,16 +101,6 @@ extension FeaturedAuthor {
             name: "Lucire",
             npub: "npub1l4s4mtt96znwu3plfeyupk37y63xfapw5e7kjn7uavuw02lvav5q3ngc3s",
             categories: [.news, .nzAustralia]
-        ),
-        FeaturedAuthor(
-            name: "Ian Griffin",
-            npub: "npub19p6edn6lvz9dmegm7s8vyz9w5w0ejzgztke8rcswxgmqr35h8feszt36jc",
-            categories: [.sciFi, .nzAustralia]
-        ),
-        FeaturedAuthor(
-            name: "Morvin",
-            npub: "npub1030nmrre84tzpq2de535pd6up2x74c32n6r5xsw2kf0zf58j333sxssyu7",
-            categories: [.art]
         ),
         FeaturedAuthor(
             name: "David Hood",


### PR DESCRIPTION
## Issues covered
https://github.com/verse-pbc/issues/issues/94

## Description
Removes the inactive accounts from the Discover tab as described in the ticket.

## How to test
1. Navigate to Discover
2. Scroll and don't see the accounts that were removed

## Screenshots/Video
There are visual changes -- we no longer have the inactive authors -- but this is something you'll just want to see for yourself.
