### PR TITLE
fixed: on your lists view, the entire cell is not tappable #179

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed: text fields sometimes don't work on onboarding screens. [#178](https://github.com/verse-pbc/issues/issues/178)
 - Fixed: lists change positions randomly. [#183](https://github.com/verse-pbc/issues/issues/183)
 - Fixed main action button is not visible on iPad on "Build Your Network" onboarding screen. [#184](https://github.com/verse-pbc/issues/issues/184)
+- Fixed: on your lists view, the entire cell is not tappable. [#179](https://github.com/verse-pbc/issues/issues/179) 
 
 ### Internal Changes
 - Added function for creating a new list and a test verifying list editing. [#112](https://github.com/verse-pbc/issues/issues/112)

--- a/Nos/Views/Lists/AuthorListsView.swift
+++ b/Nos/Views/Lists/AuthorListsView.swift
@@ -42,24 +42,25 @@ struct AuthorListsView: View {
                     ScrollView {
                         VStack(spacing: 0) {
                             ForEach(lists) { list in
-                                HStack {
-                                    VStack(alignment: .leading) {
-                                        Text(list.title ?? "")
-                                            .font(.body)
-                                        
-                                        Text(list.rowDescription)
-                                            .foregroundStyle(Color.secondaryTxt)
-                                            .font(.footnote)
-                                            .lineLimit(1)
-                                    }
-                                    
-                                    Spacer()
-                                }
-                                .padding(.leading, 16)
-                                .padding(.vertical, 12)
-                                .frame(minHeight: 50)
-                                .onTapGesture {
+                                Button {
                                     router.pushList(list)
+                                } label: {
+                                    HStack {
+                                        VStack(alignment: .leading) {
+                                            Text(list.title ?? "")
+                                                .font(.body)
+                                            
+                                            Text(list.rowDescription)
+                                                .foregroundStyle(Color.secondaryTxt)
+                                                .font(.footnote)
+                                                .lineLimit(1)
+                                        }
+                                        
+                                        Spacer()
+                                    }
+                                    .padding(.leading, 16)
+                                    .padding(.vertical, 12)
+                                    .frame(minHeight: 50)
                                 }
                                 
                                 BeveledSeparator()


### PR DESCRIPTION
## Issues covered
https://github.com/verse-pbc/issues/issues/179

## Description
Fixes the issue where the whole cell is not tappable, but only the text of the title and description itself.

## How to test
1. Navigate to Your Lists view.
2. Tap in the empty space to the right of the title and description of one of your lists.

## Screenshots/Video

| Before | After |
|--------|--------|
|![before](https://github.com/user-attachments/assets/ea85a08b-16e0-444a-a38b-f74d3162c1a6)|![after](https://github.com/user-attachments/assets/cb774d99-3ee4-40fe-bc43-0b44495d9294)|

