### PR TITLE
fixed: while searching for users to add to a list, NIP-05 searches dismiss the view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added view for managing users in a list. [#135](https://github.com/verse-pbc/issues/issues/135)
 - Added ability to delete lists. [#136](https://github.com/verse-pbc/issues/issues/136)
 - Added analytics for feed source selection and lists. [#129](https://github.com/verse-pbc/issues/issues/129)
+- Fixed: while searching for users to add to a list, NIP-05 searches dismiss the view. [#165](https://github.com/verse-pbc/issues/issues/165)
 
 ### Internal Changes
 - Added function for creating a new list and a test verifying list editing. [#112](https://github.com/verse-pbc/issues/issues/112)

--- a/Nos/Controller/SearchController.swift
+++ b/Nos/Controller/SearchController.swift
@@ -49,7 +49,7 @@ enum SearchOrigin {
     
     /// Any and all authors in the search results. As of this writing, _only_ authors appear in search results,
     /// so this contains all search results, period.
-    var authorResults = [Author]()
+    private(set) var authorResults = [Author]()
 
     var state: SearchState = .noQuery
 
@@ -72,11 +72,15 @@ enum SearchOrigin {
 
     /// The origin of the current search.
     let searchOrigin: SearchOrigin
+    
+    /// If true, will automatically trigger routing to detail views for exact matches of NIP-05s, npubs, and note ids.
+    let routesMatchesAutomatically: Bool
 
     // MARK: - Init
     
-    init(searchOrigin: SearchOrigin = .discover) {
+    init(searchOrigin: SearchOrigin = .discover, routesMatchesAutomatically: Bool = true) {
         self.searchOrigin = searchOrigin
+        self.routesMatchesAutomatically = routesMatchesAutomatically
 
         queryPublisher
             .removeDuplicates()
@@ -255,17 +259,27 @@ enum SearchOrigin {
             Task(priority: .userInitiated) {
                 if let publicKeyHex = await relayService.retrievePublicKeyFromUsername(trimmedQuery) {
                     Task { @MainActor in
-                        analytics.displayedAuthorFromDiscoverSearch(resultsCount: 1)
-                        router.pushAuthor(id: publicKeyHex)
+                        if let author = try? Author.findOrCreate(by: publicKeyHex, context: context) {
+                            if routesMatchesAutomatically {
+                                analytics.displayedAuthorFromDiscoverSearch(resultsCount: 1)
+                                router.push(author)
+                            } else {
+                                authorResults = [author]
+                            }
+                        }
                     }
                 }
             }
         } else if let author = author(fromPublicKey: trimmedQuery) {
             Task { @MainActor in
-                analytics.displayedAuthorFromDiscoverSearch(resultsCount: 1)
-                router.push(author)
+                if routesMatchesAutomatically {
+                    analytics.displayedAuthorFromDiscoverSearch(resultsCount: 1)
+                    router.push(author)
+                } else {
+                    authorResults = [author]
+                }
             }
-        } else if let note = note(fromPublicKey: trimmedQuery) {
+        } else if routesMatchesAutomatically, let note = note(fromPublicKey: trimmedQuery) {
             Task { @MainActor in
                 analytics.displayedNoteFromDiscoverSearch()
                 router.push(note)

--- a/Nos/Views/Components/Author/AuthorSearchView.swift
+++ b/Nos/Views/Components/Author/AuthorSearchView.swift
@@ -30,6 +30,7 @@ struct AuthorSearchView<EmptyPlaceholder: View>: View {
         isModal: Bool,
         avatarOverlayMode: AvatarOverlayMode = .follows,
         relatedAuthors: [Author]? = nil,
+        routesMatchesAutomatically: Bool = true,
         @ViewBuilder emptyPlaceholder: @escaping () -> EmptyPlaceholder? = { nil },
         didSelectGesture: ((Author) -> Void)? = nil
     ) {
@@ -39,7 +40,12 @@ struct AuthorSearchView<EmptyPlaceholder: View>: View {
         self.relatedAuthors = relatedAuthors
         self.didSelectGesture = didSelectGesture
         self.emptyPlaceholder = emptyPlaceholder
-        _searchController = State(initialValue: SearchController(searchOrigin: searchOrigin))
+        _searchController = State(
+            initialValue: SearchController(
+                searchOrigin: searchOrigin,
+                routesMatchesAutomatically: routesMatchesAutomatically
+            )
+        )
     }
     
     var body: some View {

--- a/Nos/Views/Lists/AuthorListManageUsersView.swift
+++ b/Nos/Views/Lists/AuthorListManageUsersView.swift
@@ -64,6 +64,7 @@ struct AuthorListManageUsersView: View {
                     searchOrigin: .lists,
                     isModal: false,
                     avatarOverlayMode: .inSet(authors: authors),
+                    routesMatchesAutomatically: false,
                     emptyPlaceholder: {
                         AuthorsView(
                             authors: Array(authors),


### PR DESCRIPTION
## Issues covered
https://github.com/verse-pbc/issues/issues/165

## Description
Fixes the issue where searching for NIP-05s or npubs in the context of managing users in a list causes the search to be dismissed.

## How to test
1. Navigate to the side menu
2. Tap on Your Lists
3. Tap on a list
4. Tap the ellipsis button
5. Tap Manage Users
6. Search for an npub or a NIP-05 username

## Screenshots/Video

| Before | After |
|--------|--------|
|![bug](https://github.com/user-attachments/assets/69da66c6-6c0d-4b55-a3e5-b84235c34772)|![lists](https://github.com/user-attachments/assets/1e7e07b7-f6e5-4cd3-9a67-83c98d133a8f)|

Regression check: Discover still behaves as expected
![discover](https://github.com/user-attachments/assets/cc1e2cb7-142f-4939-8adf-42c1a6941c11)
