### PR TITLE
Add a @State date to the ProfileView that we use when refreshing auth…

### DIFF
--- a/Nos/Views/Profile/ProfileView.swift
+++ b/Nos/Views/Profile/ProfileView.swift
@@ -50,7 +50,7 @@ struct ProfileView: View {
         
         // Profile data
         // We use our own local date for fetching contact lists and follow sets, because we want to refresh them 
-        // when the page is opened, especially because a lot of contact list data gets purged during the DatabaseCleaner 
+        // when the page is opened, especially because a lot of contact list data gets purged during the DatabaseCleaner
         // routine, but we don't want to end up in an infinite loop like in
         // [#175](https://github.com/verse-pbc/issues/issues/175)
         relaySubscriptions.append(

--- a/Nos/Views/Profile/ProfileView.swift
+++ b/Nos/Views/Profile/ProfileView.swift
@@ -19,6 +19,9 @@ struct ProfileView: View {
     @State private var showingOptions = false
     @State private var showingReportMenu = false
     @State private var relaySubscriptions = SubscriptionCancellables()
+    
+    /// Keep track of the last time we downloaded Author data so we don't do it too much.
+    @State private var lastDownloadedAuthorData: Date?
 
     @State private var selectedTab: ProfileFeedType = .notes
 
@@ -46,12 +49,16 @@ struct ProfileView: View {
         }
         
         // Profile data
+        // We use our own local date for fetching contact lists and follow sets, because we want to refresh them 
+        // when the page is opened, especially because a lot of contact list data gets purged during the DatabaseCleaner 
+        // routine, but we don't want to end up in an infinite loop like in
+        // [#175](https://github.com/verse-pbc/issues/issues/175)
         relaySubscriptions.append(
             await relayService.requestProfileData(
                 for: authorKey, 
                 lastUpdateMetadata: author.lastUpdatedMetadata, 
-                lastUpdatedContactList: nil, // always grab contact list because we purge follows aggressively
-                lastUpdatedFollowSets: nil // TODO: consider how we want to do this
+                lastUpdatedContactList: lastDownloadedAuthorData, 
+                lastUpdatedFollowSets: lastDownloadedAuthorData
             )
         )
         
@@ -59,11 +66,13 @@ struct ProfileView: View {
         let reportFilter = Filter(
             kinds: [.report],
             pTags: [authorKey],
+            since: lastDownloadedAuthorData,
             keepSubscriptionOpen: true
         )
         relaySubscriptions.append(
             await relayService.fetchEvents(matching: reportFilter)
         )
+        lastDownloadedAuthorData = .now
     }
 
     private var title: AttributedString {
@@ -189,9 +198,12 @@ struct ProfileView: View {
                 }
         )
         .alert(unwrapping: $alert)
-        .task { 
+        .task {
             await downloadAuthorData()
         }
+        .onChange(of: refreshController.lastRefreshDate, { _, _ in
+            Task { await downloadAuthorData() }
+        })
     }
     
     var noteListView: some View {


### PR DESCRIPTION
## Issues covered
Continuing the saga on https://github.com/verse-pbc/issues/issues/171 and https://github.com/verse-pbc/issues/issues/175

## Description
I caught the infinite loop in the debugger again on `c1c2bc54d`. I confirmed my hunch described in [#1748](https://github.com/planetary-social/nos/pull/1748) that the `ProfileView.downloadAuthorData()` function was downloading author data and triggering a refresh of the `ProfileView,` triggering another download of author data, creating an infinite loop.

This time my attempt at a fix is to keep track of a `lastDownloadedAuthorData` in `@State`. This date is nil when the view is first shown, which ensures that we grab the latest contact list every time. But after that we only look for newer data since the last fetch.

I also fixed an issue where the author metadata wasn't being re-fetched on pull-to-refresh.

## How to test
🤷‍♂️ at this point I would say just make sure the profile view seems to fetch data correctly. And keep an eye on the logs for the parse queue growing indefinitely.