### PR TITLE
Fix main action button is not visible on iPad on "Build Your Network" onboarding screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed: tapping a user on a list causes a crash. [#172](https://github.com/verse-pbc/issues/issues/172)
 - Removed link to Listr.lol when list is empty. [#176](https://github.com/verse-pbc/issues/issues/176)
 - Fixed: text fields sometimes don't work on onboarding screens. [#178](https://github.com/verse-pbc/issues/issues/178)
+- Fixed main action button is not visible on iPad on "Build Your Network" onboarding screen. [#184](https://github.com/verse-pbc/issues/issues/184)
 
 ### Internal Changes
 - Added function for creating a new list and a test verifying list editing. [#112](https://github.com/verse-pbc/issues/issues/112)

--- a/Nos/Views/Onboarding/BuildYourNetworkView.swift
+++ b/Nos/Views/Onboarding/BuildYourNetworkView.swift
@@ -12,33 +12,35 @@ struct BuildYourNetworkView: View {
         ZStack {
             Color.appBg
                 .ignoresSafeArea()
-            ViewThatFits(in: .vertical) {
                 buildYourNetworkStack
-
-                ScrollView {
-                    buildYourNetworkStack
-                }
-            }
         }
         .navigationBarHidden(true)
     }
 
     var buildYourNetworkStack: some View {
-        VStack(alignment: .leading, spacing: 20) {
-            Text("🔍")
-                .font(.system(size: 60))
-            Text("buildYourNetwork")
-                .font(.clarityBold(.title))
-                .foregroundStyle(Color.primaryTxt)
-                .fixedSize(horizontal: false, vertical: true)
-            Text("buildYourNetworkDescription")
-                .foregroundStyle(Color.secondaryTxt)
-                .fixedSize(horizontal: false, vertical: true)
+        VStack {
+            VStack(alignment: .leading, spacing: 20) {
+                Text("🔍")
+                    .font(.system(size: 60))
+                Text("buildYourNetwork")
+                    .font(.clarityBold(.title))
+                    .foregroundStyle(Color.primaryTxt)
+                    .fixedSize(horizontal: false, vertical: true)
+                Text("buildYourNetworkDescription")
+                    .foregroundStyle(Color.secondaryTxt)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            Spacer()
+
             Image.network
                 .resizable()
                 .aspectRatio(contentMode: .fit)
+                .frame(maxWidth: .infinity)
                 .padding(.horizontal, -padding)
-            Spacer()
+
+            Spacer(minLength: padding)
+
             BigActionButton("findPeople") { @MainActor in
                 completion()
             }


### PR DESCRIPTION
## Issues covered
[#184](https://github.com/verse-pbc/issues/issues/184)

## Description
This PR fixes an issue where the main action button is not visible on iPad on "Build Your Network" onboarding screen.

I removed the scrollview and rearranged the view, making the spacing between the stacked text above, the image and the bottom to be dynamic using a Spacer. I also added a maxWidth to the image to make it expand accordingly with different screen sizes.

## How to test
1. Build the app.
2. Log out if you are logged in and try to create a new account.
3. When you get to the "Build Your Network" screen, please check that you don't have to scroll to see the button on this screen.

## Screenshots/Video

| Before | After |
|--------|-------|
| <img src="https://github.com/user-attachments/assets/b9df7bb4-1d7f-4290-a57a-e4178d9d1e10" alt="Before" width="250"/> | <img src="https://github.com/user-attachments/assets/46838b91-b23c-4497-a740-da3a3982eed7" alt="After" width="250"/> |
|--------|-------|
| <img src="https://github.com/user-attachments/assets/8e940a50-100b-4776-9a90-b1c3a4973380" alt="Before" width="250"/> | <img src="https://github.com/user-attachments/assets/a2e55015-ce33-4299-b119-2115dbf4628c" alt="After" width="250"/> |
