### PR TITLE
fixed: Contact Support event fires too often #193

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Release Notes
+
+### Internal Changes
+- Fixed: Contact Support event fires too often.
+
 ## [1.2.1] - 2025-02-19Z
 
 ### Release Notes

--- a/Nos/Service/Analytics.swift
+++ b/Nos/Service/Analytics.swift
@@ -76,7 +76,7 @@ final class Analytics {
     }
     
     func showedSideMenu() {
-        track("Contact Support Tapped")
+        track("Side Menu Opened")
     }
     
     func showedRelays() {


### PR DESCRIPTION
## Issues covered
https://github.com/verse-pbc/issues/issues/193

## Description
Fixes the issue where the "Contact Support Tapped" analytics event fires too often. What actually happened was that the function called "showedSideMenu()" actually fired an event called "Contact Support Tapped" in addition to the "showedSupport()" function.

## How to test
1. Run the app observing analytics events (either in Xcode's console or in Posthog.
2. Open the side menu.
See what event fired.

## Screenshots/Video
This is the user path I tested to collect the console logs below:
![event](https://github.com/user-attachments/assets/fe10b4f3-a0f2-41bc-ab98-464b1242f83b)

| Before | After |
|--------|--------|
|<img width="552" alt="Nos_—_Analytics_swift_and_Desktop" src="https://github.com/user-attachments/assets/69440bc6-76cf-4c2a-bba6-722a123560f4" />|<img width="541" alt="Nos_—_Analytics_swift" src="https://github.com/user-attachments/assets/8a150196-5d56-413b-b023-abafeff19153" />|

