### PR TITLE
added lists view and two ways to navigate to it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Release Notes
 
 - Fixed: adding/removing relays not reflected on feed filter. [#119](https://github.com/verse-pbc/issues/issues/119)
+- Added Lists view and two ways to navigate to it.
 
 ### Internal Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Release Notes
 
 - Fixed: adding/removing relays not reflected on feed filter. [#119](https://github.com/verse-pbc/issues/issues/119)
-- Added Lists view and two ways to navigate to it.
+- Added Lists view and two ways to navigate to it. [#133](https://github.com/verse-pbc/issues/issues/133)
 
 ### Internal Changes
 

--- a/Nos.xcodeproj/project.pbxproj
+++ b/Nos.xcodeproj/project.pbxproj
@@ -226,6 +226,7 @@
 		50EA86D42D28150F001E62CC /* FeedSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50EA86D32D28150D001E62CC /* FeedSource.swift */; };
 		50EA86D52D28150F001E62CC /* FeedSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50EA86D32D28150D001E62CC /* FeedSource.swift */; };
 		50EA885C2D2D523F001E62CC /* follow_set_with_unknown_tag.json in Resources */ = {isa = PBXBuildFile; fileRef = 50EA885B2D2D5235001E62CC /* follow_set_with_unknown_tag.json */; };
+		50EA886F2D2D5783001E62CC /* ListsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50EA886E2D2D5780001E62CC /* ListsView.swift */; };
 		50F695072C6392C4000E4C74 /* zap_receipt.json in Resources */ = {isa = PBXBuildFile; fileRef = 50F695062C6392C4000E4C74 /* zap_receipt.json */; };
 		5B098DBC2BDAF6CB00500A1B /* NoteParserTests+NIP08.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B098DBB2BDAF6CB00500A1B /* NoteParserTests+NIP08.swift */; };
 		5B098DC62BDAF73500500A1B /* AttributedString+Links.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B098DC52BDAF73500500A1B /* AttributedString+Links.swift */; };
@@ -793,6 +794,7 @@
 		50E2EB712C86175900D4B360 /* NSRegularExpression+Replacement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSRegularExpression+Replacement.swift"; sourceTree = "<group>"; };
 		50EA86D32D28150D001E62CC /* FeedSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedSource.swift; sourceTree = "<group>"; };
 		50EA885B2D2D5235001E62CC /* follow_set_with_unknown_tag.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = follow_set_with_unknown_tag.json; sourceTree = "<group>"; };
+		50EA886E2D2D5780001E62CC /* ListsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListsView.swift; sourceTree = "<group>"; };
 		50F695062C6392C4000E4C74 /* zap_receipt.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = zap_receipt.json; sourceTree = "<group>"; };
 		5B098DBB2BDAF6CB00500A1B /* NoteParserTests+NIP08.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NoteParserTests+NIP08.swift"; sourceTree = "<group>"; };
 		5B098DC52BDAF73500500A1B /* AttributedString+Links.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AttributedString+Links.swift"; sourceTree = "<group>"; };
@@ -1580,6 +1582,14 @@
 			path = Onboarding;
 			sourceTree = "<group>";
 		};
+		50EA886D2D2D5776001E62CC /* Lists */ = {
+			isa = PBXGroup;
+			children = (
+				50EA886E2D2D5780001E62CC /* ListsView.swift */,
+			);
+			path = Lists;
+			sourceTree = "<group>";
+		};
 		5B79F5E92B97B5D7002DA9BE /* Edit */ = {
 			isa = PBXGroup;
 			children = (
@@ -2069,6 +2079,7 @@
 				65BD8DC12BDAF2C300802039 /* Discover */,
 				03618B112C825D8700BCBC55 /* Fixtures */,
 				C96877B32B4EDCCF0051ED2F /* Home */,
+				50EA886D2D2D5776001E62CC /* Lists */,
 				04368D542C99D32B00DEAA2E /* Moderation */,
 				C9CFF6D02AB241EB00D4B368 /* Modifiers */,
 				03618C6D2C8267E600BCBC55 /* Note */,
@@ -2418,6 +2429,7 @@
 				5BC0D9CC2B867B9D005D6980 /* NamesAPI.swift in Sources */,
 				C987F81D29BA6D9A00B44E7A /* ProfileTab.swift in Sources */,
 				C9ADB14129951CB10075E7F8 /* NSManagedObject+Nos.swift in Sources */,
+				50EA886F2D2D5783001E62CC /* ListsView.swift in Sources */,
 				503CA9792D19C39F00805EF8 /* FeedCustomizerView.swift in Sources */,
 				C9F84C21298DC36800C6714D /* AppView.swift in Sources */,
 				C9CE5B142A0172CF008E198C /* WebView.swift in Sources */,

--- a/Nos.xcodeproj/project.pbxproj
+++ b/Nos.xcodeproj/project.pbxproj
@@ -226,7 +226,7 @@
 		50EA86D42D28150F001E62CC /* FeedSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50EA86D32D28150D001E62CC /* FeedSource.swift */; };
 		50EA86D52D28150F001E62CC /* FeedSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50EA86D32D28150D001E62CC /* FeedSource.swift */; };
 		50EA885C2D2D523F001E62CC /* follow_set_with_unknown_tag.json in Resources */ = {isa = PBXBuildFile; fileRef = 50EA885B2D2D5235001E62CC /* follow_set_with_unknown_tag.json */; };
-		50EA886F2D2D5783001E62CC /* ListsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50EA886E2D2D5780001E62CC /* ListsView.swift */; };
+		50EA886F2D2D5783001E62CC /* AuthorListsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50EA886E2D2D5780001E62CC /* AuthorListsView.swift */; };
 		50F695072C6392C4000E4C74 /* zap_receipt.json in Resources */ = {isa = PBXBuildFile; fileRef = 50F695062C6392C4000E4C74 /* zap_receipt.json */; };
 		5B098DBC2BDAF6CB00500A1B /* NoteParserTests+NIP08.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B098DBB2BDAF6CB00500A1B /* NoteParserTests+NIP08.swift */; };
 		5B098DC62BDAF73500500A1B /* AttributedString+Links.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B098DC52BDAF73500500A1B /* AttributedString+Links.swift */; };
@@ -795,7 +795,7 @@
 		50E2EB712C86175900D4B360 /* NSRegularExpression+Replacement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSRegularExpression+Replacement.swift"; sourceTree = "<group>"; };
 		50EA86D32D28150D001E62CC /* FeedSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedSource.swift; sourceTree = "<group>"; };
 		50EA885B2D2D5235001E62CC /* follow_set_with_unknown_tag.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = follow_set_with_unknown_tag.json; sourceTree = "<group>"; };
-		50EA886E2D2D5780001E62CC /* ListsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListsView.swift; sourceTree = "<group>"; };
+		50EA886E2D2D5780001E62CC /* AuthorListsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthorListsView.swift; sourceTree = "<group>"; };
 		50F695062C6392C4000E4C74 /* zap_receipt.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = zap_receipt.json; sourceTree = "<group>"; };
 		5B098DBB2BDAF6CB00500A1B /* NoteParserTests+NIP08.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NoteParserTests+NIP08.swift"; sourceTree = "<group>"; };
 		5B098DC52BDAF73500500A1B /* AttributedString+Links.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AttributedString+Links.swift"; sourceTree = "<group>"; };
@@ -1587,7 +1587,7 @@
 		50EA886D2D2D5776001E62CC /* Lists */ = {
 			isa = PBXGroup;
 			children = (
-				50EA886E2D2D5780001E62CC /* ListsView.swift */,
+				50EA886E2D2D5780001E62CC /* AuthorListsView.swift */,
 			);
 			path = Lists;
 			sourceTree = "<group>";
@@ -2433,7 +2433,7 @@
 				5BC0D9CC2B867B9D005D6980 /* NamesAPI.swift in Sources */,
 				C987F81D29BA6D9A00B44E7A /* ProfileTab.swift in Sources */,
 				C9ADB14129951CB10075E7F8 /* NSManagedObject+Nos.swift in Sources */,
-				50EA886F2D2D5783001E62CC /* ListsView.swift in Sources */,
+				50EA886F2D2D5783001E62CC /* AuthorListsView.swift in Sources */,
 				503CA9792D19C39F00805EF8 /* FeedCustomizerView.swift in Sources */,
 				C9F84C21298DC36800C6714D /* AppView.swift in Sources */,
 				C9CE5B142A0172CF008E198C /* WebView.swift in Sources */,

--- a/Nos/Assets/Localization/Localizable.xcstrings
+++ b/Nos/Assets/Localization/Localizable.xcstrings
@@ -4755,6 +4755,17 @@
         }
       }
     },
+    "deleteList" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Delete List"
+          }
+        }
+      }
+    },
     "deleteMyAccount" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -5818,6 +5829,17 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "編輯"
+          }
+        }
+      }
+    },
+    "editListInfo" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Edit List Info"
           }
         }
       }
@@ -10412,6 +10434,17 @@
         }
       }
     },
+    "lists" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lists"
+          }
+        }
+      }
+    },
     "loading" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -10883,6 +10916,28 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "登出"
+          }
+        }
+      }
+    },
+    "manageUsers" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Manage Users"
+          }
+        }
+      }
+    },
+    "manageYourLists" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Manage Your Lists"
           }
         }
       }
@@ -20309,6 +20364,17 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "你必須在設置中輸入私鑰才能發佈帖子。"
+          }
+        }
+      }
+    },
+    "yourLists" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your Lists"
           }
         }
       }

--- a/Nos/Assets/Localization/Localizable.xcstrings
+++ b/Nos/Assets/Localization/Localizable.xcstrings
@@ -10456,6 +10456,17 @@
         }
       }
     },
+    "listsDescription" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Add your favorite users to public lists and pin them to your home feed"
+          }
+        }
+      }
+    },
     "loading" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -12299,6 +12310,17 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "否"
+          }
+        }
+      }
+    },
+    "noDescription" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No Description"
           }
         }
       }
@@ -20230,6 +20252,29 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "你有 %@ 个新关注者！"
+          }
+        }
+      }
+    },
+    "xUsers" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%1$lld user"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%1$lld users"
+                }
+              }
+            }
           }
         }
       }

--- a/Nos/Controller/FeedController.swift
+++ b/Nos/Controller/FeedController.swift
@@ -26,7 +26,7 @@ import SwiftUI
     private(set) var listRowItems: [FeedToggleRow.Item] = []
     private(set) var relayRowItems: [FeedToggleRow.Item] = []
     
-    private var lists: [AuthorList] = [] {
+    private(set) var lists: [AuthorList] = [] {
         didSet {
             updateEnabledSources()
         }
@@ -38,16 +38,8 @@ import SwiftUI
     }
     
     @ObservationIgnored private lazy var listsPublisher = {
-        let request = NSFetchRequest<AuthorList>(entityName: "AuthorList")
-        request.sortDescriptors = [NSSortDescriptor(keyPath: \Event.createdAt, ascending: false)]
-        request.predicate = NSPredicate(
-            format: "kind = %i AND author = %@ AND title != nil",
-            EventKind.followSet.rawValue,
-            author
-        )
-        
         let listWatcher = NSFetchedResultsController(
-            fetchRequest: request,
+            fetchRequest: AuthorList.authorLists(ownedBy: author),
             managedObjectContext: persistenceController.viewContext,
             sectionNameKeyPath: nil,
             cacheName: "FeedController.listWatcher"

--- a/Nos/Models/CoreData/AuthorList+CoreDataClass.swift
+++ b/Nos/Models/CoreData/AuthorList+CoreDataClass.swift
@@ -96,4 +96,15 @@ public class AuthorList: Event {
     var allAuthors: Set<Author> {
         authors.union(privateAuthors)
     }
+    
+    static func authorLists(ownedBy owner: Author) -> NSFetchRequest<AuthorList> {
+        let request = NSFetchRequest<AuthorList>(entityName: "AuthorList")
+        request.sortDescriptors = [NSSortDescriptor(keyPath: \Event.createdAt, ascending: false)]
+        request.predicate = NSPredicate(
+            format: "kind = %i AND author = %@ AND title != nil AND deletedOn.@count = 0",
+            EventKind.followSet.rawValue,
+            owner
+        )
+        return request
+    }
 }

--- a/Nos/Views/Home/FeedCustomizerView.swift
+++ b/Nos/Views/Home/FeedCustomizerView.swift
@@ -33,6 +33,7 @@ struct FeedCustomizerView: View {
     
     @Environment(FeedController.self) var feedController
     let author: Author
+    @Binding var shouldNavigateToLists: Bool
     @Binding var shouldNavigateToRelays: Bool
     
     @AppStorage("selectedFeedTogglesTab") private var selectedTab = FeedTab.lists
@@ -53,18 +54,30 @@ struct FeedCustomizerView: View {
                     items: feedController.listRowItems,
                     footer: {
                         Group {
-                            Text("Create your own lists on ") +
-                            Text("Listr ")
-                                .foregroundStyle(Color.accent) +
-                            Text(Image(systemName: "link"))
-                                .foregroundStyle(Color.accent)
-                        }
-                        .padding()
-                        .onTapGesture {
-                            if let url = URL(string: "https://listr.lol/feed") {
-                                UIApplication.shared.open(url)
+                            if feedController.listRowItems.isEmpty {
+                                Group {
+                                    Text("Create your own lists on ") +
+                                    Text("Listr ")
+                                        .foregroundStyle(Color.accent) +
+                                    Text(Image(systemName: "link"))
+                                        .foregroundStyle(Color.accent)
+                                }
+                                .onTapGesture {
+                                    if let url = URL(string: "https://listr.lol/feed") {
+                                        UIApplication.shared.open(url)
+                                    }
+                                }
+                            } else {
+                                SecondaryActionButton(
+                                    "manageYourLists",
+                                    font: .clarity(.semibold, textStyle: .footnote),
+                                    image: Image(systemName: "slider.horizontal.3")
+                                ) {
+                                    shouldNavigateToLists = true
+                                }
                             }
                         }
+                        .padding()
                     },
                     noContent: {
                         Text("It doesn’t look like you have created any lists.")    // TODO: localize

--- a/Nos/Views/Home/HomeFeedView.swift
+++ b/Nos/Views/Home/HomeFeedView.swift
@@ -217,7 +217,7 @@ struct HomeFeedView: View {
             }
         }
         .navigationDestination(for: ListsDestination.self) { destination in
-            ListsView(author: destination.author)
+            AuthorListsView(author: destination.author)
         }
         .navigationDestination(for: RelaysDestination.self) { destination in
             RelayView(author: destination.author)

--- a/Nos/Views/Home/HomeFeedView.swift
+++ b/Nos/Views/Home/HomeFeedView.swift
@@ -18,6 +18,7 @@ struct HomeFeedView: View {
     /// to get some data from relay. The amount of time is defined in `staticLoadTime`.
     @State private var showTimedLoadingIndicator = true
     
+    @State private var shouldNavigateToListsOnAppear = false
     @State private var shouldNavigateToRelaysOnAppear = false
     
     /// The amount of time (in seconds) the loading indicator will be shown when showTimedLoadingIndicator is set to 
@@ -130,7 +131,11 @@ struct HomeFeedView: View {
                     .transition(.opacity)
                 
                 VStack {
-                    FeedCustomizerView(author: user, shouldNavigateToRelays: $shouldNavigateToRelaysOnAppear)
+                    FeedCustomizerView(
+                        author: user,
+                        shouldNavigateToLists: $shouldNavigateToListsOnAppear,
+                        shouldNavigateToRelays: $shouldNavigateToRelaysOnAppear
+                    )
                     Spacer()
                 }
                 .transition(.move(edge: .top))
@@ -187,6 +192,17 @@ struct HomeFeedView: View {
                 GoToFeedTip.viewedFeed.sendDonation()
             }
         }
+        .onChange(of: shouldNavigateToListsOnAppear) {
+            if shouldNavigateToListsOnAppear {
+                showFeedSelector = false
+                
+                DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(300)) {
+                    router.push(ListsDestination(author: user))
+                }
+                
+                shouldNavigateToListsOnAppear = false
+            }
+        }
         .onChange(of: shouldNavigateToRelaysOnAppear) {
             if shouldNavigateToRelaysOnAppear {
                 showFeedSelector = false
@@ -197,6 +213,9 @@ struct HomeFeedView: View {
                 
                 shouldNavigateToRelaysOnAppear = false
             }
+        }
+        .navigationDestination(for: ListsDestination.self) { destination in
+            ListsView(author: destination.author)
         }
         .navigationDestination(for: RelaysDestination.self) { destination in
             RelayView(author: destination.author)

--- a/Nos/Views/Lists/AuthorListsView.swift
+++ b/Nos/Views/Lists/AuthorListsView.swift
@@ -5,7 +5,8 @@ struct ListsDestination: Hashable {
     let author: Author
 }
 
-struct ListsView: View {
+/// A view that displays a list of an ``Author``'s ``AuthorList``s.
+struct AuthorListsView: View {
     @Environment(\.managedObjectContext) private var viewContext
     
     let author: Author

--- a/Nos/Views/Lists/ListsView.swift
+++ b/Nos/Views/Lists/ListsView.swift
@@ -1,0 +1,94 @@
+import CoreData
+import SwiftUI
+
+struct ListsDestination: Hashable {
+    let author: Author
+}
+
+struct ListsView: View {
+    @Environment(\.managedObjectContext) private var viewContext
+    
+    let author: Author
+    
+    @FetchRequest var lists: FetchedResults<AuthorList>
+    
+    init(author: Author) {
+        self.author = author
+        _lists = FetchRequest(fetchRequest: AuthorList.authorLists(ownedBy: author))
+    }
+    
+    var body: some View {
+        ZStack {
+            Color.appBg
+            
+            Group {
+                if lists.isEmpty {
+                    VStack {
+                        Image(systemName: "person.2")
+                        
+                        Text("Add your favorite accounts to public lists and pin them to your home feed")
+                    }
+                } else {
+                    ScrollView {
+                        VStack(spacing: 0) {
+                            ForEach(lists) { list in
+                                HStack {
+                                    VStack(alignment: .leading) {
+                                        Text(list.title ?? "")
+                                            .font(.body)
+                                        
+                                        if let description = list.listDescription {
+                                            Text(description)
+                                                .foregroundStyle(Color.secondaryTxt)
+                                                .font(.footnote)
+                                        }
+                                    }
+                                    
+                                    Spacer()
+                                    
+                                    Menu {
+                                        Button("editListInfo") {
+                                            // TODO: Edit List Info
+                                        }
+                                        Button("manageUsers") {
+                                            // TODO: Manage Users
+                                        }
+                                        Button("deleteList", role: .destructive) {
+                                            // TODO: Delete List
+                                        }
+                                    } label: {
+                                        Image(systemName: "ellipsis")
+                                            .foregroundStyle(Color.secondaryTxt)
+                                            .fontWeight(.bold)
+                                    }
+                                }
+                                .padding(.horizontal, 16)
+                                .padding(.vertical, 12)
+                                .frame(minHeight: 50)
+                                
+                                BeveledSeparator()
+                            }
+                        }
+                        .background(LinearGradient.cardBackground)
+                        .clipShape(RoundedRectangle(cornerRadius: 15))
+                        .mimicCardButtonStyle()
+                    }
+                    .padding(EdgeInsets(top: 16, leading: 16, bottom: 16, trailing: 16))
+                }
+            }
+        }
+        .scrollContentBackground(.hidden)
+        .toolbar {
+            ToolbarItem(placement: .navigationBarTrailing) {
+                ActionButton("new", action: newButtonPressed)
+                    .frame(height: 22)
+                    .padding(.bottom, 3)
+            }
+        }
+        .nosNavigationBar("yourLists")
+    }
+    
+    private func newButtonPressed() {
+        
+    }
+}

--- a/Nos/Views/Lists/ListsView.swift
+++ b/Nos/Views/Lists/ListsView.swift
@@ -20,6 +20,7 @@ struct ListsView: View {
     var body: some View {
         ZStack {
             Color.appBg
+                .ignoresSafeArea()
             
             Group {
                 if lists.isEmpty {
@@ -37,11 +38,9 @@ struct ListsView: View {
                                         Text(list.title ?? "")
                                             .font(.body)
                                         
-                                        if let description = list.listDescription {
-                                            Text(description)
-                                                .foregroundStyle(Color.secondaryTxt)
-                                                .font(.footnote)
-                                        }
+                                        Text(list.rowDescription)
+                                            .foregroundStyle(Color.secondaryTxt)
+                                            .font(.footnote)
                                     }
                                     
                                     Spacer()
@@ -90,5 +89,17 @@ struct ListsView: View {
     
     private func newButtonPressed() {
         
+    }
+}
+
+extension AuthorList {
+    
+    var rowDescription: String {
+        var descriptionComponents = [String]()
+        let authorCount = allAuthors.count
+        descriptionComponents.append("\(authorCount) users")
+        
+        descriptionComponents.append(listDescription ?? "No Description")
+        return descriptionComponents.joined(separator: " • ")
     }
 }

--- a/Nos/Views/Lists/ListsView.swift
+++ b/Nos/Views/Lists/ListsView.swift
@@ -24,11 +24,28 @@ struct ListsView: View {
             
             Group {
                 if lists.isEmpty {
-                    VStack {
-                        Image(systemName: "person.2")
+                    VStack(spacing: 40) {
+                        ZStack {
+                            Circle()
+                                .fill(Color.white)
+                                .frame(width: 80, height: 80)
+                            
+                            Image(systemName: "person.2")
+                                .resizable()
+                                .fontWeight(.semibold)
+                                .aspectRatio(contentMode: .fit)
+                                .frame(width: 48)
+                                .foregroundStyle(Color.black)
+                        }
                         
-                        Text("Add your favorite accounts to public lists and pin them to your home feed")
+                        Text("listsDescription")
+                            .font(.subheadline.weight(.medium))
+                            .multilineTextAlignment(.center)
+                        
+                        Spacer()
                     }
+                    .padding(.top, 100)
+                    .padding(.horizontal, 60)
                 } else {
                     ScrollView {
                         VStack(spacing: 0) {
@@ -88,7 +105,7 @@ struct ListsView: View {
     }
     
     private func newButtonPressed() {
-        
+        // TODO
     }
 }
 
@@ -97,9 +114,10 @@ extension AuthorList {
     var rowDescription: String {
         var descriptionComponents = [String]()
         let authorCount = allAuthors.count
-        descriptionComponents.append("\(authorCount) users")
+        let countString = String.localizedStringWithFormat(String(localized: "xUsers"), authorCount)
+        descriptionComponents.append(countString)
         
-        descriptionComponents.append(listDescription ?? "No Description")
+        descriptionComponents.append(listDescription ?? String(localized: "noDescription"))
         return descriptionComponents.joined(separator: " • ")
     }
 }

--- a/Nos/Views/SideMenu/SideMenu.swift
+++ b/Nos/Views/SideMenu/SideMenu.swift
@@ -7,6 +7,7 @@ struct SideMenu: View {
     enum Destination {
         case settings
         case relays
+        case lists
         case profile
         case about
     }

--- a/Nos/Views/SideMenu/SideMenuContent.swift
+++ b/Nos/Views/SideMenu/SideMenuContent.swift
@@ -116,7 +116,7 @@ struct SideMenuContent: View {
                 case .relays:
                     RelayView(author: currentUser.author!)
                 case .lists:
-                    ListsView(author: currentUser.author!)
+                    AuthorListsView(author: currentUser.author!)
                 case .profile:
                     ProfileView(author: currentUser.author!)
                 case .about:

--- a/Nos/Views/SideMenu/SideMenuContent.swift
+++ b/Nos/Views/SideMenu/SideMenuContent.swift
@@ -77,6 +77,11 @@ struct SideMenuContent: View {
                         destination: .relays
                     )
                     SideMenuRow(
+                        "lists",
+                        image: Image(systemName: "person.2"),
+                        destination: .lists
+                    )
+                    SideMenuRow(
                         "about",
                         image: Image(systemName: "questionmark.circle"),
                         destination: .about
@@ -108,6 +113,8 @@ struct SideMenuContent: View {
                     SettingsView()
                 case .relays:
                     RelayView(author: currentUser.author!)
+                case .lists:
+                    ListsView(author: currentUser.author!)
                 case .profile:
                     ProfileView(author: currentUser.author!)
                 case .about:
@@ -151,6 +158,9 @@ struct SideMenuRow: View {
         } label: {
             HStack(alignment: .center) {
                 image
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .frame(maxWidth: 28)
                 Text(title)
                     .foregroundColor(.primaryTxt)
                 Spacer()

--- a/Nos/Views/SideMenu/SideMenuContent.swift
+++ b/Nos/Views/SideMenu/SideMenuContent.swift
@@ -79,7 +79,7 @@ struct SideMenuContent: View {
                         destination: .relays
                     )
                     SideMenuRow(
-                        "lists",
+                        "yourLists",
                         image: Image(systemName: "person.2"),
                         destination: .lists
                     )


### PR DESCRIPTION
## Issues covered
https://github.com/verse-pbc/issues/issues/133

## Description
Adds the Lists view and two ways to navigate to it.

## How to test
A:
1. Navigate to side menu
2. Tap Lists

B:
1. Navigate to Feed tab
2. Tap the filter button at the top right
3. Tap the Lists tab
4. If you have lists already, tap the Manage Your Lists button at the bottom.

## Screenshots/Video

Entry point 1:
<img width="340" alt="Bob_s_Phone" src="https://github.com/user-attachments/assets/b90472b1-6d24-4d68-8313-ac7cf5ec2b54" />

Entry point 2:
<img width="340" alt="Bob_s_Phone" src="https://github.com/user-attachments/assets/60c7ccb9-32d9-487d-b82f-fab5ccbf4d66" />

Your Lists:
<img width="340" alt="Bob_s_Phone" src="https://github.com/user-attachments/assets/8518c817-465e-4547-9fc7-6409b16b73f5" />

No Content:
<img width="340" alt="Bob_s_Phone" src="https://github.com/user-attachments/assets/ffa55b6a-c6a5-4bf7-b1a9-ed7a491ff63b" />

Pop-up menu:
<img width="340" alt="Bob_s_Phone" src="https://github.com/user-attachments/assets/231e171a-d12d-49ed-927b-bb706400f535" />
