### PR TITLE
added view for editing a list's title and description #134

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Release Notes
 - Fixed: adding/removing relays not reflected on feed filter. [#119](https://github.com/verse-pbc/issues/issues/119)
 - Added Lists view and two ways to navigate to it. [#133](https://github.com/verse-pbc/issues/issues/133)
+- Added view for editing a list's title and description. [#134](https://github.com/verse-pbc/issues/issues/134)
 
 ### Internal Changes
 - Added function for creating a new list and a test verifying list editing. [#112](https://github.com/verse-pbc/issues/issues/112)

--- a/Nos.xcodeproj/project.pbxproj
+++ b/Nos.xcodeproj/project.pbxproj
@@ -227,6 +227,7 @@
 		50EA86D52D28150F001E62CC /* FeedSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50EA86D32D28150D001E62CC /* FeedSource.swift */; };
 		50EA885C2D2D523F001E62CC /* follow_set_with_unknown_tag.json in Resources */ = {isa = PBXBuildFile; fileRef = 50EA885B2D2D5235001E62CC /* follow_set_with_unknown_tag.json */; };
 		50EA886F2D2D5783001E62CC /* AuthorListsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50EA886E2D2D5780001E62CC /* AuthorListsView.swift */; };
+		50EA89A62D3010EA001E62CC /* EditAuthorListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50EA89A52D3010EA001E62CC /* EditAuthorListView.swift */; };
 		50F695072C6392C4000E4C74 /* zap_receipt.json in Resources */ = {isa = PBXBuildFile; fileRef = 50F695062C6392C4000E4C74 /* zap_receipt.json */; };
 		5B098DBC2BDAF6CB00500A1B /* NoteParserTests+NIP08.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B098DBB2BDAF6CB00500A1B /* NoteParserTests+NIP08.swift */; };
 		5B098DC62BDAF73500500A1B /* AttributedString+Links.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B098DC52BDAF73500500A1B /* AttributedString+Links.swift */; };
@@ -796,6 +797,7 @@
 		50EA86D32D28150D001E62CC /* FeedSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedSource.swift; sourceTree = "<group>"; };
 		50EA885B2D2D5235001E62CC /* follow_set_with_unknown_tag.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = follow_set_with_unknown_tag.json; sourceTree = "<group>"; };
 		50EA886E2D2D5780001E62CC /* AuthorListsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthorListsView.swift; sourceTree = "<group>"; };
+		50EA89A52D3010EA001E62CC /* EditAuthorListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditAuthorListView.swift; sourceTree = "<group>"; };
 		50F695062C6392C4000E4C74 /* zap_receipt.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = zap_receipt.json; sourceTree = "<group>"; };
 		5B098DBB2BDAF6CB00500A1B /* NoteParserTests+NIP08.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NoteParserTests+NIP08.swift"; sourceTree = "<group>"; };
 		5B098DC52BDAF73500500A1B /* AttributedString+Links.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AttributedString+Links.swift"; sourceTree = "<group>"; };
@@ -1588,6 +1590,7 @@
 			isa = PBXGroup;
 			children = (
 				50EA886E2D2D5780001E62CC /* AuthorListsView.swift */,
+				50EA89A52D3010EA001E62CC /* EditAuthorListView.swift */,
 			);
 			path = Lists;
 			sourceTree = "<group>";
@@ -2680,6 +2683,7 @@
 				501728B42D16EFB000CF2A07 /* FeedPicker.swift in Sources */,
 				5B503F622A291A1A0098805A /* JSONRelayMetadata.swift in Sources */,
 				C98298332ADD7F9A0096C5B5 /* DeepLinkService.swift in Sources */,
+				50EA89A62D3010EA001E62CC /* EditAuthorListView.swift in Sources */,
 				03F7C4F42C10E05B006FF613 /* URLSessionProtocol.swift in Sources */,
 				CD09A74829A51EFC0063464F /* Router.swift in Sources */,
 				2D4010A22AD87DF300F93AD4 /* KnownFollowersView.swift in Sources */,

--- a/Nos/Assets/Localization/Localizable.xcstrings
+++ b/Nos/Assets/Localization/Localizable.xcstrings
@@ -10445,6 +10445,17 @@
         }
       }
     },
+    "listName" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "List Name"
+          }
+        }
+      }
+    },
     "lists" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -10463,6 +10474,17 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Add your favorite users to public lists and pin them to your home feed"
+          }
+        }
+      }
+    },
+    "listStep1" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Step 1: list info"
           }
         }
       }
@@ -11594,6 +11616,17 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "您有一位新关注者！"
+          }
+        }
+      }
+    },
+    "newList" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "New List"
           }
         }
       }

--- a/Nos/Views/Components/Form/NosFormSection.swift
+++ b/Nos/Views/Components/Form/NosFormSection.swift
@@ -18,7 +18,7 @@ struct NosFormSection<Content: View>: View {
                     Text(label)
                         .font(.clarity(.semibold, textStyle: .headline))
                         .foregroundColor(.primaryTxt)
-                        .padding(.top, 16)
+                        .padding(EdgeInsets(top: 16, leading: 8, bottom: 2, trailing: 0))
                     
                     Spacer()
                 }

--- a/Nos/Views/Components/Form/NosTextEditor.swift
+++ b/Nos/Views/Components/Form/NosTextEditor.swift
@@ -3,22 +3,28 @@ import SwiftUINavigation
 
 struct NosTextEditor: View {
     
-    var label: LocalizedStringKey
+    let label: LocalizedStringKey?
     @Binding var text: String
     
-    init(_ label: LocalizedStringKey, text: Binding<String>) {
+    init(_ label: LocalizedStringKey? = nil, text: Binding<String>) {
         self.label = label
         self._text = text
     }
     
     var body: some View {
-        NosFormField(label) {
-            TextEditor(text: $text)
-                .textInputAutocapitalization(.never)
-                .foregroundColor(.primaryTxt)
-                .scrollContentBackground(.hidden)
-                .autocorrectionDisabled()
+        Group {
+            if let label {
+                NosFormField(label) {
+                    TextEditor(text: $text)
+                }
+            } else {
+                TextEditor(text: $text)
+            }
         }
+        .textInputAutocapitalization(.never)
+        .foregroundColor(.primaryTxt)
+        .scrollContentBackground(.hidden)
+        .autocorrectionDisabled()
     }
 }
 

--- a/Nos/Views/Components/Form/NosTextField.swift
+++ b/Nos/Views/Components/Form/NosTextField.swift
@@ -3,21 +3,27 @@ import SwiftUINavigation
 
 struct NosTextField: View {
     
-    var label: LocalizedStringKey
+    let label: LocalizedStringKey?
     @Binding var text: String
     
-    init(_ label: LocalizedStringKey, text: Binding<String>) {
+    init(_ label: LocalizedStringKey? = nil, text: Binding<String>) {
         self.label = label
         self._text = text
     }
     
     var body: some View {
-        NosFormField(label) {
-            TextField("", text: $text)
-                .textInputAutocapitalization(.never)
-                .foregroundColor(.primaryTxt)
-                .autocorrectionDisabled()
+        Group {
+            if let label {
+                NosFormField(label) {
+                    TextField("", text: $text)
+                }
+            } else {
+                TextField("", text: $text)
+            }
         }
+        .textInputAutocapitalization(.never)
+        .foregroundColor(.primaryTxt)
+        .autocorrectionDisabled()
     }
 }
 

--- a/Nos/Views/Lists/AuthorListsView.swift
+++ b/Nos/Views/Lists/AuthorListsView.swift
@@ -13,7 +13,7 @@ struct AuthorListsView: View {
     
     @FetchRequest var lists: FetchedResults<AuthorList>
     
-    @State private var selectedList: AuthorList?
+    @State private var listToEditInfo: AuthorList?
     @State private var showingCreateList = false
     
     init(author: Author) {
@@ -68,7 +68,7 @@ struct AuthorListsView: View {
                                     
                                     Menu {
                                         Button("editListInfo") {
-                                            selectedList = list
+                                            listToEditInfo = list
                                         }
                                         Button("manageUsers") {
                                             // TODO: Manage Users
@@ -107,14 +107,18 @@ struct AuthorListsView: View {
             }
         }
         .nosNavigationBar("yourLists")
-        .sheet(item: $selectedList) { list in
-            EditAuthorListView(list: list)
-                .onDisappear {
-                    selectedList = nil
-                }
+        .sheet(item: $listToEditInfo) { list in
+            NavigationStack {
+                EditAuthorListView(list: list)
+                    .onDisappear {
+                        listToEditInfo = nil
+                    }
+            }
         }
         .sheet(isPresented: $showingCreateList) {
-            EditAuthorListView()
+            NavigationStack {
+                EditAuthorListView()
+            }
         }
     }
     

--- a/Nos/Views/Lists/AuthorListsView.swift
+++ b/Nos/Views/Lists/AuthorListsView.swift
@@ -13,6 +13,9 @@ struct AuthorListsView: View {
     
     @FetchRequest var lists: FetchedResults<AuthorList>
     
+    @State private var selectedList: AuthorList?
+    @State private var showingCreateList = false
+    
     init(author: Author) {
         self.author = author
         _lists = FetchRequest(fetchRequest: AuthorList.authorLists(ownedBy: author))
@@ -65,7 +68,7 @@ struct AuthorListsView: View {
                                     
                                     Menu {
                                         Button("editListInfo") {
-                                            // TODO: Edit List Info
+                                            selectedList = list
                                         }
                                         Button("manageUsers") {
                                             // TODO: Manage Users
@@ -77,9 +80,10 @@ struct AuthorListsView: View {
                                         Image(systemName: "ellipsis")
                                             .foregroundStyle(Color.secondaryTxt)
                                             .fontWeight(.bold)
+                                            .padding()
                                     }
                                 }
-                                .padding(.horizontal, 16)
+                                .padding(.leading, 16)
                                 .padding(.vertical, 12)
                                 .frame(minHeight: 50)
                                 
@@ -103,10 +107,19 @@ struct AuthorListsView: View {
             }
         }
         .nosNavigationBar("yourLists")
+        .sheet(item: $selectedList) { list in
+            EditAuthorListView(list: list)
+                .onDisappear {
+                    selectedList = nil
+                }
+        }
+        .sheet(isPresented: $showingCreateList) {
+            EditAuthorListView()
+        }
     }
     
     private func newButtonPressed() {
-        // TODO
+        showingCreateList = true
     }
 }
 

--- a/Nos/Views/Lists/EditAuthorListView.swift
+++ b/Nos/Views/Lists/EditAuthorListView.swift
@@ -1,0 +1,116 @@
+import Logger
+import SwiftUI
+
+struct EditAuthorListView: View {
+    enum Mode {
+        case create
+        case update
+    }
+    
+    enum Field: Hashable {
+        case title, description
+    }
+    
+    @Environment(\.dismiss) private var dismiss
+    @Environment(RelayService.self) private var relayService
+    @Environment(CurrentUser.self) private var currentUser
+    @Environment(\.managedObjectContext) private var viewContext
+    
+    let list: AuthorList?
+    
+    @State private var title: String = ""
+    @State private var description: String = ""
+    @FocusState private var focusedField: Field?
+    private let mode: Mode
+    
+    init(list: AuthorList? = nil) {
+        self.list = list
+        mode = list == nil ? .create : .update
+    }
+    
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                Color.appBg
+                    .ignoresSafeArea()
+                
+                VStack(alignment: .leading) {
+                    if mode == .create {
+                        Text("listStep1")
+                            .font(.clarity(.medium, textStyle: .subheadline))
+                            .foregroundColor(Color.secondaryTxt)
+                            .padding(EdgeInsets(top: 20, leading: 20, bottom: 0, trailing: 16))
+                    }
+                    
+                    NosForm {
+                        NosFormSection("listName") {
+                            NosTextField(text: $title)
+                                .padding(20)
+                                .focused($focusedField, equals: .title)
+                        }
+                        .padding(.top, 20)
+                        
+                        NosFormSection("description") {
+                            NosTextEditor(text: $description)
+                                .focused($focusedField, equals: .description)
+                                .padding()
+                                .frame(minHeight: 200, maxHeight: 250)
+                        }
+                        .padding(.top, 20)
+                    }
+                }
+            }
+            .nosNavigationBar(mode == .create ? "newList" : "editListInfo")
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Button("cancel") {
+                        dismiss()
+                    }
+                }
+                ToolbarItem(placement: .topBarTrailing) {
+                    ActionButton(mode == .create ? "next" : "save", action: saveButtonPressed)
+                        .frame(height: 22)
+                        .padding(.bottom, 3)
+                }
+            }
+            .onAppear {
+                title = list?.title ?? ""
+                description = list?.listDescription ?? ""
+                
+                focusedField = .title
+            }
+        }
+    }
+    
+    private func saveButtonPressed() {
+        guard !title.isEmpty else {
+            focusedField = .title
+            return
+        }
+        
+        guard let keyPair = currentUser.keyPair else {
+            return
+        }
+        
+        if mode == .update {
+            let event = JSONEvent.followSet(
+                pubKey: keyPair.publicKeyHex,
+                title: title,
+                description: description,
+                replaceableID: list?.replaceableIdentifier,
+                authorIDs: []
+            )
+            
+            Task {
+                do {
+                    try await relayService.publishToAll(event: event, signingKey: keyPair, context: viewContext)
+                    dismiss()
+                } catch {
+                    Log.error("Error when creating list: \(error.localizedDescription)")
+                }
+            }
+        } else {
+            // TODO: Manage Users
+        }
+    }
+}

--- a/Nos/Views/Lists/EditAuthorListView.swift
+++ b/Nos/Views/Lists/EditAuthorListView.swift
@@ -29,56 +29,54 @@ struct EditAuthorListView: View {
     }
     
     var body: some View {
-        NavigationStack {
-            ZStack {
-                Color.appBg
-                    .ignoresSafeArea()
+        ZStack {
+            Color.appBg
+                .ignoresSafeArea()
+            
+            VStack(alignment: .leading) {
+                if mode == .create {
+                    Text("listStep1")
+                        .font(.clarity(.medium, textStyle: .subheadline))
+                        .foregroundColor(Color.secondaryTxt)
+                        .padding(EdgeInsets(top: 20, leading: 20, bottom: 0, trailing: 16))
+                }
                 
-                VStack(alignment: .leading) {
-                    if mode == .create {
-                        Text("listStep1")
-                            .font(.clarity(.medium, textStyle: .subheadline))
-                            .foregroundColor(Color.secondaryTxt)
-                            .padding(EdgeInsets(top: 20, leading: 20, bottom: 0, trailing: 16))
+                NosForm {
+                    NosFormSection("listName") {
+                        NosTextField(text: $title)
+                            .padding(20)
+                            .focused($focusedField, equals: .title)
                     }
+                    .padding(.top, 20)
                     
-                    NosForm {
-                        NosFormSection("listName") {
-                            NosTextField(text: $title)
-                                .padding(20)
-                                .focused($focusedField, equals: .title)
-                        }
-                        .padding(.top, 20)
-                        
-                        NosFormSection("description") {
-                            NosTextEditor(text: $description)
-                                .focused($focusedField, equals: .description)
-                                .padding()
-                                .frame(minHeight: 200, maxHeight: 250)
-                        }
-                        .padding(.top, 20)
+                    NosFormSection("description") {
+                        NosTextEditor(text: $description)
+                            .focused($focusedField, equals: .description)
+                            .padding()
+                            .frame(minHeight: 200, maxHeight: 250)
                     }
+                    .padding(.top, 20)
                 }
             }
-            .nosNavigationBar(mode == .create ? "newList" : "editListInfo")
-            .toolbar {
-                ToolbarItem(placement: .topBarLeading) {
-                    Button("cancel") {
-                        dismiss()
-                    }
-                }
-                ToolbarItem(placement: .topBarTrailing) {
-                    ActionButton(mode == .create ? "next" : "save", action: saveButtonPressed)
-                        .frame(height: 22)
-                        .padding(.bottom, 3)
+        }
+        .nosNavigationBar(mode == .create ? "newList" : "editListInfo")
+        .toolbar {
+            ToolbarItem(placement: .topBarLeading) {
+                Button("cancel") {
+                    dismiss()
                 }
             }
-            .onAppear {
-                title = list?.title ?? ""
-                description = list?.listDescription ?? ""
-                
-                focusedField = .title
+            ToolbarItem(placement: .topBarTrailing) {
+                ActionButton(mode == .create ? "next" : "save", action: saveButtonPressed)
+                    .frame(height: 22)
+                    .padding(.bottom, 3)
             }
+        }
+        .onAppear {
+            title = list?.title ?? ""
+            description = list?.listDescription ?? ""
+            
+            focusedField = .title
         }
     }
     


### PR DESCRIPTION
## Issues covered
https://github.com/verse-pbc/issues/issues/134

## Description
Adds a view for editing the title and description of an AuthorList. This view can be used for simply editing those properties of an existing list or as the first step in a list-creation wizard (step 2 coming in a separate PR).

Note: There were also some intentional, very minor changes to the layout of the `NosForm`/`NosSection` components to match the lists design. This will make the same change everywhere they are used, such as on the edit profile view (see before/after below).

## How to test
Creating (only step 1 for this PR):
1. Open the side menu
2. Tap "Your Lists"
3. Tap "New" button at top right
4. Enter a name and description for the list.
Note: The "Next" button does nothing for now.

Updating:
1. Open the side menu
2. Tap "Your Lists"
3. Tap the ellipsis button on one of your lists
4. Edit the name and description
6. Tap the "Save" button at top right
Your changes are saved and the view is dismissed.

## Screenshots/Video
Creating:
![creating](https://github.com/user-attachments/assets/feeac640-52b1-4661-a551-2375a48beaf3)

Updating:
![updating](https://github.com/user-attachments/assets/a11c337e-273c-494a-832d-81c01f74bba9)

Minor layout changes to `NosForm`/`NosSection`:
| Before | After |
| --- | --- |
|<img width="340" alt="Bob_s_Phone" src="https://github.com/user-attachments/assets/854ae917-0059-4b5f-8611-56f1d0ec37c9" />|<img width="340" alt="Bob_s_Phone" src="https://github.com/user-attachments/assets/3d72934a-aaf5-4459-aad2-6c48edd4920c" />|

