### PR TITLE
fixed: adding/removing relays not reflected on feed filter #119

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Release Notes
+
+- Fixed: adding/removing relays not reflected on feed filter. [#119](https://github.com/verse-pbc/issues/issues/119)
+
+### Internal Changes
+
 ## [1.1] - 2025-01-03Z
 
 ### Release Notes


### PR DESCRIPTION
## Issues covered
https://github.com/verse-pbc/issues/issues/119

## Description
Fixes the issue where changes to the user's relays are not immediately reflected on the feed filter picker view.

## How to test
1. Navigate to the Feed tab. Observe the state of the relays in the feed filter picker at the top.
2. Navigate to the side menu
3. Open the Relays view
4. Add or remove a relay
5. Navigate back to the Feed tab.
At this point the relays in the filter picker should have been updated already.

## Screenshots/Video

In both videos below, the user is trying add the "nos.lol" relay.

| Before | After |
|--------|--------|
|![before](https://github.com/user-attachments/assets/c189b82f-f59d-4fd9-87c7-ab8b2bc3861a)|![after](https://github.com/user-attachments/assets/7c8e10c7-f771-4204-a96e-e4ec61e8e375)|
