### PR TITLE
fixed: crash in Event.trackDelete(on:context:) #222

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Release Notes
+- Fixed: crash in Event.trackDelete(on:context:).
+
+### Internal Changes
+
 ## [1.2.1] - 2025-02-19Z
 
 ### Release Notes

--- a/Nos/Models/CoreData/Event+CoreDataClass.swift
+++ b/Nos/Models/CoreData/Event+CoreDataClass.swift
@@ -514,17 +514,22 @@ class Event: NosManagedObject, VerifiableEvent {
             
             for aTag in aTags.map({ $0[1] }) {
                 let components = aTag.split(separator: ":").map { String($0) }
+                guard components.count >= 3 else {
+                    continue
+                }
+                
                 guard let pubkey = components[safe: 1],
                     pubkey == author.hexadecimalPublicKey else {
                     // ensure that this delete event only affects events with the author's pubkey
                     continue
                 }
                 
-                guard let kind = Int64(components[0]) else {
+                guard let kindString = components[safe: 0],
+                    let kind = Int64(kindString),
+                    let replaceableID = components[safe: 2] else {
                     continue
                 }
                 
-                let replaceableID = components[2]
                 let request = Event.event(by: replaceableID, author: author, kind: kind, before: createdAt)
                 
                 let results = try context.fetch(request)


### PR DESCRIPTION
## Issues covered
https://github.com/verse-pbc/issues/issues/222

## Description
Fixes a crash that happens while deleting a replaceable event, which for Nos right now means only lists. When the a tag is malformed, meaning the value of the tag doesn't have the right number of components (looks like "<kind>:<pubkey>:<d-identifier>"), the app will crash.

Since this doesn't happen with lists that you have created within Nos, I can only assume that some other client is creating these malformed a tags.

## How to test
1. Navigate to Your Lists.
2. Delete a list.

## Regression
Deleting lists still works without crashing:  
![list-delete](https://github.com/user-attachments/assets/33144ed0-8f04-44bf-a3e4-434bfbddaca0)
