### PR TITLE
fixed: tapping a user on a list causes a crash #172

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed: while searching for users to add to a list, NIP-05 searches dismiss the view. [#165](https://github.com/verse-pbc/issues/issues/165)
 - Fixed a performance issue that could occur after switching tabs. [#171](https://github.com/verse-pbc/issues/issues/171)
 - Fixed a crash when processing a malformed delete (kind 5) event. [#170](https://github.com/verse-pbc/issues/issues/170)
+- Fixed: tapping a user on a list causes a crash. [#172](https://github.com/verse-pbc/issues/issues/172)
 
 ### Internal Changes
 - Added function for creating a new list and a test verifying list editing. [#112](https://github.com/verse-pbc/issues/issues/112)

--- a/Nos/Models/NosNavigationDestination.swift
+++ b/Nos/Models/NosNavigationDestination.swift
@@ -4,6 +4,7 @@ import Foundation
 enum NosNavigationDestination: Hashable {
     case note(NoteIdentifiable)
     case author(RawAuthorID?)
+    case list(AuthorList)
     case url(URL)
     case replyTo(RawEventID?)
 }

--- a/Nos/Router.swift
+++ b/Nos/Router.swift
@@ -118,6 +118,10 @@ import Dependencies
         }
     }
     
+    func pushList(_ list: AuthorList) {
+        push(.list(list))
+    }
+    
     /// Pushes a web view for the given url.
     func push(_ url: URL) {
         push(.url(url))

--- a/Nos/Views/Components/NosNavigationStack.swift
+++ b/Nos/Views/Components/NosNavigationStack.swift
@@ -31,6 +31,8 @@ struct NosNavigationStack<Content: View>: View {
                         AuthorObservationView(authorID: authorID) { author in
                             ProfileView(author: author)
                         }
+                    case .list(let list):
+                        AuthorListDetailView(list: list)
                     case .url(let url):
                         URLView(url: url)
                     case .replyTo(let eventID):

--- a/Nos/Views/Lists/AuthorListDetailView.swift
+++ b/Nos/Views/Lists/AuthorListDetailView.swift
@@ -42,27 +42,28 @@ struct AuthorListDetailView: View {
             
             LazyVStack {
                 ForEach(list.allAuthors.sorted(by: { ($0.displayName ?? "") < ($1.displayName ?? "") })) { author in
-                    NavigationLink {
-                        ProfileView(author: author)
-                    } label: {
-                        AuthorObservationView(authorID: author.hexadecimalPublicKey) { author in
-                            AuthorCard(author: author, avatarOverlayView: { EmptyView() })
-                                .padding(.horizontal, 13)
-                                .padding(.top, 5)
-                                .readabilityPadding()
-                                .task {
-                                    subscriptions[author.id] =
-                                    await relayService.requestMetadata(
-                                        for: author.hexadecimalPublicKey,
-                                        since: author.lastUpdatedMetadata
-                                    )
-                                }
-                                .disabled(true) // skips the onTap action in AuthorCard
+                    AuthorObservationView(authorID: author.hexadecimalPublicKey) { author in
+                        AuthorCard(
+                            author: author,
+                            avatarOverlayView: { EmptyView() },
+                            onTap: {
+                                router.push(author)
+                            }
+                        )
+                        .padding(.horizontal, 13)
+                        .padding(.top, 5)
+                        .readabilityPadding()
+                        .task {
+                            subscriptions[author.id] =
+                            await relayService.requestMetadata(
+                                for: author.hexadecimalPublicKey,
+                                since: author.lastUpdatedMetadata
+                            )
                         }
                     }
                 }
+                .padding(.vertical, 12)
             }
-            .padding(.vertical, 12)
         }
         .nosNavigationBar("")
         .background(Color.appBg)

--- a/Nos/Views/Lists/AuthorListsView.swift
+++ b/Nos/Views/Lists/AuthorListsView.swift
@@ -8,6 +8,7 @@ struct ListsDestination: Hashable {
 /// A view that displays a list of an ``Author``'s ``AuthorList``s.
 struct AuthorListsView: View {
     
+    @EnvironmentObject private var router: Router
     let author: Author
     
     @FetchRequest var lists: FetchedResults<AuthorList>
@@ -41,25 +42,24 @@ struct AuthorListsView: View {
                     ScrollView {
                         VStack(spacing: 0) {
                             ForEach(lists) { list in
-                                NavigationLink {
-                                    AuthorListDetailView(list: list)
-                                } label: {
-                                    HStack {
-                                        VStack(alignment: .leading) {
-                                            Text(list.title ?? "")
-                                                .font(.body)
-                                            
-                                            Text(list.rowDescription)
-                                                .foregroundStyle(Color.secondaryTxt)
-                                                .font(.footnote)
-                                                .lineLimit(1)
-                                        }
+                                HStack {
+                                    VStack(alignment: .leading) {
+                                        Text(list.title ?? "")
+                                            .font(.body)
                                         
-                                        Spacer()
+                                        Text(list.rowDescription)
+                                            .foregroundStyle(Color.secondaryTxt)
+                                            .font(.footnote)
+                                            .lineLimit(1)
                                     }
-                                    .padding(.leading, 16)
-                                    .padding(.vertical, 12)
-                                    .frame(minHeight: 50)
+                                    
+                                    Spacer()
+                                }
+                                .padding(.leading, 16)
+                                .padding(.vertical, 12)
+                                .frame(minHeight: 50)
+                                .onTapGesture {
+                                    router.pushList(list)
                                 }
                                 
                                 BeveledSeparator()


### PR DESCRIPTION
## Issues covered
https://github.com/verse-pbc/issues/issues/172

## Description
Fixes an issue where the app would crash when you tap a user on a list view.

This happened because I originally chose to use `NavigationLink` rather than `Router` to push views. Moving to `Router` fixed it.

## How to test
1. Navigate to the Manage Lists screen
2. Tap a list to view its detail view
3. Tap a profile

## Screenshots/Video

| Before | After |
|--------|--------|
|![broken](https://github.com/user-attachments/assets/6141d936-538d-4c94-a383-f978781d7eff)|![fixed](https://github.com/user-attachments/assets/960729fd-1351-49e1-8895-16ed4da7a62d)|
