### PR TITLE
perf: RepliesLabel, AuthorLabel, NoteCardHeader, Date+Elapsed #215

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Release Notes
+- Performance improvements for RepliesLabel, AuthorLabel, NoteCardHeader, Date+Elapsed
+
+### Internal Changes
+
 ## [1.2.1] - 2025-02-19Z
 
 ### Release Notes

--- a/Nos/Extensions/Date+Elapsed.swift
+++ b/Nos/Extensions/Date+Elapsed.swift
@@ -15,6 +15,9 @@ fileprivate final class DateFormatters {
         return dateComponentsFormatter
     }()
     
+    /// A formatter to use for month-day-year format.
+    /// - Parameter calendar: A calendar used to inform the formatter's style.
+    /// - Returns: A date formatter that produces outputs like "Aug 9, 2024".
     func longDateFormatter(forCalendar calendar: Calendar) -> DateFormatter {
         let cacheKey = "long-\(calendar.locale?.identifier ?? "")-\(calendar.timeZone.identifier)"
         if let formatter = formatterCache[cacheKey] {
@@ -31,6 +34,9 @@ fileprivate final class DateFormatters {
         }
     }
     
+    /// A formatter to use for month-day format.
+    /// - Parameter calendar: A calendar used to inform the formatter's style.
+    /// - Returns: A date formatter that produces outputs like "Aug 9".
     func monthDayFormatter(forCalendar calendar: Calendar) -> DateFormatter {
         let cacheKey = "monthDay-\(calendar.locale?.identifier ?? "")-\(calendar.timeZone.identifier)"
         if let formatter = formatterCache[cacheKey] {
@@ -84,7 +90,12 @@ extension Date {
     ///   - calendar: The calendar to use when formatting the human-readable string
     /// - Returns:.The localized human-readable string of this date relative to the end date.
     func distanceString(_ endDate: Date = Date.now, calendar: Calendar = Calendar.current) -> String {
-        let components = (calendar as NSCalendar).components(DateFormatters.unitFlags, from: self, to: endDate, options: [])
+        let components = (calendar as NSCalendar).components(
+            DateFormatters.unitFlags,
+            from: self,
+            to: endDate,
+            options: []
+        )
 
         if let year = components.year, year >= 1 {
             return formatLongDate(calendar)

--- a/Nos/Extensions/Date+Elapsed.swift
+++ b/Nos/Extensions/Date+Elapsed.swift
@@ -1,5 +1,57 @@
 import Foundation
 
+fileprivate final class DateFormatters {
+    static let shared = DateFormatters()
+    
+    static let unitFlags: NSCalendar.Unit = [.minute, .hour, .day, .weekOfMonth, .year]
+    
+    private var formatterCache = [String: DateFormatter]()
+    
+    lazy var dateComponentsFormatter: DateComponentsFormatter = {
+        let dateComponentsFormatter = DateComponentsFormatter()
+        dateComponentsFormatter.unitsStyle = .abbreviated
+        dateComponentsFormatter.maximumUnitCount = 1
+        dateComponentsFormatter.allowedUnits = DateFormatters.unitFlags
+        return dateComponentsFormatter
+    }()
+    
+    func longDateFormatter(forCalendar calendar: Calendar) -> DateFormatter {
+        let cacheKey = "long-\(calendar.locale?.identifier ?? "")-\(calendar.timeZone.identifier)"
+        if let formatter = formatterCache[cacheKey] {
+            return formatter
+        } else {
+            let formatter = DateFormatter()
+            formatter.timeStyle = .none
+            formatter.dateStyle = .medium
+            formatter.calendar = calendar
+            formatter.locale = calendar.locale
+            formatter.timeZone = calendar.timeZone
+            formatterCache[cacheKey] = formatter
+            return formatter
+        }
+    }
+    
+    func monthDayFormatter(forCalendar calendar: Calendar) -> DateFormatter {
+        let cacheKey = "monthDay-\(calendar.locale?.identifier ?? "")-\(calendar.timeZone.identifier)"
+        if let formatter = formatterCache[cacheKey] {
+            return formatter
+        } else {
+            let formatter = DateFormatter()
+            formatter.timeStyle = .none
+            formatter.dateFormat = DateFormatter.dateFormat(
+                fromTemplate: "MMM d",
+                options: 0,
+                locale: calendar.locale
+            )
+            formatter.calendar = calendar
+            formatter.locale = calendar.locale
+            formatter.timeZone = calendar.timeZone
+            formatterCache[cacheKey] = formatter
+            return formatter
+        }
+    }
+}
+
 extension Date {
 
     /// Formats the date into a localized human-readable string, relative to a given end date and calendar.
@@ -32,47 +84,31 @@ extension Date {
     ///   - calendar: The calendar to use when formatting the human-readable string
     /// - Returns:.The localized human-readable string of this date relative to the end date.
     func distanceString(_ endDate: Date = Date.now, calendar: Calendar = Calendar.current) -> String {
-        let unitFlags: NSCalendar.Unit = [.minute, .hour, .day, .weekOfMonth, .year]
-
-        let components = (calendar as NSCalendar).components(unitFlags, from: self, to: endDate, options: [])
+        let components = (calendar as NSCalendar).components(DateFormatters.unitFlags, from: self, to: endDate, options: [])
 
         if let year = components.year, year >= 1 {
             return formatLongDate(calendar)
         }
 
         if let week = components.weekOfMonth, week >= 1 {
-            let dateFormatter = DateFormatter()
-            dateFormatter.timeStyle = .none
-            dateFormatter.dateFormat = DateFormatter.dateFormat(
-                fromTemplate: "MMM d",
-                options: 0,
-                locale: calendar.locale
-            )
-            dateFormatter.calendar = calendar
-            dateFormatter.locale = calendar.locale
-            dateFormatter.timeZone = calendar.timeZone
-            return dateFormatter.string(from: self)
+            let formatter = DateFormatters.shared.monthDayFormatter(forCalendar: calendar)
+            return formatter.string(from: self)
         }
 
-        let dateComponentsFormatter = DateComponentsFormatter()
-        dateComponentsFormatter.unitsStyle = .abbreviated
-        dateComponentsFormatter.maximumUnitCount = 1
-        dateComponentsFormatter.allowedUnits = unitFlags
-
         if let day = components.day, day >= 1, let formattedDate =
-            dateComponentsFormatter.string(from: DateComponents(calendar: calendar, day: day)) {
+            DateFormatters.shared.dateComponentsFormatter.string(from: DateComponents(calendar: calendar, day: day)) {
             return formattedDate
         }
 
         if let hour = components.hour, hour >= 1, let formattedDate =
-            dateComponentsFormatter.string(from: DateComponents(calendar: calendar, hour: hour)) {
+            DateFormatters.shared.dateComponentsFormatter.string(from: DateComponents(calendar: calendar, hour: hour)) {
             return formattedDate
         }
 
         if let minute = components.minute {
             if minute >= 1 {
                 let dateComponents = DateComponents(calendar: calendar, minute: max(1, minute))
-                if let formattedDate = dateComponentsFormatter.string(from: dateComponents) {
+                if let formattedDate = DateFormatters.shared.dateComponentsFormatter.string(from: dateComponents) {
                     return formattedDate
                 }
             } else {
@@ -87,12 +123,7 @@ extension Date {
     /// - Parameters:
     ///   - calendar: The calendar to use when formatting the date.
     private func formatLongDate(_ calendar: Calendar) -> String {
-        let dateFormatter = DateFormatter()
-        dateFormatter.timeStyle = .none
-        dateFormatter.dateStyle = .medium
-        dateFormatter.calendar = calendar
-        dateFormatter.locale = calendar.locale
-        dateFormatter.timeZone = calendar.timeZone
-        return dateFormatter.string(from: self)
+        let formatter = DateFormatters.shared.longDateFormatter(forCalendar: calendar)
+        return formatter.string(from: self)
     }
 }

--- a/Nos/Views/Components/Author/AuthorLabel.swift
+++ b/Nos/Views/Components/Author/AuthorLabel.swift
@@ -2,19 +2,21 @@ import SwiftUI
 
 struct AuthorLabel: View {
     
-    @ObservedObject var author: Author
-    var note: Event?
+    let profilePhotoURL: URL?
+    private let attributedAuthor: AttributedString
     
-    private var attributedAuthor: AttributedString {
-        var authorName = AttributedString(author.safeName)
+    init(safeName: String, profilePhotoURL: URL?) {
+        self.profilePhotoURL = profilePhotoURL
+        
+        var authorName = AttributedString(safeName)
         authorName.foregroundColor = .primaryTxt
         authorName.font = .clarity(.semibold)
-        return authorName
+        attributedAuthor = authorName
     }
 
     var body: some View {
         HStack {
-            AvatarView(imageUrl: author.profilePhotoURL, size: 24)
+            AvatarView(imageUrl: profilePhotoURL, size: 24)
             Text(attributedAuthor)
                 .lineLimit(1)
                 .font(.clarity(.medium))
@@ -27,6 +29,9 @@ struct AuthorLabel: View {
 struct AuthorLabel_Previews: PreviewProvider {
     static var previewData = PreviewData()
     static var previews: some View {
-        AuthorLabel(author: previewData.previewAuthor)
+        AuthorLabel(
+            safeName: previewData.previewAuthor.safeName,
+            profilePhotoURL: previewData.previewAuthor.profilePhotoURL
+        )
     }
 }

--- a/Nos/Views/Components/Author/AuthorLabel.swift
+++ b/Nos/Views/Components/Author/AuthorLabel.swift
@@ -2,24 +2,16 @@ import SwiftUI
 
 struct AuthorLabel: View {
     
+    let name: String
     let profilePhotoURL: URL?
-    private let attributedAuthor: AttributedString
-    
-    init(safeName: String, profilePhotoURL: URL?) {
-        self.profilePhotoURL = profilePhotoURL
-        
-        var authorName = AttributedString(safeName)
-        authorName.foregroundColor = .primaryTxt
-        authorName.font = .clarity(.semibold)
-        attributedAuthor = authorName
-    }
 
     var body: some View {
         HStack {
             AvatarView(imageUrl: profilePhotoURL, size: 24)
-            Text(attributedAuthor)
+            Text(name)
                 .lineLimit(1)
-                .font(.clarity(.medium))
+                .foregroundStyle(Color.primaryTxt)
+                .font(.clarity(.semibold))
                 .multilineTextAlignment(.leading)
                 .frame(alignment: .leading)
         }
@@ -30,7 +22,7 @@ struct AuthorLabel_Previews: PreviewProvider {
     static var previewData = PreviewData()
     static var previews: some View {
         AuthorLabel(
-            safeName: previewData.previewAuthor.safeName,
+            name: previewData.previewAuthor.safeName,
             profilePhotoURL: previewData.previewAuthor.profilePhotoURL
         )
     }

--- a/Nos/Views/Components/Button/NoteButton.swift
+++ b/Nos/Views/Components/Button/NoteButton.swift
@@ -97,7 +97,7 @@ struct NoteButton: View {
                     router.push(author)
                 }, label: { 
                     HStack(alignment: .center) {
-                        AuthorLabel(safeName: author.safeName, profilePhotoURL: author.profilePhotoURL)
+                        AuthorLabel(name: author.safeName, profilePhotoURL: author.profilePhotoURL)
                         Image.repostSymbol
                         if let elapsedTime = note.createdAt?.distanceString() {
                             Text(elapsedTime)

--- a/Nos/Views/Components/Button/NoteButton.swift
+++ b/Nos/Views/Components/Button/NoteButton.swift
@@ -81,7 +81,7 @@ struct NoteButton: View {
     }
 
     /// The note displayed in the note card. Could be different from `note` i.e. in the case of a repost.
-    var displayedNote: Event {
+    private var displayedNote: Event {
         if note.kind == EventKind.repost.rawValue,
             let repostedNote = note.repostedNote() {
             return repostedNote
@@ -97,7 +97,7 @@ struct NoteButton: View {
                     router.push(author)
                 }, label: { 
                     HStack(alignment: .center) {
-                        AuthorLabel(author: author)
+                        AuthorLabel(safeName: author.safeName, profilePhotoURL: author.profilePhotoURL)
                         Image.repostSymbol
                         if let elapsedTime = note.createdAt?.distanceString() {
                             Text(elapsedTime)

--- a/Nos/Views/Components/Media/ImageButton.swift
+++ b/Nos/Views/Components/Media/ImageButton.swift
@@ -28,7 +28,7 @@ struct ImageButton: View {
                 isViewerPresented = true
             } label: {
                 ZStack {
-                    WebImage(url: url, isAnimating: $isAnimating)
+                    WebImage(url: url, options: [.scaleDownLargeImages], isAnimating: $isAnimating)
                         .onSuccess { image, _, _ in
                             Task {
                                 isAnimated = image.sd_isAnimated

--- a/Nos/Views/Note/NoteCard.swift
+++ b/Nos/Views/Note/NoteCard.swift
@@ -79,7 +79,12 @@ struct NoteCard: View {
                                 Button {
                                     router.push(author)
                                 } label: {
-                                    NoteCardHeader(note: note, author: author)
+                                    NoteCardHeader(
+                                        authorSafeName: author.safeName,
+                                        authorProfilePhotoURL: author.profilePhotoURL,
+                                        noteExpirationDate: note.expirationDate,
+                                        noteCreatedDate: note.createdAt
+                                    )
                                 }
                             }
                             Spacer()
@@ -127,13 +132,13 @@ struct NoteCard: View {
                         }
                         BeveledSeparator()
                         HStack(spacing: 0) {
-                            if repliesDisplayType != .displayNothing {
+                            if repliesDisplayType != .displayNothing, let noteIdentifier = note.identifier {
                                 Button {
                                     router.push(note)
                                 } label: {
                                     RepliesLabel(
                                         repliesDisplayType: repliesDisplayType,
-                                        for: note
+                                        for: noteIdentifier
                                     )
                                 }
                             }

--- a/Nos/Views/Note/NoteCardHeader.swift
+++ b/Nos/Views/Note/NoteCardHeader.swift
@@ -2,23 +2,28 @@ import SwiftUI
 
 struct NoteCardHeader: View {
     
-    @ObservedObject var note: Event
-    @ObservedObject var author: Author
+    let authorSafeName: String
+    let authorProfilePhotoURL: URL?
+    let noteExpirationDate: Date?
+    let noteCreatedDate: Date?
+    
+    @State private var expirationDateDistanceString: String?
+    @State private var createdDateDistanceString: String?
     
     var body: some View {
         HStack(alignment: .center, spacing: 8) {
-            AuthorLabel(author: author, note: note)
-            if let expirationTime = note.expirationDate?.distanceString() {
+            AuthorLabel(safeName: authorSafeName, profilePhotoURL: authorProfilePhotoURL)
+            if let expirationDateDistanceString {
                 Image.disappearingMessages
                     .resizable()
                     .foregroundColor(.secondaryTxt)
                     .frame(width: 25, height: 25)
-                Text(expirationTime)
+                Text(expirationDateDistanceString)
                     .lineLimit(1)
                     .font(.clarity(.medium))
                     .foregroundColor(.secondaryTxt)
-            } else if let elapsedTime = note.createdAt?.distanceString() {
-                Text(elapsedTime)
+            } else if let createdDateDistanceString {
+                Text(createdDateDistanceString)
                     .lineLimit(1)
                     .font(.clarity(.medium))
                     .foregroundColor(.secondaryTxt)
@@ -27,15 +32,31 @@ struct NoteCardHeader: View {
             Spacer()
         }
         .padding(.leading, 10)
+        .onAppear {
+            expirationDateDistanceString = noteExpirationDate?.distanceString()
+            createdDateDistanceString = noteCreatedDate?.distanceString()
+        }
     }
 }
 
 struct NoteCardHeader_Previews: PreviewProvider {
     static var previewData = PreviewData()
+    
     static var previews: some View {
-        NoteCardHeader(note: previewData.imageNote, author: previewData.previewAuthor)
-            .inject(previewData: previewData)
-        NoteCardHeader(note: previewData.expiringNote, author: previewData.previewAuthor)
-            .inject(previewData: previewData)
+        NoteCardHeader(
+            authorSafeName: previewData.previewAuthor.safeName,
+            authorProfilePhotoURL: previewData.previewAuthor.profilePhotoURL,
+            noteExpirationDate: previewData.imageNote.expirationDate,
+            noteCreatedDate: previewData.imageNote.createdAt
+        )
+        .inject(previewData: previewData)
+        
+        NoteCardHeader(
+            authorSafeName: previewData.previewAuthor.safeName,
+            authorProfilePhotoURL: previewData.previewAuthor.profilePhotoURL,
+            noteExpirationDate: previewData.expiringNote.expirationDate,
+            noteCreatedDate: previewData.expiringNote.createdAt
+        )
+        .inject(previewData: previewData)
     }
 }


### PR DESCRIPTION
## Issues covered
https://github.com/verse-pbc/issues/issues/215

## Description
While this does not alleviate all the performance issues, performance needs to be improved a little bit at a time to mitigate the risk of big changes all at once.

## How to test
1. Build and run the app from Xcode
2. Open Xcode -> Open Developer Tool -> Instruments
3. Select SwiftUI instrument
4. Run app on device through Instruments with this instrument active

My strategy was to run the app prior to any changes in Instruments and locate which views have the longest Average Duration (the time it takes to run the `body` method) and/or have an unreasonably high Count, meaning they're redrawing too frequently, and then see if I can make some improvement in these values without degrading the user experience.

One change I made was to cache `DateFormatter`s. It is best practice not to create a lot of these as they are somewhat heavy objects, and every time we call `Date.distanceString()`, we were creating a branch new `DateFormatter`. These are now cached per `Calendar`.

Another important strategy is to limit the data that goes into a particular view to only what it actually needs to render itself, rather than passing in large observable objects, such as `Note` and `Author`, which are Core Data classes that behave like `ObservableObject`s, causing views to re-render when *any* property changes, not just when accessed properties change. I applied this strategy to `AuthorLabel` and `NoteCardHeader`.

## Screenshots

Below you can see the performance gains from these changes in the reduction of the average time to render the affected views.

|State|Result|
| --- | --- |
|`AuthorLabel` Before|<img width="934" alt="AuthorLabel before" src="https://github.com/user-attachments/assets/22b96091-4ee3-4d49-871f-9120e321969e" />|
|`AuthorLabel` After|<img width="930" alt="AuthorLabel after" src="https://github.com/user-attachments/assets/8a74c135-636f-4300-9e0f-28850f4c0967" />|
|`NoteCardHeader` before|<img width="958" alt="NCH before" src="https://github.com/user-attachments/assets/7fcbaa6a-6cfa-41e9-a81d-267db9c3d54c" />|
|`NoteCardHeader` after|<img width="933" alt="NCH after" src="https://github.com/user-attachments/assets/c31421b1-bf0b-46f0-bbb1-0269eecff699" />|
|`RepliesLabel` before|<img width="917" alt="RepliesLabel before" src="https://github.com/user-attachments/assets/3d41cd22-c82f-485b-a9ee-366891080528" />|
|`RepliesLabel` after|<img width="894" alt="RepliesLabel after" src="https://github.com/user-attachments/assets/8818ba8e-c973-46e8-95ce-6bbc0f7357cb" />|




