### PR TITLE
Track TestFlight vs AppStore installations in Posthog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added function for creating a new list and a test verifying list editing. [#112](https://github.com/verse-pbc/issues/issues/112)
 - Localized strings on the feed filter drop-down view.
 - Disabled automatic tracking in Sentry. [#126](https://github.com/verse-pbc/issues/issues/126)
+- Track TestFlight vs AppStore installations in Posthog. [#130](https://github.com/verse-pbc/issues/issues/130)
 
 ## [1.1] - 2025-01-03Z
 

--- a/Nos/AppController.swift
+++ b/Nos/AppController.swift
@@ -20,6 +20,7 @@ import Logger
     init() {
         currentState = .loading
         Log.info("App Version: \(Bundle.current.versionAndBuild)")
+        analytics.trackInstallationSourceIfNeeded()
     }
     
     func configureCurrentState() {

--- a/Nos/Extensions/Bundle+Current.swift
+++ b/Nos/Extensions/Bundle+Current.swift
@@ -27,6 +27,9 @@ extension Bundle {
         "\(self.version) (\(self.build))"
     }
 
+    /// > Warning: This method relies on undocumented implementation details to determine the installation source
+    /// and may break in future iOS releases.
+    /// https://gist.github.com/lukaskubanek/cbfcab29c0c93e0e9e0a16ab09586996
     /// Checks the app's receipt URL to determine if it contains the TestFlight-specific
     /// "sandboxReceipt" identifier.
     /// - Returns: `true` if the app was installed through TestFlight, `false` otherwise.

--- a/Nos/Extensions/Bundle+Current.swift
+++ b/Nos/Extensions/Bundle+Current.swift
@@ -39,11 +39,7 @@ extension Bundle {
     #if DEBUG
         return .debug
     #else
-        if isTestFlight {
-            return .testFlight
-        } else {
-            return .appStore
-        }
+        return isTestFlight ? .testFlight : .appStore
     #endif
     }
 }

--- a/Nos/Extensions/Bundle+Current.swift
+++ b/Nos/Extensions/Bundle+Current.swift
@@ -3,6 +3,11 @@ import Foundation
 private class CurrentBundle {}
 
 extension Bundle {
+    enum InstallationSource: String {
+        case testFlight = "TestFlight"
+        case appStore = "App Store"
+        case debug = "Debug"
+    }
 
     static let current = Bundle(for: CurrentBundle.self)
     
@@ -20,5 +25,25 @@ extension Bundle {
     /// formatted as 1.2.3 (123).
     var versionAndBuild: String {
         "\(self.version) (\(self.build))"
+    }
+
+    /// checks the app's receipt URL to determine if it contains the TestFlight-specific
+    /// "sandboxReceipt" identifier.
+    /// - Returns: `true` if the app was installed through TestFlight, `false` otherwise.
+    private var isTestFlight: Bool {
+        Bundle.main.appStoreReceiptURL?.lastPathComponent == "sandboxReceipt"
+    }
+
+    /// Returns the app's installation source: debug, TestFlight, or App Store.
+    var installationSource: InstallationSource {
+    #if DEBUG
+        return .debug
+    #else
+        if isTestFlight {
+            return .testFlight
+        } else {
+            return .appStore
+        }
+    #endif
     }
 }

--- a/Nos/Extensions/Bundle+Current.swift
+++ b/Nos/Extensions/Bundle+Current.swift
@@ -27,7 +27,7 @@ extension Bundle {
         "\(self.version) (\(self.build))"
     }
 
-    /// checks the app's receipt URL to determine if it contains the TestFlight-specific
+    /// Checks the app's receipt URL to determine if it contains the TestFlight-specific
     /// "sandboxReceipt" identifier.
     /// - Returns: `true` if the app was installed through TestFlight, `false` otherwise.
     private var isTestFlight: Bool {

--- a/Nos/Extensions/UIDevice+Simulator.swift
+++ b/Nos/Extensions/UIDevice+Simulator.swift
@@ -6,4 +6,12 @@ extension UIDevice {
     static var isSimulator: Bool {
         ProcessInfo.processInfo.environment["SIMULATOR_DEVICE_NAME"] != nil
     }
+
+    static var platformName: String {
+    #if os(iOS)
+        return UIDevice.current.systemName
+    #elseif os(macOS)
+        return "macOS"
+    #endif
+    }
 }

--- a/Nos/Service/Analytics.swift
+++ b/Nos/Service/Analytics.swift
@@ -155,6 +155,30 @@ class Analytics {
         postHog?.capture(eventName, properties: properties)
     }
 
+    /// Tracks the source of the app download when the user launches the app.
+    func trackInstallationSourceIfNeeded() {
+        let installSourceKey = "TrackedAppInstallationSource"
+        let source = Bundle.main.installationSource
+
+        // Make sure we don't track in debug mode.
+        guard source != .debug else { return }
+
+        // Check if we've already tracked this installation.
+        if UserDefaults.standard.bool(forKey: installSourceKey) {
+            return
+        }
+
+        track(
+            "Installation Source",
+            properties: [
+                "source": source.rawValue,
+                "App Version": Bundle.current.versionAndBuild
+            ]
+        )
+        // Mark as tracked so we don't track again
+        UserDefaults.standard.set(true, forKey: installSourceKey)
+    }
+
     /// Tracks when the user submits a search on the Discover screen.
     func searchedDiscover() {
         track("Discover Search Started")

--- a/Nos/Service/Analytics.swift
+++ b/Nos/Service/Analytics.swift
@@ -1,4 +1,4 @@
-import Foundation
+import UIKit
 import PostHog
 import Dependencies
 import Logger
@@ -172,7 +172,8 @@ class Analytics {
             "Installation Source",
             properties: [
                 "source": source.rawValue,
-                "App Version": Bundle.current.versionAndBuild
+                "platform": UIDevice.platformName,
+                "app_version": Bundle.current.versionAndBuild
             ]
         )
         // Mark as tracked so we don't track again

--- a/Nos/Service/Analytics.swift
+++ b/Nos/Service/Analytics.swift
@@ -157,11 +157,11 @@ class Analytics {
 
     /// Tracks the source of the app download when the user launches the app.
     func trackInstallationSourceIfNeeded() {
-        let installSourceKey = "TrackedAppInstallationSource"
         let source = Bundle.main.installationSource
-
         // Make sure we don't track in debug mode.
         guard source != .debug else { return }
+
+        let installSourceKey = "TrackedAppInstallationSource"
 
         // Check if we've already tracked this installation.
         if UserDefaults.standard.bool(forKey: installSourceKey) {


### PR DESCRIPTION
## Issues covered
[#130](https://github.com/verse-pbc/issues/issues/130)

## Description
This PR tries to track where the app running in the user's device is downloaded from. There is a link in the ticket that shows that the `appstoreReceiptUrl` can be used to differentiate `App Store` from `TestFlight`.

There were 2 tracking options: [Identify](https://posthog.com/docs/product-analytics/identify) and Capture. 

Though, Identify matches the user to a specific event across all devices, so no single user's download across various devices is tracked twice. 

I opted to use Capture instead because, if the user is not logged in, we won't be able to associate them with their unique id, which can be their npub in this case. It also defeats the purpose of getting the real number of downloads as it won't count a user that hasn't logged in yet. But it will include each download by a single user across multiple devices.

If we only want to get the number of downloads of people, I can update the tracking to use `identify` instead of `capture`.

## How to test
Merge and check if events shows up on Posthog after app is downloaded on TestFlight and App Store.
