### PR TITLE
Add breadcrumbs to Sentry for all analytics events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Localized strings on the feed filter drop-down view.
 - Disabled automatic tracking in Sentry. [#126](https://github.com/verse-pbc/issues/issues/126)
 - Track TestFlight vs AppStore installations in Posthog. [#130](https://github.com/verse-pbc/issues/issues/130)
+- Track breadcrumbs in Sentry for all analytics events. [#125](https://github.com/verse-pbc/issues/issues/125)
 
 ## [1.1] - 2025-01-03Z
 

--- a/Nos/Service/CrashReporting.swift
+++ b/Nos/Service/CrashReporting.swift
@@ -51,7 +51,17 @@ class CrashReporting {
         Log.error("Reporting error to Crash Reporting service: \(errorMessage)")
         sentry.capture(message: errorMessage)
     }
-    
+
+    /// Adds a breadcrumb for the given event name for tracking in our error reporting tool (Sentry).
+    /// - Parameter eventName: The event for which to add a breadcrumb.
+    func trackBreadcrumb(_ eventName: String) {
+        let crumb = Breadcrumb()
+        crumb.level = SentryLevel.info
+        crumb.category = "analytics"
+        crumb.message = eventName
+        SentrySDK.addBreadcrumb(crumb)
+    }
+
     func logout() {
         SentrySDK.setUser(nil)
     }


### PR DESCRIPTION
## Issues covered
https://github.com/verse-pbc/issues/issues/125

## Description
Adds breadcrumbs to Sentry whenever an analytics event happens.

## How to test
I'm really not sure. The app should keep working as it was before. But do these breadcrumbs show up in Sentry? I'm not sure how to find out. I think it would require us to create a crash or error since breadcrumbs only show up in those in Sentry; I don't think there's a separate view for them. But I could be wrong.

## Screenshots/Video
None