### PR TITLE
Fix main action button is not visible on iPad on "Build Your Network" onboarding screen in release/1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed: tapping a user on a list causes a crash. [#172](https://github.com/verse-pbc/issues/issues/172)
 - Removed link to Listr.lol when list is empty. [#176](https://github.com/verse-pbc/issues/issues/176)
 - Fixed: text fields sometimes don't work on onboarding screens. [#178](https://github.com/verse-pbc/issues/issues/178)
+- Fixed main action button is not visible on iPad on "Build Your Network" onboarding screen. [#184](https://github.com/verse-pbc/issues/issues/184)
 
 ### Internal Changes
 - Added function for creating a new list and a test verifying list editing. [#112](https://github.com/verse-pbc/issues/issues/112)

--- a/Nos/Views/Onboarding/BuildYourNetworkView.swift
+++ b/Nos/Views/Onboarding/BuildYourNetworkView.swift
@@ -12,33 +12,35 @@ struct BuildYourNetworkView: View {
         ZStack {
             Color.appBg
                 .ignoresSafeArea()
-            ViewThatFits(in: .vertical) {
                 buildYourNetworkStack
-
-                ScrollView {
-                    buildYourNetworkStack
-                }
-            }
         }
         .navigationBarHidden(true)
     }
 
     var buildYourNetworkStack: some View {
-        VStack(alignment: .leading, spacing: 20) {
-            Text("🔍")
-                .font(.system(size: 60))
-            Text("buildYourNetwork")
-                .font(.clarityBold(.title))
-                .foregroundStyle(Color.primaryTxt)
-                .fixedSize(horizontal: false, vertical: true)
-            Text("buildYourNetworkDescription")
-                .foregroundStyle(Color.secondaryTxt)
-                .fixedSize(horizontal: false, vertical: true)
+        VStack {
+            VStack(alignment: .leading, spacing: 20) {
+                Text("🔍")
+                    .font(.system(size: 60))
+                Text("buildYourNetwork")
+                    .font(.clarityBold(.title))
+                    .foregroundStyle(Color.primaryTxt)
+                    .fixedSize(horizontal: false, vertical: true)
+                Text("buildYourNetworkDescription")
+                    .foregroundStyle(Color.secondaryTxt)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            Spacer()
+
             Image.network
                 .resizable()
                 .aspectRatio(contentMode: .fit)
+                .frame(maxWidth: .infinity)
                 .padding(.horizontal, -padding)
-            Spacer()
+
+            Spacer(minLength: padding)
+
             BigActionButton("findPeople") { @MainActor in
                 completion()
             }


### PR DESCRIPTION
Fix main action button is not visible on iPad on "Build Your Network" onboarding screen

Already merged to main: #1757 