### PR TITLE
fixed a case where lists don't show up immediately after signing in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added pop-up tip for feed customization. [#101](https://github.com/verse-pbc/issues/issues/101)
 - Added remembering which feed source is selected.
 - Factored out the segmented picker on the ProfileHeader for reusability.
+- Fixed a case where lists don't show up immediately after signing in.
 
 ### Internal Changes
 - Upgraded to Xcode 16. [#1570](https://github.com/planetary-social/nos/issues/1570)

--- a/Nos/Controller/FeedController.swift
+++ b/Nos/Controller/FeedController.swift
@@ -74,7 +74,8 @@ enum FeedSource: RawRepresentable, Hashable, Equatable {
 @Observable @MainActor final class FeedController {
     
     @ObservationIgnored @Dependency(\.persistenceController) private var persistenceController
-    @ObservationIgnored @Dependency(\.currentUser) private var currentUser
+    
+    let author: Author
     
     var enabledSources: [FeedSource] = [.following]
     
@@ -106,7 +107,8 @@ enum FeedSource: RawRepresentable, Hashable, Equatable {
     
     private var cancellables = Set<AnyCancellable>()
     
-    init() {
+    init(author: Author) {
+        self.author = author
         observeLists()
         observeRelays()
         
@@ -118,10 +120,6 @@ enum FeedSource: RawRepresentable, Hashable, Equatable {
     }
     
     private func observeLists() {
-        guard let author = currentUser.author else {
-            return
-        }
-        
         let request = NSFetchRequest<AuthorList>(entityName: "AuthorList")
         request.sortDescriptors = [NSSortDescriptor(keyPath: \Event.createdAt, ascending: false)]
         request.predicate = NSPredicate(
@@ -147,10 +145,6 @@ enum FeedSource: RawRepresentable, Hashable, Equatable {
     }
     
     private func observeRelays() {
-        guard let author = currentUser.author else {
-            return
-        }
-        
         let request = Relay.relays(for: author)
         
         let relayWatcher = NSFetchedResultsController(

--- a/Nos/Service/CurrentUser.swift
+++ b/Nos/Service/CurrentUser.swift
@@ -177,7 +177,7 @@ import Dependencies
     }
 
     /// Subscribes to relays for important events concerning the current user like their latest contact list, 
-    /// notifications, reports, mutes, zaps, etc.
+    /// notifications, reports, mutes, zaps, lists etc.
     @MainActor func subscribe() async {
         guard let key = publicKeyHex, let author else {
             return
@@ -189,6 +189,11 @@ import Dependencies
         // Always make a request for the latest contact list
         subscriptions.append(
             await relayService.requestContactList(for: key, since: author.lastUpdatedContactList)
+        )
+        
+        // Always request the user's lists
+        subscriptions.append(
+            await relayService.requestAuthorLists(for: key, since: nil)
         )
         
         // Subscribe to important events we may not get incidentally while browsing the feed

--- a/Nos/Views/Home/HomeFeedView.swift
+++ b/Nos/Views/Home/HomeFeedView.swift
@@ -12,7 +12,7 @@ struct HomeFeedView: View {
 
     @State private var refreshController = RefreshController(lastRefreshDate: Date.now + Self.staticLoadTime)
     @State private var isVisible = false
-    @State private var feedController = FeedController()
+    @State private var feedController: FeedController
     
     /// When set to true this will display a fullscreen progress wheel for a set amount of time to give us a chance
     /// to get some data from relay. The amount of time is defined in `staticLoadTime`.
@@ -29,6 +29,13 @@ struct HomeFeedView: View {
     let user: Author
     @Binding var showFeedTip: Bool
     @Binding var scrollOffsetY: CGFloat
+    
+    init(user: Author, showFeedTip: Binding<Bool>, scrollOffsetY: Binding<CGFloat>) {
+        self.user = user
+        self._showFeedTip = showFeedTip
+        self._scrollOffsetY = scrollOffsetY
+        _feedController = State(initialValue: FeedController(author: user))
+    }
     
     /// A tip to display at the top of the feed.
     private let welcomeTip = WelcomeToFeedTip()

--- a/NosTests/Service/Relay/RelayServiceTests.swift
+++ b/NosTests/Service/Relay/RelayServiceTests.swift
@@ -17,7 +17,7 @@ class RelayServiceTests: XCTestCase {
         XCTAssertEqual(resultFilter, expectedFilter)
     }
 
-    func test_requestFollowSets_uses_correct_filter() async throws {
+    func test_requestAuthorLists_uses_correct_filter() async throws {
         let since = Date()
         let expectedFilter = Filter(
             authorKeys: ["test"],


### PR DESCRIPTION
## Description
Fixes a case where lists don't show up immediately after signing in.

## How to test
1. Install and launch app (with no account previously signed in)
2. Sign in
3. Navigate to the Feed tab
At this point we expect to see the user's lists in the feed source picker under the navigation bar right away.
