### PR TITLE
added remembering which feed source is selected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add empty state for lists/relays drop-down.
 - Added support for decrypting private tags in kind 30000 lists.
 - Added pop-up tip for feed customization. [#101](https://github.com/verse-pbc/issues/issues/101)
+- Added remembering which feed source is selected.
 
 ### Internal Changes
 - Upgraded to Xcode 16. [#1570](https://github.com/planetary-social/nos/issues/1570)

--- a/Nos/Models/CoreData/Event+Fetching.swift
+++ b/Nos/Models/CoreData/Event+Fetching.swift
@@ -392,11 +392,12 @@ extension Event {
     @nonobjc public class func homeFeed(
         for user: Author,
         after: Date,
-        seenOn relay: Relay? = nil
+        seenOn relay: Relay? = nil,
+        from authors: Set<Author>? = nil
     ) -> NSFetchRequest<Event> {
         let fetchRequest = NSFetchRequest<Event>(entityName: "Event")
         fetchRequest.sortDescriptors = [NSSortDescriptor(keyPath: \Event.createdAt, ascending: false)]
-        fetchRequest.predicate = homeFeedPredicate(for: user, after: after, seenOn: relay)
+        fetchRequest.predicate = homeFeedPredicate(for: user, after: after, seenOn: relay, from: authors)
         return fetchRequest
     }
 

--- a/Nos/Views/Home/FeedPicker.swift
+++ b/Nos/Views/Home/FeedPicker.swift
@@ -7,28 +7,35 @@ struct FeedPicker: View {
     
     var body: some View {
         BeveledContainerView {
-            ScrollView(.horizontal, showsIndicators: false) {
-                HStack(spacing: 0) {
-                    ForEach(feedController.enabledSources, id: \.self) { source in
-                        Button(action: {
-                            withAnimation(nil) {
-                                feedController.selectedSource = source
-                            }
-                        }, label: {
-                            let isSelected = feedController.selectedSource == source
-                            Text(source.displayName)
-                                .font(.system(size: 16, weight: isSelected ? .medium : .regular))
-                                .padding(.horizontal, 10)
-                                .padding(.vertical, 4)
-                                .background(isSelected ? Color.pickerBackgroundSelected : Color.clear)
-                                .foregroundStyle(isSelected ? Color.white : Color.secondaryTxt)
-                                .clipShape(Capsule())
-                        })
+            ScrollViewReader { proxy in
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: 0) {
+                        ForEach(feedController.enabledSources, id: \.self) { source in
+                            Button(action: {
+                                withAnimation(nil) {
+                                    feedController.selectedSource = source
+                                }
+                            }, label: {
+                                let isSelected = feedController.selectedSource == source
+                                Text(source.displayName)
+                                    .font(.system(size: 16, weight: isSelected ? .medium : .regular))
+                                    .padding(.horizontal, 10)
+                                    .padding(.vertical, 4)
+                                    .background(isSelected ? Color.pickerBackgroundSelected : Color.clear)
+                                    .foregroundStyle(isSelected ? Color.white : Color.secondaryTxt)
+                                    .clipShape(Capsule())
+                            })
+                        }
+                    }
+                    .padding(.horizontal, 8)
+                    .onChange(of: feedController.selectedSource) {
+                        withAnimation {
+                            proxy.scrollTo(feedController.selectedSource)
+                        }
                     }
                 }
-                .padding(.horizontal, 8)
+                .frame(height: 40)
             }
-            .frame(height: 40)
         }
         .background(Color.cardBgTop)
     }

--- a/Nos/Views/Home/HomeFeedView.swift
+++ b/Nos/Views/Home/HomeFeedView.swift
@@ -48,7 +48,8 @@ struct HomeFeedView: View {
         Event.homeFeed(
             for: user,
             after: refreshController.lastRefreshDate,
-            seenOn: feedController.selectedRelay
+            seenOn: feedController.selectedRelay,
+            from: feedController.selectedList?.allAuthors
         )
     }
 


### PR DESCRIPTION
## Description
The app now persists the user's selected feed source.

## How to test
1. Navigate to the feed and change the source to a list or specific relay.
2. Stop the app.
3. Restart the app.
The app should resume to the previously selected feed source.
