### PR TITLE
Disable automatic tracking in Sentry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Internal Changes
 - Added function for creating a new list and a test verifying list editing. [#112](https://github.com/verse-pbc/issues/issues/112)
 - Localized strings on the feed filter drop-down view.
+- Disabled automatic tracking in Sentry. [#126](https://github.com/verse-pbc/issues/issues/126)
 
 ## [1.1] - 2025-01-03Z
 

--- a/Nos/Service/CrashReporting.swift
+++ b/Nos/Service/CrashReporting.swift
@@ -28,9 +28,6 @@ class CrashReporting {
             #elseif DEV
             options.environment = "debug"
             #endif
-            options.enableTracing = true
-            options.tracesSampleRate = 0.3 // tracing must be enabled for profiling
-            options.profilesSampleRate = 0.3 // see also `profilesSampler` if you need custom sampling logic
             // Enable all experimental features
             options.attachViewHierarchy = true
             options.enablePreWarmedAppStartTracing = true


### PR DESCRIPTION
## Issues covered
https://github.com/verse-pbc/issues/issues/126

## Description
Automatic tracking in Sentry doesn't work for us; it just generates a ton of noise and makes it harder to find useful data.

## How to test
1. Launch the app
2. Tap around and make sure the app still works
3. I'm not sure you'll see anything in Sentry right now
