### PR TITLE
fixed: lists change positions randomly #183

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed: tapping a user on a list causes a crash. [#172](https://github.com/verse-pbc/issues/issues/172)
 - Removed link to Listr.lol when list is empty. [#176](https://github.com/verse-pbc/issues/issues/176)
 - Fixed: text fields sometimes don't work on onboarding screens. [#178](https://github.com/verse-pbc/issues/issues/178)
+- Fixed: lists change positions randomly. [#183](https://github.com/verse-pbc/issues/issues/183)
 
 ### Internal Changes
 - Added function for creating a new list and a test verifying list editing. [#112](https://github.com/verse-pbc/issues/issues/112)

--- a/Nos/Controller/FeedController.swift
+++ b/Nos/Controller/FeedController.swift
@@ -82,11 +82,7 @@ import SwiftUI
             .publisher
             .receive(on: DispatchQueue.main)
             .sink(receiveValue: { [weak self] lists in
-                // ensure that we only publish the most recent list for each replaceable identifier
-                let grouped = Dictionary(grouping: lists, by: { $0.replaceableIdentifier ?? "" })
-                self?.lists = grouped.compactMap { _, events in
-                    events.max(by: { $0.createdAt ?? Date.distantPast < $1.createdAt ?? Date.distantPast })
-                }
+                self?.lists = lists
             })
             .store(in: &cancellables)
     }


### PR DESCRIPTION
## Issues covered
https://github.com/verse-pbc/issues/issues/183

## Description
Fixes the issue where lists change order randomly.

## Steps to Reproduce
1. Navigate to the Feed tab
2. Tap the feed customizer button at top-right
3. Note the order of the lists
4. Quit and relaunch the app
5. Repeat steps 1-4 to see if the order changed

## Videos

In the before video, you can see that the order of lists is different each time I launch the app. In the after video, the order is always the same.
| Before | After |
| --- | --- |
|![before](https://github.com/user-attachments/assets/72654629-32b9-4d29-bf65-33dd2159936a)|![after](https://github.com/user-attachments/assets/331923a6-7b12-4747-8806-41d315a5303a)| 

