### PR TITLE
Style the empty lists drawer to match Figma

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed: while searching for users to add to a list, NIP-05 searches dismiss the view. [#165](https://github.com/verse-pbc/issues/issues/165)
 - Fixed a crash when processing a malformed delete (kind 5) event. [#170](https://github.com/verse-pbc/issues/issues/170)
 - Fixed: tapping a user on a list causes a crash. [#172](https://github.com/verse-pbc/issues/issues/172)
+- Removed link to Listr.lol when list is empty.
 
 ### Internal Changes
 - Added function for creating a new list and a test verifying list editing. [#112](https://github.com/verse-pbc/issues/issues/112)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed: while searching for users to add to a list, NIP-05 searches dismiss the view. [#165](https://github.com/verse-pbc/issues/issues/165)
 - Fixed a crash when processing a malformed delete (kind 5) event. [#170](https://github.com/verse-pbc/issues/issues/170)
 - Fixed: tapping a user on a list causes a crash. [#172](https://github.com/verse-pbc/issues/issues/172)
-- Removed link to Listr.lol when list is empty.
+- Removed link to Listr.lol when list is empty. [#176](https://github.com/verse-pbc/issues/issues/176)
 
 ### Internal Changes
 - Added function for creating a new list and a test verifying list editing. [#112](https://github.com/verse-pbc/issues/issues/112)

--- a/Nos/Assets/Localization/Localizable.xcstrings
+++ b/Nos/Assets/Localization/Localizable.xcstrings
@@ -4371,6 +4371,17 @@
         }
       }
     },
+    "createYourFirstList" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Create your first list"
+          }
+        }
+      }
+    },
     "dayAbbreviated" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -12552,7 +12563,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "It doesn’t look like you have created any lists."
+            "value" : "It doesn’t look like you have created any lists. Add lists to your feed to filter by topic."
           }
         }
       }
@@ -14194,7 +14205,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Your **@username** is your identity in the Nos community.\u2028\nChoose a name that reflects you or your organization. Make it memorable and distinct!"
+            "value" : "Your **@username** is your identity in the Nos community. \nChoose a name that reflects you or your organization. Make it memorable and distinct!"
           }
         },
         "es" : {
@@ -19452,7 +19463,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Well done, you've successfully claimed your **@username**!\u2028\nYou can share this name with other people in the Nostr and Fediverse communities to make it easy to find you."
+            "value" : "Well done, you've successfully claimed your **@username**! \nYou can share this name with other people in the Nostr and Fediverse communities to make it easy to find you."
           }
         },
         "es" : {

--- a/Nos/Views/Home/FeedCustomizerView.swift
+++ b/Nos/Views/Home/FeedCustomizerView.swift
@@ -56,20 +56,7 @@ struct FeedCustomizerView: View {
                     items: feedController.listRowItems,
                     footer: {
                         Group {
-                            if feedController.listRowItems.isEmpty {
-                                Group {
-                                    Text("Create your own lists on ") +
-                                    Text("Listr ")
-                                        .foregroundStyle(Color.accent) +
-                                    Text(Image(systemName: "link"))
-                                        .foregroundStyle(Color.accent)
-                                }
-                                .onTapGesture {
-                                    if let url = URL(string: "https://listr.lol/feed") {
-                                        UIApplication.shared.open(url)
-                                    }
-                                }
-                            } else {
+                            if !feedController.listRowItems.isEmpty {
                                 SecondaryActionButton(
                                     "manageYourLists",
                                     font: .clarity(.semibold, textStyle: .footnote),
@@ -83,7 +70,19 @@ struct FeedCustomizerView: View {
                         .padding()
                     },
                     noContent: {
-                        Text("noLists")
+                        VStack(spacing: 28) {
+                            Text("noLists")
+                                .font(.clarity(.medium))
+                                .multilineTextAlignment(.center)
+                            SecondaryActionButton(
+                                "createYourFirstList",
+                                font: .clarity(.semibold, textStyle: .footnote)
+                            ) {
+                                analytics.feedCustomizerClosed()
+                                shouldNavigateToLists = true
+                            }
+                        }
+                        .padding(24)
                     }
                 )
             } else {


### PR DESCRIPTION
## Issues covered
https://github.com/verse-pbc/issues/issues/176

## Description
This is a quick update to the feed selector drawer so that it doesn't link to list.lol when the user doesn't have any lists.

## How to test
1. Log into an account with no lists
2. Tap the feed selector button in the top right of the home feed

## Screenshots/Video

| Before | After |
|--------|--------|
|  ![Simulator Screenshot - iPhone 16 for real - 2025-01-31 at 13 55 48](https://github.com/user-attachments/assets/ef3a9134-c764-496f-906c-3e76f46d844f)|![Simulator Screenshot - iPhone 16 for real - 2025-01-31 at 14 18 27](https://github.com/user-attachments/assets/50ba12c0-f1fc-449e-81a1-ca3a57b08f82) |
